### PR TITLE
PR open and close concurrency

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.ref }}
+  group: pr-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # PR open and close use the same group, allowing only one at a time
+  group: pr-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Handle PR open and close concurrency so that they can interrupt each other.  This prevents orphaning OpenShift artifacts and skips more quickly to the most recent workflow.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-58-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-58-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-58-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)