### PR TITLE
fix: wrong backend api urls

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -89,12 +89,12 @@ jobs:
             verification_path: "actuator/health"
             parameters:
               -p REACT_APP_SPAR_BUILD_VERSION=snapshot-test
-              -p REACT_APP_SERVER_URL=https://https://nr-spar-test-backend.apps.silver.devops.gov.bc.ca
+              -p REACT_APP_SERVER_URL=https://nr-spar-test-backend.apps.silver.devops.gov.bc.ca
+              -p REACT_APP_ORACLE_SERVER_URL=https://nr-spar-test-oracle-api.apps.silver.devops.gov.bc.ca
               -p REACT_APP_NRSPARWEBAPP_VERSION=test
               -p REACT_APP_KC_URL=https://test.loginproxy.gov.bc.ca/auth
               -p REACT_APP_KC_REALM=standard
               -p REACT_APP_KC_CLIENT_ID=seed-planning-test-4296
-              -p REACT_APP_ENABLE_MOCK_SERVER=true
               -p MIN_REPLICAS=1 -p MAX_REPLICAS=1
           - name: oracle-api
             file: oracle-api/openshift.deploy.yml
@@ -198,12 +198,12 @@ jobs:
             verification_path: "actuator/health"
             parameters:
               -p REACT_APP_SPAR_BUILD_VERSION=snapshot-prod
-              -p REACT_APP_SERVER_URL=https://https://nr-spar-prod-backend.apps.silver.devops.gov.bc.ca
+              -p REACT_APP_SERVER_URL=https://nr-spar-prod-backend.apps.silver.devops.gov.bc.ca
+              -p REACT_APP_ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca
               -p REACT_APP_NRSPARWEBAPP_VERSION=prod
               -p REACT_APP_KC_URL=https://loginproxy.gov.bc.ca/auth
               -p REACT_APP_KC_REALM=standard
               -p REACT_APP_KC_CLIENT_ID=seed-planning-test-4296
-              -p REACT_APP_ENABLE_MOCK_SERVER=true
               -p MIN_REPLICAS=1 -p MAX_REPLICAS=1
           - name: oracle-api
             file: oracle-api/openshift.deploy.yml

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -101,11 +101,11 @@ jobs:
             parameters:
               -p REACT_APP_SPAR_BUILD_VERSION=snapshot-${{ github.event.number }}
               -p REACT_APP_SERVER_URL=https://nr-spar-${{ github.event.number }}-backend.apps.silver.devops.gov.bc.ca
+              -p REACT_APP_ORACLE_SERVER_URL=https://nr-spar-${{ github.event.number }}-oracle-api.apps.silver.devops.gov.bc.ca
               -p REACT_APP_NRSPARWEBAPP_VERSION=dev
               -p REACT_APP_KC_URL=https://test.loginproxy.gov.bc.ca/auth
               -p REACT_APP_KC_REALM=standard
               -p REACT_APP_KC_CLIENT_ID=seed-planning-test-4296
-              -p REACT_APP_ENABLE_MOCK_SERVER=true
               -p MIN_REPLICAS=1 -p MAX_REPLICAS=1
           - name: oracle-api
             file: oracle-api/openshift.deploy.yml

--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -59,11 +59,11 @@ Remember of setting up the required environment variables. You can create a `.en
 
 ```
 REACT_APP_SERVER_URL=
+REACT_APP_ORACLE_SERVER_URL=
 REACT_APP_NRSPARWEBAPP_VERSION=
 REACT_APP_KC_URL=
 REACT_APP_KC_REALM=
 REACT_APP_KC_CLIENT_ID=
-REACT_APP_ENABLE_MOCK_SERVER=
 ```
 
 And if you want to run Cypress, please add:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -60,7 +60,6 @@ REACT_APP_ORACLE_SERVER_URL=https://localhost:8092/
 REACT_APP_KC_URL=https://test.loginproxy.gov.bc.ca/auth
 REACT_APP_KC_REALM=standard
 REACT_APP_KC_CLIENT_ID=seed-planning-test-4296
-REACT_APP_ENABLE_MOCK_SERVER=true
 CYPRESS_USERNAME=LOAD-3-TEST
 CYPRESS_PASSWORD=[password-here]
 ```

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -20,6 +20,5 @@ module.exports = {
 process.env = Object.assign(process.env, {
   REACT_APP_KC_URL: 'https://dev.any-keycloak-server.com/auth',
   REACT_APP_KC_REALM: 'default',
-  REACT_APP_KC_CLIENT_ID: 'test-client-id',
-  REACT_APP_ENABLE_MOCK_SERVER: 'true'
+  REACT_APP_KC_CLIENT_ID: 'test-client-id'
 });

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -55,8 +55,8 @@ parameters:
   - name: REACT_APP_KC_CLIENT_ID
     description: REACT_APP_KC_CLIENT_ID
     required: true
-  - name: REACT_APP_ENABLE_MOCK_SERVER
-    description: REACT_APP_ENABLE_MOCK_SERVER
+  - name: REACT_APP_ORACLE_SERVER_URL
+    description: Oracle back-end api URL
     required: true
 objects:
   - apiVersion: v1
@@ -120,8 +120,8 @@ objects:
                   value: ${REACT_APP_KC_REALM}
                 - name: REACT_APP_KC_CLIENT_ID
                   value: ${REACT_APP_KC_CLIENT_ID}
-                - name: REACT_APP_ENABLE_MOCK_SERVER
-                  value: ${REACT_APP_ENABLE_MOCK_SERVER}
+                - name: REACT_APP_ORACLE_SERVER_URL
+                  value: ${REACT_APP_ORACLE_SERVER_URL}
               ports:
                 - containerPort: 3000
                   protocol: TCP


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixes wrong Back-end api URLs addresses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was tested locally, and will be tested with new depoyments.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-76-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-76-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-76-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)