### PR TITLE
feat: upgrade eclipse-temuri so it works with apple chips

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,7 @@ COPY pom.xml /home/spring
 WORKDIR /home/spring
 RUN mvn --no-transfer-progress --update-snapshots -P prod clean package
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17.0.7_7-jre-jammy
 LABEL maintainer="Ricardo Montania Prado de Campos <ricardo.campos@encora.com>"
 
 ENV LANG en_CA.UTF-8


### PR DESCRIPTION
a simple PR to update eclipse-temurin used in `/backend/Dockerfile`, the old one gives me RPC error on my macbook

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-89-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-89-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-89-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)