### PR TITLE
Backend Cloud Native in Dockerfile

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,16 +57,16 @@ jobs:
       packages: write
     strategy:
       matrix:
-        package: [database, frontend, backend, oracle-api]
+        # package: [database, frontend, backend, oracle-api]
         include:
-          - package: database
-            triggers: ('database/')
+          # - package: database
+          #   triggers: ('database/')
           - package: backend
             triggers: ('backend/')
-          - package: frontend
-            triggers: ('frontend/')
-          - package: oracle-api
-            triggers: ('oracle-api/')
+          # - package: frontend
+          #   triggers: ('frontend/')
+          # - package: oracle-api
+          #   triggers: ('oracle-api/')
     steps:
       - uses: actions/checkout@v3
       - uses: bcgov-nr/action-builder-ghcr@v1.1.1
@@ -85,12 +85,12 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        name: [database, backend, frontend, oracle-api]
+        # name: [database, backend, frontend, oracle-api]
         include:
-          - name: database
-            file: database/openshift.deploy.yml
-            parameters: -p DB_PVC_SIZE=128Mi
-            overwrite: false
+          # - name: database
+          #   file: database/openshift.deploy.yml
+          #   parameters: -p DB_PVC_SIZE=128Mi
+          #   overwrite: false
           - name: backend
             file: backend/openshift.deploy.yml
             overwrite: true

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,16 +57,16 @@ jobs:
       packages: write
     strategy:
       matrix:
-        package: [database, frontend, oracle-api]
+        package: [database, backend, frontend, oracle-api]
         include:
           - package: database
             triggers: ('database/')
+          - package: backend
+            triggers: ('backend/')
           - package: frontend
             triggers: ('frontend/')
           - package: oracle-api
             triggers: ('oracle-api/')
-          - package: backend
-            triggers: ('backend/')
     steps:
       - uses: actions/checkout@v3
       - uses: bcgov-nr/action-builder-ghcr@v1.1.1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -49,45 +49,7 @@ jobs:
             -p ORACLE_DB_USER=${{ secrets.DB_USER }}
             -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
-
-  cloud-native-builds:
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        package: [backend]
-    name: Cloud Native Builds (${{ matrix.package }})
-    runs-on: ubuntu-22.04
-    env:
-      COMPONENT: ${{ matrix.package }}
-      ZONE: ${{ github.event.number }}
-      NAME: ghcr.io/${{ github.repository }}/${{ matrix.package }}:${{ github.event.number }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: graalvm/setup-graalvm@v1
-        with:
-          version: "22.3.0"
-          java-version: "17"
-          components: "native-image"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Native Image
-        run: |
-          cd ${{ matrix.package }}
-          chmod +x ./mvnw
-          ./mvnw -Pnative clean spring-boot:build-image \
-            -Dspring-boot.build-image.imageName="${{ env.NAME }}" \
-            -Doci.revision=${{ github.event.number }} --quiet
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pushing
-        run: docker push ${{ env.NAME }}
-
+  
   builds:
     name: Builds
     runs-on: ubuntu-22.04
@@ -95,10 +57,12 @@ jobs:
       packages: write
     strategy:
       matrix:
-        package: [database, frontend, oracle-api]
+        package: [database, frontend, backend, oracle-api]
         include:
           - package: database
             triggers: ('database/')
+          - package: backend
+            triggers: ('backend/')
           - package: frontend
             triggers: ('frontend/')
           - package: oracle-api
@@ -116,7 +80,6 @@ jobs:
   deploys:
     name: Deploys
     needs:
-      - cloud-native-builds
       - builds
       - init
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -49,7 +49,7 @@ jobs:
             -p ORACLE_DB_USER=${{ secrets.DB_USER }}
             -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
-  
+
   builds:
     name: Builds
     runs-on: ubuntu-22.04
@@ -57,16 +57,16 @@ jobs:
       packages: write
     strategy:
       matrix:
-        # package: [database, frontend, backend, oracle-api]
+        package: [database, frontend, oracle-api]
         include:
-          # - package: database
-          #   triggers: ('database/')
+          - package: database
+            triggers: ('database/')
+          - package: frontend
+            triggers: ('frontend/')
+          - package: oracle-api
+            triggers: ('oracle-api/')
           - package: backend
             triggers: ('backend/')
-          # - package: frontend
-          #   triggers: ('frontend/')
-          # - package: oracle-api
-          #   triggers: ('oracle-api/')
     steps:
       - uses: actions/checkout@v3
       - uses: bcgov-nr/action-builder-ghcr@v1.1.1
@@ -85,12 +85,12 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # name: [database, backend, frontend, oracle-api]
+        name: [database, backend, frontend, oracle-api]
         include:
-          # - name: database
-          #   file: database/openshift.deploy.yml
-          #   parameters: -p DB_PVC_SIZE=128Mi
-          #   overwrite: false
+          - name: database
+            file: database/openshift.deploy.yml
+            parameters: -p DB_PVC_SIZE=128Mi
+            overwrite: false
           - name: backend
             file: backend/openshift.deploy.yml
             overwrite: true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,28 +1,46 @@
-FROM maven:3.9.2-eclipse-temurin-17 AS build
+FROM ghcr.io/graalvm/native-image:ol8-java17-22 AS builder
 
-# User
-RUN addgroup --system spring && adduser --system spring --ingroup spring
-USER spring:spring
+# Install tar and gzip to extract the Maven binaries
+RUN microdnf update \
+ && microdnf install --nodocs \
+    tar \
+    gzip \
+ && microdnf clean all \
+ && rm -rf /var/cache/yum
 
-# App
-WORKDIR /home/spring
-COPY src /home/spring/src
-COPY pom.xml /home/spring
-RUN mvn --no-transfer-progress --update-snapshots -P prod clean package
+# Install Maven
+# Source:
+# 1) https://github.com/carlossg/docker-maven/blob/925e49a1d0986070208e3c06a11c41f8f2cada82/openjdk-17/Dockerfile
+# 2) https://maven.apache.org/download.cgi
+ARG USER_HOME_DIR="/root"
+ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
 
-FROM eclipse-temurin:17.0.7_7-jre-jammy AS deploy
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref
+RUN curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_DOWNLOAD_URL}
+RUN tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
-ENV LANG en_CA.UTF-8
-ENV LANGUAGE en_CA.UTF-8
-ENV LC_ALL en_CA.UTF-8
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+# 
+# Set the working directory to /home/app
+WORKDIR /build
 
-# App
-WORKDIR /usr/share/service/
-COPY --from=build /home/spring/target/nr-spar-backend.jar /usr/share/service/service.jar
-COPY dockerfile-entrypoint.sh /usr/share/service/dockerfile-entrypoint.sh
+# Copy the source code into the image for building
+COPY . /build
 
-# User, port and healthcheck
-USER 1001
-EXPOSE 8090
-HEALTHCHECK CMD curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
-ENTRYPOINT ["/usr/share/service/dockerfile-entrypoint.sh"]
+# Build
+RUN mvn -Pnative native:compile -Dtests.skip=true
+
+# The deployment Image
+FROM docker.io/oraclelinux:8-slim
+
+EXPOSE 3000
+
+# Copy the native executable into the containers
+# COPY --from=builder /build/target/nr-spar-backend.jar .
+WORKDIR /app
+COPY --from=builder /build/target/nr-spar-backend.jar .
+
+ENTRYPOINT ["/nr-spar-backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN ./mvnw -Pnative native:compile -Dtests.skip=true
 
 
 ### Deployer
-FROM gcr.io/distroless/java-base AS deploy
+FROM gcr.io/distroless/java-base:nonroot AS deploy
 ARG PORT=8090
 
 # Copy

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,36 +1,42 @@
+### Builder
 FROM ghcr.io/graalvm/native-image:ol8-java17-22 AS builder
-ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
 
+# Packages
 RUN microdnf update \
- && microdnf install --nodocs tar gzip \
- && microdnf clean all \
- && rm -rf /var/cache/yum
+  && microdnf install --nodocs tar gzip \
+  && microdnf clean all \
+  && rm -rf /var/cache/yum
 
+# Maven
+ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_DOWNLOAD_URL} \
   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
-# ENV MAVEN_HOME /usr/share/maven
-# ENV MAVEN_CONFIG "~/.m2"
+# # Envars
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "/root/.m2"
 
-WORKDIR /app/src
-COPY src .
+# Copy
 WORKDIR /app
 COPY pom.xml .
+COPY src ./src
 
 # Build
 RUN mvn -Pnative native:compile -Dtests.skip=true
 
-# # The deployment Image
+
+### Deployer
 FROM docker.io/oraclelinux:8-slim
 
-EXPOSE 3000
+# Copy
+COPY --from=builder /app/target/nr-spar-backend ./
 
-# Copy the native executable into the containers
-# COPY --from=builder /build/target/nr-spar-backend.jar .
-WORKDIR /app
-COPY --from=builder /app/target/ .
+# User, port and health check
+EXPOSE 8090
+HEALTHCHECK CMD curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
 
-ENTRYPOINT ["/app/nr-spar-backend"]
+# Startup
+ENTRYPOINT ["/nr-spar-backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,42 +1,29 @@
 ### Builder
 FROM ghcr.io/graalvm/native-image:ol8-java17-22 AS builder
 
-# Packages
-RUN microdnf update \
-  && microdnf install --nodocs tar gzip \
-  && microdnf clean all \
-  && rm -rf /var/cache/yum
-
-# Maven
-ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_DOWNLOAD_URL} \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-
-# # Envars
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "/root/.m2"
-
 # Copy
 WORKDIR /app
 COPY pom.xml .
 COPY src ./src
+COPY .mvn/ ./.mvn
+COPY mvnw ./mvnw
 
 # Build
-RUN mvn -Pnative native:compile -Dtests.skip=true
+RUN ./mvnw -Pnative native:compile -Dtests.skip=true
 
 
 ### Deployer
-FROM docker.io/oraclelinux:8-slim
+FROM gcr.io/distroless/java-base
+ARG PORT=8090
 
 # Copy
-COPY --from=builder /app/target/nr-spar-backend ./
+WORKDIR /app
+COPY --from=builder /app/target/nr-spar-backend ./nr-spar-backend
 
 # User, port and health check
-EXPOSE 8090
-HEALTHCHECK CMD curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
+USER 1001
+EXPOSE ${PORT}
+HEALTHCHECK CMD curl -f http://localhost:${PORT}/actuator/health | grep '"status":"UP"'
 
 # Startup
-ENTRYPOINT ["/nr-spar-backend"]
+ENTRYPOINT ["/app/nr-spar-backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,39 +1,29 @@
 FROM ghcr.io/graalvm/native-image:ol8-java17-22 AS builder
+ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
 
-# Install tar and gzip to extract the Maven binaries
 RUN microdnf update \
- && microdnf install --nodocs \
-    tar \
-    gzip \
+ && microdnf install --nodocs tar gzip \
  && microdnf clean all \
  && rm -rf /var/cache/yum
 
-# Install Maven
-# Source:
-# 1) https://github.com/carlossg/docker-maven/blob/925e49a1d0986070208e3c06a11c41f8f2cada82/openjdk-17/Dockerfile
-# 2) https://maven.apache.org/download.cgi
-ARG USER_HOME_DIR="/root"
-ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref
-RUN curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_DOWNLOAD_URL}
-RUN tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_DOWNLOAD_URL} \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-# 
-# Set the working directory to /home/app
-WORKDIR /build
+# ENV MAVEN_HOME /usr/share/maven
+# ENV MAVEN_CONFIG "~/.m2"
 
-# Copy the source code into the image for building
-COPY . /build
+WORKDIR /app/src
+COPY src .
+WORKDIR /app
+COPY pom.xml .
 
 # Build
 RUN mvn -Pnative native:compile -Dtests.skip=true
 
-# The deployment Image
+# # The deployment Image
 FROM docker.io/oraclelinux:8-slim
 
 EXPOSE 3000
@@ -41,6 +31,6 @@ EXPOSE 3000
 # Copy the native executable into the containers
 # COPY --from=builder /build/target/nr-spar-backend.jar .
 WORKDIR /app
-COPY --from=builder /build/target/nr-spar-backend.jar .
+COPY --from=builder /app/target/ .
 
-ENTRYPOINT ["/nr-spar-backend"]
+ENTRYPOINT ["/app/nr-spar-backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,24 +1,23 @@
 ### Builder
-FROM ghcr.io/graalvm/native-image:ol8-java17-22 AS builder
+FROM ghcr.io/graalvm/native-image:ol8-java17-22 AS build
 
 # Copy
 WORKDIR /app
-COPY pom.xml .
+COPY pom.xml mvnw ./
 COPY src ./src
 COPY .mvn/ ./.mvn
-COPY mvnw ./mvnw
 
 # Build
 RUN ./mvnw -Pnative native:compile -Dtests.skip=true
 
 
 ### Deployer
-FROM gcr.io/distroless/java-base
+FROM gcr.io/distroless/java-base AS deploy
 ARG PORT=8090
 
 # Copy
 WORKDIR /app
-COPY --from=builder /app/target/nr-spar-backend ./nr-spar-backend
+COPY --from=build /app/target/nr-spar-backend ./nr-spar-backend
 
 # User, port and health check
 USER 1001

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -177,7 +177,16 @@
                 <metadataVersion>6.1.1.Final</metadataVersion>
               </dependency>
             </dependencies>
+            <enabled>true</enabled>
           </metadataRepository>
+          <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+          <requiredVersion>22.3.0</requiredVersion>
+          <verbose>true</verbose>
+          <buildArgs>
+            <arg>--verbose</arg>
+            <arg>--initialize-at-build-time=org.slf4j.LoggerFactory</arg>
+            <arg>--trace-class-initialization=org.slf4j.LoggerFactory</arg>
+          </buildArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Cloud Native standalone builds break the QuickStart workflow.  We can either add support for that to the builder or stuff Cloud Native into a Dockerfile.  This PR tries the latter.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-163-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-163-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-163-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)