### PR TITLE
fix: add autoscaling to oracle api

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -131,7 +131,10 @@ jobs:
             file: backend/openshift.deploy.yml
             overwrite: true
             verification_path: "actuator/health"
-            parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=1 -p BUILD=snapshot-${{ github.event.number }}
+            parameters:
+              -p MIN_REPLICAS=1
+              -p MAX_REPLICAS=1
+              -p BUILD=snapshot-${{ github.event.number }}
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
@@ -143,7 +146,8 @@ jobs:
               -p REACT_APP_KC_URL=https://test.loginproxy.gov.bc.ca/auth
               -p REACT_APP_KC_REALM=standard
               -p REACT_APP_KC_CLIENT_ID=seed-planning-test-4296
-              -p MIN_REPLICAS=1 -p MAX_REPLICAS=1
+              -p MIN_REPLICAS=1
+              -p MAX_REPLICAS=1
           - name: oracle-api
             file: oracle-api/openshift.deploy.yml
             overwrite: true
@@ -163,9 +167,9 @@ jobs:
           penetration_test: false
           verification_path: ${{ matrix.verification_path}}
           parameters:
-            -p ZONE=${{ github.event.number }} -p NAME=${{ github.event.repository.name }}
-            -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:${{ github.event.number }}
-            ${{ matrix.parameters }}
+            -p ZONE=${{ github.event.number }}
+            -p NAME=${{ github.event.repository.name }}
+            -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:${{ github.event.number }}${{ matrix.parameters }}
 
   # tests-api:
   #   name: API Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -86,7 +86,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pushing
         run: docker push ${{ env.NAME }}
-  
+
   builds:
     name: Builds
     runs-on: ubuntu-22.04
@@ -148,7 +148,10 @@ jobs:
             file: oracle-api/openshift.deploy.yml
             overwrite: true
             verification_path: "actuator/health"
-            parameters: -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ github.event.number }}
+            parameters:
+              -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ github.event.number }}
+              -p MIN_REPLICAS=1
+              -p MAX_REPLICAS=1
     steps:
       - uses: bcgov-nr/action-deployer-openshift@v1.0.4
         with:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -212,4 +212,4 @@ objects:
             name: cpu
             target:
               type: Utilization
-              averageUtilization: 100
+              averageUtilization: 80

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -200,7 +200,7 @@ objects:
             name: cpu
             target:
               type: Utilization
-              averageUtilization: 100
+              averageUtilization: 80
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -73,7 +73,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
+      replicas: 3
       triggers:
         - type: ConfigChange
         - type: ImageChange

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -203,4 +203,4 @@ objects:
             name: cpu
             target:
               type: Utilization
-              averageUtilization: 100
+              averageUtilization: 80

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -49,6 +49,12 @@ parameters:
   - name: KEYCLOAK_REALM_URL
     description: Keycloak realm address
     value: https://test.loginproxy.gov.bc.ca/auth/realms/standard
+  - name: MIN_REPLICAS
+    description: The minimum amount of replicas for the horizontal pod autoscaler.
+    value: "3"
+  - name: MAX_REPLICAS
+    description: The maximum amount of replicas for the horizontal pod autoscaler.
+    value: "5"
 objects:
   - apiVersion: v1
     kind: ImageStream
@@ -73,7 +79,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 3
+      replicas: 1
       triggers:
         - type: ConfigChange
         - type: ImageChange
@@ -180,3 +186,21 @@ objects:
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      scaleTargetRef:
+        apiVersion: apps.openshift.io/v1
+        kind: DeploymentConfig
+        name: ${NAME}-${ZONE}-${COMPONENT}
+      minReplicas: ${{MIN_REPLICAS}}
+      maxReplicas: ${{MAX_REPLICAS}}
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 100


### PR DESCRIPTION
Add autoscaling to oracle api, configured the same way as backend service
DEV: Min=1, Max=1
TEST & PROD: Min=3, MAX=5

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-170-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-170-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-170-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)