### PR TITLE
Run PR description add if PR opened or reopened

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -19,6 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: PR Greeting
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
         uses: bcgov-nr/action-pr-description-add@v0.0.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub hasn't been performing wonderfully.  Our PR description adder can double up messages if the call to GitHub times out.  This change lets the commenter run on opened or reopened PRs.  It also prevents using a GitHub runner, which is handy when they're in short supply and we end up queued.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-171-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-171-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-171-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)