### PR TITLE
bug: increase probe failure thresholds

### DIFF
--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -134,17 +134,17 @@ objects:
                   memory: ${MEMORY_LIMIT}
               readinessProbe:
                 successThreshold: 1
-                failureThreshold: 5
+                failureThreshold: 15
                 httpGet:
                   path: /
                   port: 3000
                   scheme: HTTP
-                initialDelaySeconds: 15
+                initialDelaySeconds: 30
                 periodSeconds: 30
                 timeoutSeconds: 10
               livenessProbe:
                 successThreshold: 1
-                failureThreshold: 5
+                failureThreshold: 15
                 httpGet:
                   path: /
                   port: 3000


### PR DESCRIPTION
Frontend is timing out.  This increases the probes' failure thesholds.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-191-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-191-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-191-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)