### PR TITLE
hotfix: reduce replicas for auto scaler

### DIFF
--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -51,10 +51,10 @@ parameters:
     value: https://test.loginproxy.gov.bc.ca/auth/realms/standard
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
-    value: "3"
+    value: "1"
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
-    value: "5"
+    value: "2"
 objects:
   - apiVersion: v1
     kind: ImageStream


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
The oracle-api service is down on both test and prod, this hotfix is aimed to reduce the number of pods thus decreasing the amount of connection to the oracle DB, Ricardo mentioned the maximum is 5. 
The new config has min of 1 and max of 2 pods for oracle-api

![image](https://github.com/bcgov/nr-spar/assets/25162561/3b69f074-1ac0-48e7-aaba-c13482f27254)
![image](https://github.com/bcgov/nr-spar/assets/25162561/cd082ffb-733a-4770-a16b-92d2104262da)


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-219-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-219-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-219-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)