### PR TITLE
feat: keep only one highlighted activity to user

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/repository/FavouriteActivityRepository.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/repository/FavouriteActivityRepository.java
@@ -3,6 +3,8 @@ package ca.bc.gov.backendstartapi.repository;
 import ca.bc.gov.backendstartapi.entity.FavouriteActivityEntity;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 /** This class represents a user's favorite activity repository. */
@@ -13,4 +15,8 @@ public interface FavouriteActivityRepository extends CrudRepository<FavouriteAct
   List<FavouriteActivityEntity> findAllByEnabledAndUserId(Boolean enabled, String userId);
 
   Optional<FavouriteActivityEntity> findByActivity(String activity);
+
+  @Modifying
+  @Query("update FavouriteActivityEntity set highlighted = false where userId = ?1")
+  void removeAllHighlightedByUser(String userId);
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Update `backend` to keep only one highlighted favourite activity to an user.

Fixes #241 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This was tested locally.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-250-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-250-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-250-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)