### PR TITLE
feat: PR deployment triggers

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -91,14 +91,16 @@ jobs:
             file: database/openshift.deploy.yml
             parameters: -p DB_PVC_SIZE=128Mi
             overwrite: false
+            triggers: ('database/')
           - name: backend
             file: backend/openshift.deploy.yml
             overwrite: true
-            verification_path: "actuator/health"
             parameters:
               -p MIN_REPLICAS=1
               -p MAX_REPLICAS=1
               -p BUILD=snapshot-${{ github.event.number }}
+            triggers: ('database/', 'backend/')
+            verification_path: "actuator/health"
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
@@ -112,14 +114,16 @@ jobs:
               -p REACT_APP_KC_CLIENT_ID=seed-planning-test-4296
               -p MIN_REPLICAS=1
               -p MAX_REPLICAS=1
+            triggers: ('database/', 'backend/', 'frontend/')
           - name: oracle-api
             file: oracle-api/openshift.deploy.yml
             overwrite: true
-            verification_path: "actuator/health"
             parameters:
               -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ github.event.number }}
               -p MIN_REPLICAS=1
               -p MAX_REPLICAS=1
+            triggers: ('oracle-api')
+            verification_path: "actuator/health"
     steps:
       - uses: bcgov-nr/action-deployer-openshift@v1.0.4
         with:
@@ -129,12 +133,13 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false
-          verification_path: ${{ matrix.verification_path}}
           parameters:
             -p ZONE=${{ github.event.number }}
             -p NAME=${{ github.event.repository.name }}
             -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:${{ github.event.number }}
             ${{ matrix.parameters }}
+          triggers: ${{ matrix.triggers }}
+          verification_path: ${{ matrix.verification_path}}
 
   # tests-api:
   #   name: API Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -125,7 +125,7 @@ jobs:
             triggers: ('common/', 'oracle-api')
             verification_path: "actuator/health"
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v1.0.4
+      - uses: bcgov-nr/action-deployer-openshift@v1.1.1
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -91,7 +91,7 @@ jobs:
             file: database/openshift.deploy.yml
             parameters: -p DB_PVC_SIZE=128Mi
             overwrite: false
-            triggers: ('database/')
+            triggers: ('common/', 'database/')
           - name: backend
             file: backend/openshift.deploy.yml
             overwrite: true
@@ -99,7 +99,7 @@ jobs:
               -p MIN_REPLICAS=1
               -p MAX_REPLICAS=1
               -p BUILD=snapshot-${{ github.event.number }}
-            triggers: ('database/', 'backend/')
+            triggers: ('common/', 'database/', 'backend/')
             verification_path: "actuator/health"
           - name: frontend
             file: frontend/openshift.deploy.yml
@@ -114,7 +114,7 @@ jobs:
               -p REACT_APP_KC_CLIENT_ID=seed-planning-test-4296
               -p MIN_REPLICAS=1
               -p MAX_REPLICAS=1
-            triggers: ('database/', 'backend/', 'frontend/')
+            triggers: ('common/', 'database/', 'backend/', 'frontend/')
           - name: oracle-api
             file: oracle-api/openshift.deploy.yml
             overwrite: true
@@ -122,7 +122,7 @@ jobs:
               -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ github.event.number }}
               -p MIN_REPLICAS=1
               -p MAX_REPLICAS=1
-            triggers: ('oracle-api')
+            triggers: ('common/', 'oracle-api')
             verification_path: "actuator/health"
     steps:
       - uses: bcgov-nr/action-deployer-openshift@v1.0.4

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -36,7 +36,7 @@ jobs:
             [Main Merge Workflow](https://github.com/${{ github.repository }}/actions/workflows/merge-main.yml)
 
       - name: OpenShift Init
-        uses: bcgov-nr/action-deployer-openshift@v1.0.4
+        uses: bcgov-nr/action-deployer-openshift@v1.1.1
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
@@ -49,6 +49,7 @@ jobs:
             -p ORACLE_DB_USER=${{ secrets.DB_USER }}
             -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
+          triggers: ('common/', 'backend/', 'frontend/', 'oracle-api/')
 
   builds:
     name: Builds


### PR DESCRIPTION
Deployment triggers are used to conditionally deploy components.  This speeds up PR deployments by picking required components using triggers.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-255-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-255-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-255-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)