### PR TITLE
bug: commas on deploy action triggers

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -49,7 +49,7 @@ jobs:
             -p ORACLE_DB_USER=${{ secrets.DB_USER }}
             -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
-          triggers: ('common/', 'backend/', 'frontend/', 'oracle-api/')
+          triggers: ('common/' 'backend/' 'frontend/' 'oracle-api/')
 
   builds:
     name: Builds

--- a/common/trigger.txt
+++ b/common/trigger.txt
@@ -1,0 +1,1 @@
+Please delete

--- a/common/trigger.txt
+++ b/common/trigger.txt
@@ -1,1 +1,0 @@
-Please delete


### PR DESCRIPTION
I introduced deploy triggers with commas that shouldn't have been there.  This action removes them.  Please expect a few commits to be made/removed during testing.

Thanks to @RMCampos for catching this and troubleshooting.  :)


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-296-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-296-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-296-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)