### PR TITLE
Cut down .github/codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Matched against repo root (asterisk)
-*       @craigyu @RMCampos @SLDonnelly @DerekRoberts
+*       @craigyu @RMCampos
 
 # Matched against directories
-# /.github/workflows/       @craigyu @@SLDonnelly @DerekRoberts
+# /.github/workflows/       @craigyu @DerekRoberts
 
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 *       @craigyu @RMCampos
 
 # Matched against directories
-/.github/workflows/       @craigyu @DerekRoberts
+/.github/workflows/       @craigyu @RMCampos @DerekRoberts
 
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 *       @craigyu @RMCampos
 
 # Matched against directories
-# /.github/workflows/       @craigyu @DerekRoberts
+/.github/workflows/       @craigyu @DerekRoberts
 
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners


### PR DESCRIPTION
Remove DerekRoberts (me!) and SLDonnelly (Sabina) from .github/codeowners, since we're no longer necessary.  Good job team.  :)

We'll still have admin rights on the repo and can help out as necessary.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-344-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-344-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-344-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)