### PR TITLE
chore: restore SLDonnelly in .github/codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Matched against repo root (asterisk)
-*       @craigyu @RMCampos
+*       @craigyu @RMCampos @SLDonnelly
 
 # Matched against directories
-/.github/workflows/       @craigyu @RMCampos @DerekRoberts
+/.github/workflows/       @craigyu @RMCampos @DerekRoberts @SLDonnelly
 
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners


### PR DESCRIPTION
I dun goof't by removing Sabina from codeowners.  This is a correction.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-345-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-345-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-345-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)