### PR TITLE
hotfix: replaced mock server call with dummy data

### DIFF
--- a/frontend/src/api-service/filesAndDocsAPI.ts
+++ b/frontend/src/api-service/filesAndDocsAPI.ts
@@ -1,9 +1,5 @@
-import ApiConfig from './ApiConfig';
-import api from './api';
+import FilesDocsItems from '../mock-server/fixtures/FilesDocsItems';
 
-const getFilesAndDocs = () => {
-  const url = ApiConfig.filesAndDocs;
-  return api.get(url).then((res) => res.data);
-};
+const getFilesAndDocs = () => FilesDocsItems;
 
 export default getFilesAndDocs;

--- a/frontend/src/api-service/recentActivitiesAPI.ts
+++ b/frontend/src/api-service/recentActivitiesAPI.ts
@@ -1,9 +1,5 @@
-import ApiConfig from './ApiConfig';
-import api from './api';
+import RecentActivityItems from '../mock-server/fixtures/RecentActivityItems';
 
-const getRecentActivities = () => {
-  const url = ApiConfig.recentActivities;
-  return api.get(url).then((res) => res.data);
-};
+const getRecentActivities = () => RecentActivityItems;
 
 export default getRecentActivities;

--- a/frontend/src/components/RecentActivities/RecentActivitiesTable/index.tsx
+++ b/frontend/src/components/RecentActivities/RecentActivitiesTable/index.tsx
@@ -36,7 +36,7 @@ const RecentActivitiesTable = ({
 }: TableProps) => {
   const iconSize = '18';
 
-  const writeFileFormat = (format: string) => `${format.charAt(0) + format.slice(1).toLowerCase()} file`;
+  const writeFileFormat = (format: string) => `${format} file`;
 
   const createTableCell = (obj: any, key: string, index: number) => {
     const mapKey = `${key}-${index}`;

--- a/frontend/src/components/RecentActivities/index.tsx
+++ b/frontend/src/components/RecentActivities/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
@@ -63,13 +64,14 @@ const RecentActivities = () => {
               <Tab>{componentTexts.tabs.files}</Tab>
             </TabList>
             {
-              recentActivitiesQuery.isSuccess
-              && filesAndDocsQuery.isSuccess
+              (recentActivitiesQuery.isSuccess
+                && filesAndDocsQuery.isSuccess)
                 ? (
                   <TabPanels>
                     <TabPanel>
                       {
-                        recentActivitiesQuery.data.length === 0
+                        (Array.isArray(recentActivitiesQuery.data)
+                          && recentActivitiesQuery.data.length === 0)
                           ? (
                             <div className="empty-recent-activities">
                               <EmptySection
@@ -90,7 +92,8 @@ const RecentActivities = () => {
                     </TabPanel>
                     <TabPanel>
                       {
-                        filesAndDocsQuery.data.length === 0
+                        (Array.isArray(filesAndDocsQuery.data)
+                          && filesAndDocsQuery.data.length === 0)
                           ? (
                             <div className="empty-recent-activity-files-docs">
                               <EmptySection

--- a/frontend/src/components/RecentActivities/index.tsx
+++ b/frontend/src/components/RecentActivities/index.tsx
@@ -70,8 +70,7 @@ const RecentActivities = () => {
                   <TabPanels>
                     <TabPanel>
                       {
-                        (Array.isArray(recentActivitiesQuery.data)
-                          && recentActivitiesQuery.data.length === 0)
+                        recentActivitiesQuery.data.length === 0
                           ? (
                             <div className="empty-recent-activities">
                               <EmptySection
@@ -92,8 +91,7 @@ const RecentActivities = () => {
                     </TabPanel>
                     <TabPanel>
                       {
-                        (Array.isArray(filesAndDocsQuery.data)
-                          && filesAndDocsQuery.data.length === 0)
+                        filesAndDocsQuery.data.length === 0
                           ? (
                             <div className="empty-recent-activity-files-docs">
                               <EmptySection

--- a/frontend/src/mock-server/fixtures/FilesDocsItems.ts
+++ b/frontend/src/mock-server/fixtures/FilesDocsItems.ts
@@ -9,21 +9,21 @@ const FilesDocsItems = [
   {
     id: '1',
     name: 'Seedlots details report',
-    format: 'EXCEL',
+    format: 'Excel',
     createdAt: '2022-09-04',
     lastUpdate: '2022-10-27'
   },
   {
     id: '2',
     name: 'Orchard report',
-    format: 'EXCEL',
+    format: 'Excel',
     createdAt: '2022-09-04',
     lastUpdate: '2022-10-27'
   },
   {
     id: '3',
     name: 'Seedlot use report',
-    format: 'WORD',
+    format: 'Word',
     createdAt: '2022-01-16',
     lastUpdate: '2022-10-26'
   },


### PR DESCRIPTION
this fixes an issue where the mock server is not operating correctly, it crashes local, test, and dev environment. 

this is related to the task where changes were made to recent activities. 

<img width="706" alt="image" src="https://github.com/bcgov/nr-spar/assets/25162561/d0c2171b-2e23-49ae-9198-f036511727a0">

The exact reason on why this error wasn't happening during code review needs to be investigated.
Basically mock server does not run on test and prod, but it should run on dev. 
Instead of returning an array of file docs, it returns `{}` thus causing the `elements.map()` is not a function error.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-346-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-346-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-346-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)