### PR TITLE
bug: clip namespace from fluentbit metadata

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -213,8 +213,6 @@ jobs:
           - name: fluentbit
             file: backend/openshift.fluentbit.yml
             overwrite: true
-            parameters:
-              -p NAMESPACE=${{ vars.OC_NAMESPACE }}
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -111,8 +111,6 @@ jobs:
           - name: fluentbit
             file: backend/openshift.fluentbit.yml
             overwrite: true
-            parameters:
-              -p NAMESPACE=${{ vars.OC_NAMESPACE }}
             triggers: ('common/' 'database/' 'backend/' 'frontend/' 'oracle-api/')
           - name: frontend
             file: frontend/openshift.deploy.yml

--- a/backend/openshift.fluentbit.yml
+++ b/backend/openshift.fluentbit.yml
@@ -12,10 +12,6 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: NAMESPACE
-    description: Target namespace reference (i.e. '9f0fbe-dev')
-    displayName: Target Namespace
-    required: true
   - name: AWS_KINESIS_STREAM
     description: AWS Kinesis Stream identifier
     required: false

--- a/backend/openshift.fluentbit.yml
+++ b/backend/openshift.fluentbit.yml
@@ -165,7 +165,6 @@ objects:
     apiVersion: v1
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}-configs
-      namespace: ${NAMESPACE}
     data:
       filters.conf: |
         [FILTER]


### PR DESCRIPTION
FluentBit is consuming a namespace variable to add into metadata.  This is generally unnecessary, but not always.  For now I'm removing the variable.  If that fails we can use a GitHub Environment to handle DEV/TEST/PROD differences.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-431-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-431-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-431-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)