### PR TITLE
feat: caddy in compose and var consistency

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -133,7 +133,7 @@ objects:
                       key: forest-client-api-key
                 - name: POSTGRES_HOST
                   value: ${NAME}-${ZONE}-database
-                - name: POSTGRES_DATABASE
+                - name: POSTGRES_DB
                   valueFrom:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-database

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -131,19 +131,19 @@ objects:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-backend
                       key: forest-client-api-key
-                - name: POSTGRESQL_HOST
+                - name: POSTGRES_HOST
                   value: ${NAME}-${ZONE}-database
-                - name: POSTGRESQL_DATABASE
+                - name: POSTGRES_DATABASE
                   valueFrom:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-database
                       key: database-name
-                - name: POSTGRESQL_PASSWORD
+                - name: POSTGRES_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-database
                       key: database-password
-                - name: POSTGRESQL_USER
+                - name: POSTGRES_USER
                   valueFrom:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-database

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -24,9 +24,9 @@ nr-spar-team-email-address = FSA.Delivery.Team2@gov.bc.ca
 
 # Database, datasource and JPA
 spring.datasource.driver-class-name = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://${POSTGRESQL_HOST}:5432/${POSTGRESQL_DATABASE}
-spring.datasource.username = ${POSTGRESQL_USER}
-spring.datasource.password = ${POSTGRESQL_PASSWORD}
+spring.datasource.url = jdbc:postgresql://${POSTGRES_HOST}:5432/${POSTGRES_DATABASE}
+spring.datasource.username = ${POSTGRES_USER}
+spring.datasource.password = ${POSTGRES_PASSWORD}
 spring.datasource.hikari.connectionTimeout = 90000
 spring.datasource.hikari.idleTimeout = 45000
 spring.datasource.hikari.maxLifetime = 60000

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -24,7 +24,7 @@ nr-spar-team-email-address = FSA.Delivery.Team2@gov.bc.ca
 
 # Database, datasource and JPA
 spring.datasource.driver-class-name = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://${POSTGRES_HOST}:5432/${POSTGRES_DATABASE}
+spring.datasource.url = jdbc:postgresql://${POSTGRES_HOST}:5432/${POSTGRES_DB}
 spring.datasource.username = ${POSTGRES_USER}
 spring.datasource.password = ${POSTGRES_PASSWORD}
 spring.datasource.hikari.connectionTimeout = 90000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,24 @@ x-var:
   - &POSTGRES_DB
     postgres
 
+x-frontend: &frontend
+  depends_on:
+    backend:
+      condition: service_started
+  environment:
+    VITE_SERVER_URL: http://localhost:8090
+    VITE_ORACLE_SERVER_URL: https://nr-spar-test-oracle-api.apps.silver.devops.gov.bc.ca
+    VITE_KC_URL: https://test.loginproxy.gov.bc.ca/auth
+    VITE_KC_REALM: standard
+    VITE_KC_CLIENT_ID: seed-planning-test-4296
+    LOG_LEVEL: debug
+  healthcheck:
+    test: wget --spider http://localhost:3000
+    interval: 10s
+    timeout: 10s
+    retries: 5
+    start_period: 10s
+
 services:
   database:
     container_name: database
@@ -50,6 +68,7 @@ services:
 
   oracle-api:
     container_name: oracle-api
+    profiles: ["oracle-api"]
     depends_on:
       backend:
         condition: service_started
@@ -66,7 +85,6 @@ services:
       - "8091:8091"
     image: maven:3.9.3-eclipse-temurin-17
     entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n"
-    profiles: ["oracle-api"]
     network_mode: "host"
     working_dir: /app
     volumes:
@@ -74,26 +92,17 @@ services:
 
   frontend:
     container_name: frontend
-    depends_on:
-      backend:
-        condition: service_started
-    environment:
-      VITE_SERVER_URL: http://localhost:8090
-      VITE_ORACLE_SERVER_URL: https://nr-spar-test-oracle-api.apps.silver.devops.gov.bc.ca
-      VITE_KC_URL: https://test.loginproxy.gov.bc.ca/auth
-      VITE_KC_REALM: standard
-      VITE_KC_CLIENT_ID: seed-planning-test-4296
-      CHOKIDAR_USEPOLLING: true
-    ports:
-      - "3000:3000"
-    healthcheck:
-      test: wget --spider http://localhost:3000
-      interval: 10s
-      timeout: 10s
-      retries: 5
-      start_period: 10s
+    ports: ["3000:3000"]
     image: node:18.17.1-alpine3.17
     entrypoint: sh -c "apk add --no-cache python3 g++ make && cd /app && npm i && npm run start"
     user: root
-    volumes:
-      - ./frontend:/app:z
+    volumes: ["./frontend:/app:z"]
+    <<: *frontend
+
+  caddy:
+    container_name: caddy
+    profiles: ["caddy"]
+    build: ./frontend
+    ports: ["3005:3000"]
+    volumes: ["./frontend/Caddyfile:/etc/caddy/Caddyfile"]
+    <<: *frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,9 @@
 version: '3.9'
 
-x-var:
-  - &POSTGRES_USER
-    postgres
-  - &POSTGRES_PASSWORD
-    default
-  - &POSTGRES_DB
-    postgres
+x-db-vars: &db-vars
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: default
+  POSTGRES_DB: postgres
 
 x-frontend: &frontend
   depends_on:
@@ -30,11 +27,8 @@ services:
   database:
     container_name: database
     environment:
-      POSTGRES_USER: *POSTGRES_USER
-      POSTGRES_PASSWORD: *POSTGRES_PASSWORD
-      POSTGRES_DB: *POSTGRES_DB
-    volumes:
-      - /pgdata
+      <<: *db-vars
+    volumes: ["/pgdata"]
     healthcheck:
       test: pg_isready -U postgres
       interval: 5s
@@ -50,21 +44,16 @@ services:
     environment:
       ALLOWED_ORIGINS: "http://localhost:*"
       KEYCLOAK_REALM_URL: https://test.loginproxy.gov.bc.ca/auth/realms/standard
-      POSTGRESQL_HOST: database
-      POSTGRESQL_DATABASE: *POSTGRES_DB
-      POSTGRESQL_USER: *POSTGRES_USER
-      POSTGRESQL_PASSWORD: *POSTGRES_PASSWORD
       FORESTCLIENTAPI_ADDRESS: https://nr-forest-client-api-prod.api.gov.bc.ca/api
       FORESTCLIENTAPI_KEY: "${FORESTCLIENTAPI_KEY}"
       ORACLE_SERVER_URL: https://nr-spar-test-oracle-api.apps.silver.devops.gov.bc.ca
-    ports:
-      - "8090:8090"
-      - "5005:5005"
+      POSTGRES_HOST: database
+      <<: *db-vars
+    ports: ["8090:8090", "5005:5005"]
     image: maven:3.9.3-eclipse-temurin-17
     entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005"
     working_dir: /app
-    volumes:
-      - ./backend:/app:z
+    volumes: ["./backend:/app:z"]
     healthcheck:
       test: curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
       interval: 5s
@@ -86,14 +75,12 @@ services:
       DATABASE_USER: proxy_fsa_spar_read_only_user
       DATABASE_PASSWORD: "${DATABASE_PASSWORD}"
       KEYCLOAK_REALM_URL: "https://test.loginproxy.gov.bc.ca/auth/realms/standard"
-    ports:
-      - "8091:8091"
+    ports: ["8091:8091"]
     image: maven:3.9.3-eclipse-temurin-17
     entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n"
     network_mode: "host"
     working_dir: /app
-    volumes:
-      - ./oracle-api:/app:z
+    volumes: ["./oracle-api:/app:z"]
     healthcheck:
       test: curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,11 @@ services:
     working_dir: /app
     volumes:
       - ./backend:/app:z
+    healthcheck:
+      test: curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   oracle-api:
     container_name: oracle-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,32 +60,32 @@ services:
       timeout: 5s
       retries: 5
 
-  oracle-api:
-    container_name: oracle-api
-    profiles: ["oracle-api"]
-    depends_on:
-      backend:
-        condition: service_healthy
-    environment:
-      NR_SPAR_ORACLE_API_VERSION: "dev"
-      SERVER_PORT: "8091"
-      DATABASE_HOST: nrcdb03.bcgov
-      DATABASE_PORT: "1543"
-      SERVICE_NAME: dbq01.nrs.bcgov
-      DATABASE_USER: proxy_fsa_spar_read_only_user
-      DATABASE_PASSWORD: "${DATABASE_PASSWORD}"
-      KEYCLOAK_REALM_URL: "https://test.loginproxy.gov.bc.ca/auth/realms/standard"
-    ports: ["8091:8091"]
-    image: maven:3.9.3-eclipse-temurin-17
-    entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n"
-    network_mode: "host"
-    working_dir: /app
-    volumes: ["./oracle-api:/app"]
-    healthcheck:
-      test: curl -f http://localhost:8091/actuator/health | grep '"status":"UP"'
-      interval: 5s
-      timeout: 5s
-      retries: 5
+  # oracle-api:
+  #   container_name: oracle-api
+  #   profiles: ["oracle-api"]
+  #   depends_on:
+  #     backend:
+  #       condition: service_healthy
+  #   environment:
+  #     NR_SPAR_ORACLE_API_VERSION: "dev"
+  #     SERVER_PORT: "8091"
+  #     DATABASE_HOST: nrcdb03.bcgov
+  #     DATABASE_PORT: "1543"
+  #     SERVICE_NAME: dbq01.nrs.bcgov
+  #     DATABASE_USER: proxy_fsa_spar_read_only_user
+  #     DATABASE_PASSWORD: "${DATABASE_PASSWORD}"
+  #     KEYCLOAK_REALM_URL: "https://test.loginproxy.gov.bc.ca/auth/realms/standard"
+  #   ports: ["8091:8091"]
+  #   image: maven:3.9.3-eclipse-temurin-17
+  #   entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n"
+  #   network_mode: "host"
+  #   working_dir: /app
+  #   volumes: ["./oracle-api:/app"]
+  #   healthcheck:
+  #     test: curl -f http://localhost:8091/actuator/health | grep '"status":"UP"'
+  #     interval: 5s
+  #     timeout: 5s
+  #     retries: 5
 
   frontend:
     container_name: frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     image: maven:3.9.3-eclipse-temurin-17
     entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005"
     working_dir: /app
-    volumes: ["./backend:/app:z"]
+    volumes: ["./backend:/app"]
     healthcheck:
       test: curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
       interval: 5s
@@ -65,7 +65,7 @@ services:
     profiles: ["oracle-api"]
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
     environment:
       NR_SPAR_ORACLE_API_VERSION: "dev"
       SERVER_PORT: "8091"
@@ -80,9 +80,9 @@ services:
     entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n"
     network_mode: "host"
     working_dir: /app
-    volumes: ["./oracle-api:/app:z"]
+    volumes: ["./oracle-api:/app"]
     healthcheck:
-      test: curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
+      test: curl -f http://localhost:8091/actuator/health | grep '"status":"UP"'
       interval: 5s
       timeout: 5s
       retries: 5
@@ -93,7 +93,7 @@ services:
     image: node:18.17.1-alpine3.17
     entrypoint: sh -c "apk add --no-cache python3 g++ make && cd /app && npm i && npm run start"
     user: root
-    volumes: ["./frontend:/app:z"]
+    volumes: ["./frontend:/app"]
     <<: *frontend
 
   caddy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,11 @@ services:
     working_dir: /app
     volumes:
       - ./oracle-api:/app:z
+    healthcheck:
+      test: curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   frontend:
     container_name: frontend

--- a/oracle-api/Dockerfile
+++ b/oracle-api/Dockerfile
@@ -24,8 +24,8 @@ RUN mkdir config dump public && \
 
 # User, port and healthcheck
 USER 1001
-EXPOSE 8090
-HEALTHCHECK CMD curl -f http://localhost:8090/actuator/health | grep '"status":"UP"'
+EXPOSE 8091
+HEALTHCHECK CMD curl -f http://localhost:8091/actuator/health | grep '"status":"UP"'
 
 # Start
 ENTRYPOINT ["/usr/share/service/dockerfile-entrypoint.sh"]


### PR DESCRIPTION
Caddy in docker-compose.yml.

Run caddy (serves frontend), backend and database:
`docker compose up caddy`

Run caddy and oracle-api:
`docker compose up caddy oracle-api`

Extra: Backend vars changed to line up with expected Postgres vars.  Good for consistency, but not a deal breaker.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-443-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-443-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-443-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)