### PR TITLE
fix: remove tooltip on step 5

### DIFF
--- a/frontend/src/components/InfoSection/InfoSectionColumn/index.tsx
+++ b/frontend/src/components/InfoSection/InfoSectionColumn/index.tsx
@@ -27,8 +27,7 @@ const InfoSectionColumn = (
       <TextInput
         id={`${formatStrForKey(item.name)}-id`}
         labelText={item.name}
-        value={item.value}
-        placeholder="--"
+        value={item.value ? item.value : '--'}
         readOnly
       />
     </Column>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

A tooltip was displayed when a user hovered over an input at the bottom of the page in Step 5. This behavior has been removed. To do this I had to remove the placeholder, as there is no easy way to remove the tooltip from the carbon components.
Fixes #[#387](https://github.com/bcgov/nr-spar/issues/387)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-491-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-491-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-491-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)