### PR TITLE
fix: allow ibm cdn

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -23,7 +23,7 @@
 		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
 		X-Content-Type-Options "nosniff"
 		Strict-Transport-Security "max-age=31536000"
-		Content-Security-Policy "base-uri 'self'; connect-src 'self' https://*.gov.bc.ca {$VITE_SERVER_URL}; default-src 'self'; font-src 'self'; frame-src 'self' https://*.gov.bc.ca; img-src 'self'; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'unsafe-inline' 'report-sample' 'self'; style-src 'report-sample' 'self'; worker-src 'none';"
+		Content-Security-Policy "base-uri 'self'; connect-src 'self' https://*.gov.bc.ca {$VITE_SERVER_URL}; default-src 'self'; font-src 'self' https://1.www.s81c.com/; frame-src 'self' https://*.gov.bc.ca; img-src 'self'; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'unsafe-inline' 'report-sample' 'self'; style-src 'report-sample' 'self'; worker-src 'none';"
 		Referrer-Policy "same-origin"
 	}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Allow IBM CDN to serve font files

Related to #490 

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-517-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-517-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-517-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)