### PR TITLE
Feat/448 step 1 validation

### DIFF
--- a/frontend/src/components/FormProgress/index.tsx
+++ b/frontend/src/components/FormProgress/index.tsx
@@ -8,6 +8,7 @@ import { DocumentBlank } from '@carbon/icons-react';
 
 import Subtitle from '../Subtitle';
 import SeedlotRegistrationProgress from '../SeedlotRegistrationProgress';
+import { initialProgressConfig } from '../../views/Seedlot/SeedlotRegistrationForm/constants';
 
 import './styles.scss';
 
@@ -26,7 +27,7 @@ const FormProgress = ({ seedlotNumber }: FormProgressProps) => {
         <Subtitle text="Where you are in the registration process" />
       </div>
       <div className="steps-box">
-        <SeedlotRegistrationProgress currentIndex={5} />
+        <SeedlotRegistrationProgress progressStatus={initialProgressConfig} />
       </div>
       <div>
         <Button

--- a/frontend/src/components/FormReview/index.tsx
+++ b/frontend/src/components/FormReview/index.tsx
@@ -20,6 +20,7 @@ import InterimStorage from '../SeedlotRegistrationSteps/InterimStep';
 import CollectionStep from '../SeedlotRegistrationSteps/CollectionStep';
 import ExtractionAndStorage from '../SeedlotRegistrationSteps/ExtractionAndStorageStep';
 import { OrchardForm } from '../SeedlotRegistrationSteps/OrchardStep/definitions';
+import { initCollectionState } from '../../views/Seedlot/SeedlotRegistrationForm/utils';
 
 const mockFormData = [
   {
@@ -114,18 +115,7 @@ const ownershipMock = {
   }
 };
 
-const collectionMock = {
-  useDefaultAgencyInfo: true,
-  collectorAgency: 'Strong Seeds Orchard - SSO',
-  locationCode: '32',
-  startDate: '2023/01/04',
-  endDate: '2023/01/22',
-  numberOfContainers: '2',
-  volumePerContainers: '2',
-  volumeOfCones: '4',
-  selectedCollectionCodes: [],
-  comments: 'Example of additional comments about the seedlot'
-};
+const collectionMock = initCollectionState('', '');
 
 const extractionMock = {
   extractoryUseTSC: true,

--- a/frontend/src/components/FormReview/index.tsx
+++ b/frontend/src/components/FormReview/index.tsx
@@ -115,7 +115,7 @@ const ownershipMock = {
   }
 };
 
-const collectionMock = initCollectionState('', '');
+const collectionMock = initCollectionState(defaultAgency, defaultCode);
 
 const extractionMock = {
   extractoryUseTSC: true,

--- a/frontend/src/components/FormReview/index.tsx
+++ b/frontend/src/components/FormReview/index.tsx
@@ -20,7 +20,6 @@ import InterimStorage from '../SeedlotRegistrationSteps/InterimStep';
 import CollectionStep from '../SeedlotRegistrationSteps/CollectionStep';
 import ExtractionAndStorage from '../SeedlotRegistrationSteps/ExtractionAndStorageStep';
 import { OrchardForm } from '../SeedlotRegistrationSteps/OrchardStep/definitions';
-import { initCollectionState } from '../../views/Seedlot/SeedlotRegistrationForm/utils';
 
 const mockFormData = [
   {
@@ -115,7 +114,18 @@ const ownershipMock = {
   }
 };
 
-const collectionMock = initCollectionState('', '');
+const collectionMock = {
+  useDefaultAgencyInfo: true,
+  collectorAgency: 'Strong Seeds Orchard - SSO',
+  locationCode: '32',
+  startDate: '2023/01/04',
+  endDate: '2023/01/22',
+  numberOfContainers: '2',
+  volumePerContainers: '2',
+  volumeOfCones: '4',
+  selectedCollectionCodes: [],
+  comments: 'Example of additional comments about the seedlot'
+};
 
 const extractionMock = {
   extractoryUseTSC: true,

--- a/frontend/src/components/SeedlotRegistrationProgress/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationProgress/index.tsx
@@ -4,47 +4,66 @@ import {
   ProgressIndicator,
   ProgressStep
 } from '@carbon/react';
+import { ProgressIndicatorConfig } from '../../views/Seedlot/SeedlotRegistrationForm/definitions';
 
 interface SeedlotRegistrationProgressProps {
-  currentIndex: number;
+  progressStatus: ProgressIndicatorConfig;
   className?: string;
   interactFunction?: Function;
 }
 
 const SeedlotRegistrationProgress = ({
-  currentIndex,
+  progressStatus,
   className,
   interactFunction
 }: SeedlotRegistrationProgressProps) => (
   <ProgressIndicator
+    currentIndex={-1} // Needs to feed it a -1 value otherwise step 1 will stuck at current
     className={className}
-    currentIndex={currentIndex}
     spaceEqually
     onChange={interactFunction ?? null}
   >
     <ProgressStep
       label="Collection"
       secondaryLabel="Step 1"
+      complete={progressStatus.collection.isComplete}
+      current={progressStatus.collection.isCurrent}
+      invalid={progressStatus.collection.isInvalid}
     />
     <ProgressStep
       label="Ownership"
       secondaryLabel="Step 2"
+      complete={progressStatus.ownership.isComplete}
+      current={progressStatus.ownership.isCurrent}
+      invalid={progressStatus.ownership.isInvalid}
     />
     <ProgressStep
       label="Interim storage"
       secondaryLabel="Step 3"
+      complete={progressStatus.interim.isComplete}
+      current={progressStatus.interim.isCurrent}
+      invalid={progressStatus.interim.isInvalid}
     />
     <ProgressStep
       label="Orchard"
       secondaryLabel="Step 4"
+      complete={progressStatus.orchard.isComplete}
+      current={progressStatus.orchard.isCurrent}
+      invalid={progressStatus.orchard.isInvalid}
     />
     <ProgressStep
       label="Parent tree and SMP"
       secondaryLabel="Step 5"
+      complete={progressStatus.parent.isComplete}
+      current={progressStatus.parent.isCurrent}
+      invalid={progressStatus.parent.isInvalid}
     />
     <ProgressStep
       label="Extraction and storage"
       secondaryLabel="Step 6"
+      complete={progressStatus.extraction.isComplete}
+      current={progressStatus.extraction.isCurrent}
+      invalid={progressStatus.extraction.isInvalid}
     />
   </ProgressIndicator>
 );

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/constants.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/constants.ts
@@ -47,17 +47,17 @@ const fieldsConfig = {
   numberOfContainers: {
     name: 'numberOfContainers',
     labelText: 'Number of Containers',
-    invalidText: 'Number is not valid'
+    invalidText: 'Number has more than 3 decimals or bigger than 9,999.999'
   },
   volumePerContainers: {
     name: 'volumePerContainers',
     labelText: 'Volume per Containers (HI)',
-    invalidText: 'Number is not valid'
+    invalidText: 'Number has more than 3 decimals or bigger than 9,999.999'
   },
   volumeOfCones: {
     name: 'volumeOfCones',
     labelText: 'Volume of Cones (HI)',
-    invalidText: 'Number is not valid',
+    invalidText: 'Number has more than 3 decimals',
     helperText: 'This value should be the "Volume per container" X "Number of containers".',
     warnText: 'The total volume of cones does not equal, please note that this value should be the "Volume per container" x "Number of containers"'
   },

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/constants.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/constants.ts
@@ -1,7 +1,8 @@
-const DATE_FORMAT = 'Y/m/d';
-const MOMENT_DATE_FORMAT = 'YYYY/MM/DD';
+export const DATE_FORMAT = 'Y/m/d';
+export const MOMENT_DATE_FORMAT = 'YYYY/MM/DD';
+export const MAX_INPUT_DECIMAL = 9999.999;
 
-const fieldsConfig = {
+export const fieldsConfig = {
   titleSection: {
     title: 'Collector agency',
     subtitle: 'Enter the collector agency information'
@@ -74,5 +75,3 @@ const fieldsConfig = {
     placeholder: 'Additional comments about the seedlot'
   }
 };
-
-export { DATE_FORMAT, MOMENT_DATE_FORMAT, fieldsConfig };

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/definitions.ts
@@ -1,17 +1,19 @@
 import MultiOptionsObj from '../../../types/MultiOptionsObject';
-import { FormInvalidationObj } from '../../../views/Seedlot/SeedlotRegistrationForm/definitions';
+import { FormInputType, FormInvalidationObj } from '../../../views/Seedlot/SeedlotRegistrationForm/definitions';
 
-export interface CollectionForm {
-  useDefaultAgencyInfo: boolean,
-  collectorAgency: string,
-  locationCode: string,
-  startDate: string,
-  endDate: string,
-  numberOfContainers: string,
-  volumePerContainers: string,
-  volumeOfCones: string,
-  selectedCollectionCodes: string[],
-  comments: string
+export type CollectionForm = {
+  useDefaultAgencyInfo: FormInputType & {
+    value: boolean
+  },
+  collectorAgency: FormInputType & { value: string },
+  locationCode: FormInputType & { value: string },
+  startDate: FormInputType & { value: string },
+  endDate: FormInputType & { value: string },
+  numberOfContainers: FormInputType & { value: string },
+  volumePerContainers: FormInputType & { value: string },
+  volumeOfCones: FormInputType & { value: string },
+  selectedCollectionCodes: FormInputType & { value: string[] },
+  comments: FormInputType & { value: string }
 }
 
 export interface CollectionStepProps {
@@ -22,7 +24,7 @@ export interface CollectionStepProps {
   agencyOptions: Array<string>,
   collectionMethods: Array<MultiOptionsObj>,
   readOnly?: boolean,
-  invalidateObj?:FormInvalidationObj
+  invalidateObj?: FormInvalidationObj
 }
 
 export type FormValidation = {

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/definitions.ts
@@ -1,19 +1,17 @@
 import MultiOptionsObj from '../../../types/MultiOptionsObject';
-import { FormInputType, FormInvalidationObj } from '../../../views/Seedlot/SeedlotRegistrationForm/definitions';
+import { FormInvalidationObj } from '../../../views/Seedlot/SeedlotRegistrationForm/definitions';
 
-export type CollectionForm = {
-  useDefaultAgencyInfo: FormInputType & {
-    value: boolean
-  },
-  collectorAgency: FormInputType & { value: string },
-  locationCode: FormInputType & { value: string },
-  startDate: FormInputType & { value: string },
-  endDate: FormInputType & { value: string },
-  numberOfContainers: FormInputType & { value: string },
-  volumePerContainers: FormInputType & { value: string },
-  volumeOfCones: FormInputType & { value: string },
-  selectedCollectionCodes: FormInputType & { value: string[] },
-  comments: FormInputType & { value: string }
+export interface CollectionForm {
+  useDefaultAgencyInfo: boolean,
+  collectorAgency: string,
+  locationCode: string,
+  startDate: string,
+  endDate: string,
+  numberOfContainers: string,
+  volumePerContainers: string,
+  volumeOfCones: string,
+  selectedCollectionCodes: string[],
+  comments: string
 }
 
 export interface CollectionStepProps {
@@ -24,7 +22,7 @@ export interface CollectionStepProps {
   agencyOptions: Array<string>,
   collectionMethods: Array<MultiOptionsObj>,
   readOnly?: boolean,
-  invalidateObj?: FormInvalidationObj
+  invalidateObj?:FormInvalidationObj
 }
 
 export type FormValidation = {

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/index.tsx
@@ -92,14 +92,14 @@ const CollectionStep = (
   //   return structuredClone(state, { transfer: transferredObjs });
   // };
 
-  const setRef = (el: HTMLInputElement, name: keyof CollectionForm) => {
-    console.log('settingref...', name);
-    if (state && el) {
-      const clonedState = { ...state };
-      clonedState[name].ref = el;
-      // setStepData(clonedState);
-    }
-  };
+  // const setRef = (el: HTMLInputElement, name: keyof CollectionForm) => {
+  //   console.log('settingref...', name);
+  //   if (state && el) {
+  //     const clonedState = { ...state };
+  //     clonedState[name].ref = el;
+  //     // setStepData(clonedState);
+  //   }
+  // };
 
   const updateAfterLocValidation = (isInvalid: boolean) => {
     setValidationObj({
@@ -170,9 +170,9 @@ const CollectionStep = (
     checked?: boolean
   ) => {
     const clonedState = { ...state };
-    if (optName && optName !== name) {
+    if (optName && optName !== name && optValue) {
       clonedState[name].value = value;
-      clonedState[optName].value = optName;
+      clonedState[optName].value = optValue;
 
       if (setDefaultAgency) {
         clonedState.useDefaultAgencyInfo.value = checked ?? false;
@@ -205,14 +205,14 @@ const CollectionStep = (
 
   useEffect(() => {
     const useDefault = state.useDefaultAgencyInfo.value;
-    const agency = useDefault ? defaultAgency : state.collectorAgency.value;
-    const code = useDefault ? defaultCode : state.locationCode.value;
+    const agencyValue = useDefault ? defaultAgency : state.collectorAgency.value;
+    const codeValue = useDefault ? defaultCode : state.locationCode.value;
 
     handleFormInput(
       'collectorAgency',
-      agency,
+      agencyValue,
       'locationCode',
-      code,
+      codeValue,
       true,
       useDefault
     );
@@ -258,17 +258,16 @@ const CollectionStep = (
   };
 
   const validateLocationCode = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let locationCode = event.target.value;
-    const isInRange = validator.isInt(locationCode, { min: 0, max: 99 });
+    let locationCodeValue = event.target.value;
+    const isInRange = validator.isInt(locationCodeValue, { min: 0, max: 99 });
 
     // Adding this check to add an extra 0 on the left, for cases where
     // the user types values between 0 and 9
-    if (isInRange && locationCode.length === 1) {
-      locationCode = locationCode.padStart(2, '0');
-      setStepData({
-        ...state,
-        locationCode
-      });
+    if (isInRange && locationCodeValue.length === 1) {
+      locationCodeValue = locationCodeValue.padStart(2, '0');
+      const clonedState = structuredClone(state);
+      clonedState.locationCode.value = locationCodeValue;
+      setStepData(clonedState);
     }
 
     if (!isInRange) {
@@ -281,7 +280,7 @@ const CollectionStep = (
     }
 
     if (forestClientNumber) {
-      validateLocationCodeMutation.mutate([forestClientNumber, locationCode]);
+      validateLocationCodeMutation.mutate([forestClientNumber, locationCodeValue]);
       setValidationObj({
         ...validationObj,
         isLocationCodeInvalid: false
@@ -301,9 +300,8 @@ const CollectionStep = (
       <Row className="collection-step-row">
         <Column sm={4} md={8} lg={16} xlg={16}>
           <Checkbox
-            id={fieldsConfig.checkbox.name}
+            id={state.useDefaultAgencyInfo.id}
             name={fieldsConfig.checkbox.name}
-            ref={(el: HTMLInputElement) => setRef(el, 'useDefaultAgencyInfo')}
             labelText={fieldsConfig.checkbox.labelText}
             readOnly={readOnly}
             checked={state.useDefaultAgencyInfo.value}
@@ -329,15 +327,14 @@ const CollectionStep = (
       <Row className="collection-step-row">
         <Column sm={4} md={4} lg={8} xlg={6}>
           <ComboBox
-            id="collector-agency-combobox"
+            id={state.collectorAgency.id}
             name={fieldsConfig.collector.name}
-            ref={(el: HTMLInputElement) => setRef(el, 'collectorAgency')}
             placeholder={fieldsConfig.collector.placeholder}
             titleText={fieldsConfig.collector.titleText}
             helperText={fieldsConfig.collector.helperText}
             invalidText={fieldsConfig.collector.invalidText}
             items={agencyOptions}
-            readOnly={state.useDefaultAgencyInfo || readOnly}
+            readOnly={state.useDefaultAgencyInfo.value || readOnly}
             selectedItem={state.collectorAgency.value}
             onChange={(e: ComboBoxEvent) => {
               handleFormInput(
@@ -354,10 +351,9 @@ const CollectionStep = (
         </Column>
         <Column sm={4} md={4} lg={8} xlg={6}>
           <TextInput
-            id="collector-location-code-input"
+            id={state.locationCode.id}
             className="cone-collector-location-code"
             name={fieldsConfig.code.name}
-            ref={(el: HTMLInputElement) => setRef(el, 'locationCode')}
             value={state.locationCode.value}
             type="number"
             placeholder={!forestClientNumber ? '' : fieldsConfig.code.placeholder}
@@ -365,7 +361,7 @@ const CollectionStep = (
             helperText={locationCodeHelperText}
             invalid={validationObj.isLocationCodeInvalid}
             invalidText={invalidLocationMessage}
-            readOnly={state.useDefaultAgencyInfo.value || readOnly}
+            readOnly={state.useDefaultAgencyInfo.value ?? readOnly}
             disabled={!forestClientNumber}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               handleFormInput(
@@ -408,9 +404,8 @@ const CollectionStep = (
             }}
           >
             <DatePickerInput
-              id="collection-start-date-picker"
+              id={state.startDate.id}
               name={fieldsConfig.startDate.name}
-              ref={(el: HTMLInputElement) => setRef(el, 'startDate')}
               placeholder={fieldsConfig.startDate.placeholder}
               labelText={fieldsConfig.startDate.labelText}
               helperText={fieldsConfig.startDate.helperText}
@@ -435,9 +430,8 @@ const CollectionStep = (
             }}
           >
             <DatePickerInput
-              id="collection-end-date-picker"
+              id={state.endDate.id}
               name={fieldsConfig.endDate.name}
-              ref={(el: HTMLInputElement) => setRef(el, 'endDate')}
               placeholder={fieldsConfig.endDate.placeholder}
               labelText={fieldsConfig.endDate.labelText}
               helperText={fieldsConfig.endDate.helperText}
@@ -451,9 +445,8 @@ const CollectionStep = (
       <Row className="collection-step-row">
         <Column sm={4} md={4} lg={8} xlg={6}>
           <NumberInput
-            id="collection-num-of-container-input"
+            id={state.numberOfContainers.id}
             name={fieldsConfig.numberOfContainers.name}
-            ref={(el: HTMLInputElement) => setRef(el, 'numberOfContainers')}
             value={state.numberOfContainers.value}
             label={fieldsConfig.numberOfContainers.labelText}
             readOnly={readOnly}
@@ -470,10 +463,9 @@ const CollectionStep = (
         </Column>
         <Column sm={4} md={4} lg={8} xlg={6}>
           <NumberInput
-            id="collection-colume-perc-input"
+            id={state.volumePerContainers.id}
             name={fieldsConfig.volumePerContainers.name}
-            ref={(el: HTMLInputElement) => setRef(el, 'volumePerContainers')}
-            value={state.volumePerContainers}
+            value={state.volumePerContainers.value}
             label={fieldsConfig.volumePerContainers.labelText}
             readOnly={readOnly}
             invalidText={fieldsConfig.volumePerContainers.invalidText}
@@ -491,9 +483,8 @@ const CollectionStep = (
       <Row className="collection-step-row">
         <Column sm={4} md={4} lg={16} xlg={12}>
           <NumberInput
-            id="collection-value-of-cones-input"
+            id={state.volumeOfCones.id}
             name={fieldsConfig.volumeOfCones.name}
-            ref={(el: HTMLInputElement) => setRef(el, 'volumeOfCones')}
             value={state.volumeOfCones.value}
             label={fieldsConfig.volumeOfCones.labelText}
             invalidText={fieldsConfig.volumeOfCones.invalidText}
@@ -516,7 +507,7 @@ const CollectionStep = (
         <Column sm={4} md={8} lg={16} xlg={16}>
           <CheckboxGroup
             legendText={fieldsConfig.collectionMethodOptionsLabel}
-            ref={(el: HTMLInputElement) => setRef(el, 'selectedCollectionCodes')}
+            id={state.selectedCollectionCodes.id}
           >
             {
               collectionMethods.map((method) => (
@@ -564,8 +555,8 @@ const CollectionStep = (
       <Row className="collection-step-row">
         <Column sm={4} md={4} lg={16} xlg={12}>
           <TextArea
+            id={state.comments.id}
             name={fieldsConfig.comments.name}
-            ref={(el: HTMLInputElement) => setRef(el, 'comments')}
             value={state.comments.value}
             labelText={fieldsConfig.comments.labelText}
             readOnly={readOnly}

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/index.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import moment from 'moment';
-
 import {
   FlexGrid,
   Column,
@@ -16,22 +14,22 @@ import {
   TextInput,
   InlineLoading
 } from '@carbon/react';
-
+import moment from 'moment';
 import validator from 'validator';
 
 import Subtitle from '../../Subtitle';
-
 import getForestClientLocation from '../../../api-service/forestClientsAPI';
-
-import { DATE_FORMAT, MOMENT_DATE_FORMAT, fieldsConfig } from './constants';
 import { filterInput, FilterObj } from '../../../utils/filterUtils';
 import getForestClientNumber from '../../../utils/StringUtils';
 import { LOCATION_CODE_LIMIT } from '../../../shared-constants/shared-constants';
 import ComboBoxEvent from '../../../types/ComboBoxEvent';
+
+import { DATE_FORMAT, MOMENT_DATE_FORMAT, fieldsConfig } from './constants';
 import {
   CollectionStepProps,
   CollectionForm
 } from './definitions';
+import { calcVolume, formatLocationCode, isNumNotInRange } from './utils';
 
 import './styles.scss';
 
@@ -120,8 +118,6 @@ const CollectionStep = (
     setStepData(clonedState);
   };
 
-  const formatLocationCode = (value: string) => (value.length > 1 ? value : value.padStart(2, '0'));
-
   const handleLocationCodeBlur = (value: string) => {
     const formattedCode = value.length ? formatLocationCode(value) : '';
     if (formattedCode === '') return;
@@ -148,20 +144,6 @@ const CollectionStep = (
 
     setStepData(clonedState);
   };
-
-  /**
-   * Calculate volume_of_cones = num_of_container * vol_per_container
-   */
-  const calcVolume = (numOfContainer: string, volPerContainer: string) => (
-    (Number(numOfContainer) * Number(volPerContainer)).toFixed(3)
-  );
-
-  /**
-   * Only for number of container and vol per container
-   */
-  const isNumNotInRange = (value: string): boolean => (
-    !((Number(value) > 0) && (Number(value) < 9999.999))
-  );
 
   const handleContainerNumAndVol = (isNum: boolean, value: string) => {
     const clonedState = structuredClone(state);

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Calculate volume_of_cones = num_of_container * vol_per_container.
+ */
+export const calcVolume = (numOfContainer: string, volPerContainer: string) => (
+  (Number(numOfContainer) * Number(volPerContainer)).toFixed(3)
+);
+
+/**
+ * Only for number of container and vol per container.
+ */
+export const isNumNotInRange = (value: string): boolean => (
+  !((Number(value) > 0) && (Number(value) < 9999.999))
+);
+
+/**
+ * Format single digit location code to have a leading 0.
+ */
+export const formatLocationCode = (value: string) => (value.length > 1 ? value : value.padStart(2, '0'));

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/utils.ts
@@ -1,3 +1,5 @@
+import { MAX_INPUT_DECIMAL } from './constants';
+
 /**
  * Calculate volume_of_cones = num_of_container * vol_per_container.
  */
@@ -9,7 +11,7 @@ export const calcVolume = (numOfContainer: string, volPerContainer: string) => (
  * Only for number of container and vol per container.
  */
 export const isNumNotInRange = (value: string): boolean => (
-  !((Number(value) > 0) && (Number(value) < 9999.999))
+  !((Number(value) > 0) && (Number(value) < MAX_INPUT_DECIMAL))
 );
 
 /**

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/constants.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/constants.ts
@@ -1,18 +1,43 @@
-const inputText = {
-  modal: {
-    buttonText: 'Submit registration',
-    modalLabel: 'Seedlot registration',
-    modalHeading: 'Declaration',
-    primaryButtonText: 'Submit seedlot',
-    secondaryButtonText: 'Cancel',
-    helperText: 'Read and accept the declaration to complete the seedlot registration',
-    checkboxLabelText: 'I hereby declare that the information provided in this application is true and correct, and that I am the owner of the seedlot or have been authorized by the owner(s) of the seedlot to submit this application.',
-    notification: {
-      title: 'Review the form:',
-      subtitle: 'Please, be sure to review the content and check if everything is correct with your seedlot registration.',
-      link: 'Go to first step and review the form'
-    }
+import { ProgressIndicatorConfig, StepMap } from './definitions';
+
+export const initialProgressConfig: ProgressIndicatorConfig = {
+  collection: {
+    isComplete: false,
+    isCurrent: true,
+    isInvalid: false
+  },
+  ownership: {
+    isComplete: false,
+    isCurrent: false,
+    isInvalid: false
+  },
+  interim: {
+    isComplete: false,
+    isCurrent: false,
+    isInvalid: false
+  },
+  orchard: {
+    isComplete: false,
+    isCurrent: false,
+    isInvalid: false
+  },
+  parent: {
+    isComplete: false,
+    isCurrent: false,
+    isInvalid: false
+  },
+  extraction: {
+    isComplete: false,
+    isCurrent: false,
+    isInvalid: false
   }
 };
 
-export default inputText;
+export const stepMap: StepMap = {
+  0: 'collection',
+  1: 'ownership',
+  2: 'interim',
+  3: 'orchard',
+  4: 'parent',
+  5: 'extraction'
+};

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
@@ -29,7 +29,7 @@ type SingleInvalidObj = {
 
 export type FormInputType = {
   id: string;
-  invalid: SingleInvalidObj;
+  isInvalid: boolean;
 }
 
 export type FormInvalidationObj = {

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
@@ -27,11 +27,6 @@ type SingleInvalidObj = {
   optInvalidText?: string
 }
 
-export type FormInputType = {
-  ref: HTMLInputElement | null;
-  invalid: SingleInvalidObj;
-}
-
 export type FormInvalidationObj = {
   [key: string]: SingleInvalidObj;
 }

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
@@ -28,7 +28,7 @@ type SingleInvalidObj = {
 }
 
 export type FormInputType = {
-  ref: HTMLInputElement | null;
+  id: string;
   invalid: SingleInvalidObj;
 }
 

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
@@ -47,3 +47,22 @@ export type AllStepInvalidationObj = {
   orchardStep: FormInvalidationObj,
   extractionStorageStep: FormInvalidationObj
 }
+
+type ProgressStepStatus = {
+  isComplete: boolean;
+  isCurrent: boolean;
+  isInvalid: boolean;
+}
+
+export type ProgressIndicatorConfig = {
+  collection: ProgressStepStatus;
+  ownership: ProgressStepStatus;
+  interim: ProgressStepStatus;
+  orchard: ProgressStepStatus;
+  parent: ProgressStepStatus;
+  extraction: ProgressStepStatus;
+}
+
+export type StepMap = {
+  [key: number]: keyof ProgressIndicatorConfig;
+}

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/definitions.ts
@@ -27,6 +27,11 @@ type SingleInvalidObj = {
   optInvalidText?: string
 }
 
+export type FormInputType = {
+  ref: HTMLInputElement | null;
+  invalid: SingleInvalidObj;
+}
+
 export type FormInvalidationObj = {
   [key: string]: SingleInvalidObj;
 }

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/index.tsx
@@ -34,7 +34,13 @@ import { CollectionForm } from '../../../components/SeedlotRegistrationSteps/Col
 import { SingleOwnerForm } from '../../../components/SeedlotRegistrationSteps/OwnershipStep/definitions';
 import InterimForm from '../../../components/SeedlotRegistrationSteps/InterimStep/definitions';
 import { OrchardForm } from '../../../components/SeedlotRegistrationSteps/OrchardStep/definitions';
-import { AllStepData, AllStepInvalidationObj, FormInvalidationObj } from './definitions';
+import { getMultiOptList, getCheckboxOptions } from '../../../utils/MultiOptionsUtils';
+import ExtractionStorage from '../../../types/SeedlotTypes/ExtractionStorage';
+import MultiOptionsObj from '../../../types/MultiOptionsObject';
+import {
+  AllStepData, AllStepInvalidationObj,
+  FormInvalidationObj, ProgressIndicatorConfig
+} from './definitions';
 import {
   initCollectionState,
   initInterimState,
@@ -44,11 +50,11 @@ import {
   initInvalidationObj,
   initOwnerShipInvalidState,
   initParentTreeState,
-  generateDefaultRows
+  generateDefaultRows,
+  validateCollectionStep,
+  verifyCollectionStepCompleteness
 } from './utils';
-import { getMultiOptList, getCheckboxOptions } from '../../../utils/MultiOptionsUtils';
-import ExtractionStorage from '../../../types/SeedlotTypes/ExtractionStorage';
-import MultiOptionsObj from '../../../types/MultiOptionsObject';
+import { initialProgressConfig, stepMap } from './constants';
 
 import './styles.scss';
 
@@ -60,6 +66,10 @@ const SeedlotRegistrationForm = () => {
   const seedlotNumber = useParams().seedlot ?? '';
 
   const [formStep, setFormStep] = useState<number>(0);
+  const [
+    progressStatus,
+    setProgressStatus
+  ] = useState<ProgressIndicatorConfig>(initialProgressConfig);
 
   // Initialize all step's state here
   const [allStepData, setAllStepData] = useState<AllStepData>({
@@ -105,7 +115,6 @@ const SeedlotRegistrationForm = () => {
     extractionStorageStep: initInvalidationObj()
   });
 
-  // Can't find a good way to specify the type of stepData
   const setStepData = (stepName: keyof AllStepData, stepData: any) => {
     const newData = { ...allStepData };
     newData[stepName] = stepData;
@@ -137,9 +146,38 @@ const SeedlotRegistrationForm = () => {
     console.log(allStepData);
   };
 
+  /**
+   * Update the progress indicator status
+   */
+  const updateProgressStatus = (currentStepNum: number) => {
+    const clonedStatus = structuredClone(progressStatus);
+    const currentStepName = stepMap[currentStepNum];
+
+    // Set the current step's current val to true, and everything else false
+    clonedStatus[currentStepName].isCurrent = true;
+    const stepNames = Object.keys(clonedStatus) as Array<keyof ProgressIndicatorConfig>;
+    stepNames.filter((stepName: keyof ProgressIndicatorConfig) => stepName !== currentStepName)
+      .forEach((nonCurrentStepName) => {
+        clonedStatus[nonCurrentStepName].isCurrent = false;
+      });
+
+    // Set invalid or complete status for Collection Step
+    if (currentStepName !== 'collection') {
+      const isCollectionInvalid = validateCollectionStep(allStepData.collectionStep);
+      clonedStatus.collection.isInvalid = isCollectionInvalid;
+      if (!isCollectionInvalid) {
+        const isCollectionComplete = verifyCollectionStepCompleteness(allStepData.collectionStep);
+        clonedStatus.collection.isComplete = isCollectionComplete;
+      }
+    }
+
+    setProgressStatus(clonedStatus);
+  };
+
   const setStep = (delta: number) => {
     logState();
     const newStep = formStep + delta;
+    updateProgressStatus(newStep);
     setFormStep(newStep);
   };
 
@@ -171,7 +209,6 @@ const SeedlotRegistrationForm = () => {
             defaultCode={defaultCode}
             agencyOptions={agencyOptions}
             collectionMethods={getCheckboxOptions(coneCollectionMethodsQuery.data)}
-            // invalidateObj={allInvalidationObj.collectionStep}
           />
         );
       // Ownership
@@ -262,9 +299,10 @@ const SeedlotRegistrationForm = () => {
         <Row>
           <Column className="seedlot-registration-progress" sm={4} md={8} lg={16} xlg={16}>
             <SeedlotRegistrationProgress
-              currentIndex={formStep}
+              progressStatus={progressStatus}
               className="seedlot-registration-steps"
               interactFunction={(e: number) => {
+                updateProgressStatus(e);
                 setFormStep(e);
               }}
             />

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/index.tsx
@@ -194,8 +194,8 @@ const SeedlotRegistrationForm = () => {
         return (
           <InterimStorage
             state={allStepData.interimStep}
-            collectorAgency={allStepData.collectionStep.collectorAgency}
-            collectorCode={allStepData.collectionStep.locationCode}
+            collectorAgency={allStepData.collectionStep.collectorAgency.value}
+            collectorCode={allStepData.collectionStep.locationCode.value}
             agencyOptions={agencyOptions}
             setStepData={(data: InterimForm) => setStepData('interimStep', data)}
           />

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/index.tsx
@@ -194,8 +194,8 @@ const SeedlotRegistrationForm = () => {
         return (
           <InterimStorage
             state={allStepData.interimStep}
-            collectorAgency={allStepData.collectionStep.collectorAgency.value}
-            collectorCode={allStepData.collectionStep.locationCode.value}
+            collectorAgency={allStepData.collectionStep.collectorAgency}
+            collectorCode={allStepData.collectionStep.locationCode}
             agencyOptions={agencyOptions}
             setStepData={(data: InterimForm) => setStepData('interimStep', data)}
           />

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { OrchardForm } from '../../../components/SeedlotRegistrationSteps/OrchardStep/definitions';
 import {
   ownerTemplate,
@@ -6,22 +7,94 @@ import {
 import { notificationCtrlObj } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/constants';
 import { RowDataDictType } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/definitions';
 import { getMixRowTemplate } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/utils';
-import { FormInvalidationObj, OwnershipInvalidObj, ParentTreeStepDataObj } from './definitions';
+import {
+  FormInvalidationObj, OwnershipInvalidObj, ParentTreeStepDataObj
+} from './definitions';
 
 export const initCollectionState = (
   defaultAgency: string,
   defaultCode: string
 ) => ({
-  useDefaultAgencyInfo: true,
-  collectorAgency: defaultAgency,
-  locationCode: defaultCode,
-  startDate: '',
-  endDate: '',
-  numberOfContainers: '1',
-  volumePerContainers: '1',
-  volumeOfCones: '1',
-  selectedCollectionCodes: [],
-  comments: ''
+  useDefaultAgencyInfo: {
+    value: true,
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  collectorAgency: {
+    value: defaultAgency,
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  locationCode: {
+    value: defaultCode,
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  startDate: {
+    value: '',
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  endDate: {
+    value: '',
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  numberOfContainers: {
+    value: '1',
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  volumePerContainers: {
+    value: '1',
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  volumeOfCones: {
+    value: '1',
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  selectedCollectionCodes: {
+    value: [],
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  },
+  comments: {
+    value: '',
+    ref: useRef(null),
+    invalid: {
+      isInvalid: false,
+      invalidText: ''
+    }
+  }
 });
 
 export const initOwnershipState = (

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
@@ -1,3 +1,4 @@
+import { CollectionForm } from '../../../components/SeedlotRegistrationSteps/CollectionStep/definitions';
 import { OrchardForm } from '../../../components/SeedlotRegistrationSteps/OrchardStep/definitions';
 import {
   ownerTemplate,
@@ -158,4 +159,51 @@ export const initOwnerShipInvalidState = (): OwnershipInvalidObj => {
   return {
     0: initialOwnerInvalidState
   };
+};
+
+/**
+ * Validate Collection Step.
+ * Return true if it's Invalid, false otherwise.
+ */
+export const validateCollectionStep = (collectionData: CollectionForm): boolean => {
+  let isInvalid = false;
+  const collectionkeys = Object.keys(collectionData) as Array<keyof CollectionForm>;
+  collectionkeys.forEach((key) => {
+    if (collectionData[key].isInvalid) {
+      isInvalid = true;
+    }
+  });
+  return isInvalid;
+};
+
+/**
+ * Verify if the collection step is compelete
+ * Return true if it's compelte, false otherwise
+ */
+export const verifyCollectionStepCompleteness = (collectionData: CollectionForm): boolean => {
+  if (!collectionData.collectorAgency.value.length) {
+    return false;
+  }
+  if (!collectionData.locationCode.value.length) {
+    return false;
+  }
+  if (!collectionData.startDate.value.length) {
+    return false;
+  }
+  if (!collectionData.endDate.value.length) {
+    return false;
+  }
+  if (!collectionData.numberOfContainers.value.length) {
+    return false;
+  }
+  if (!collectionData.volumePerContainers.value.length) {
+    return false;
+  }
+  if (!collectionData.volumeOfCones.value.length) {
+    return false;
+  }
+  if (!collectionData.selectedCollectionCodes.value.length) {
+    return false;
+  }
+  return true;
 };

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { OrchardForm } from '../../../components/SeedlotRegistrationSteps/OrchardStep/definitions';
 import {
   ownerTemplate,
@@ -16,80 +15,80 @@ export const initCollectionState = (
   defaultCode: string
 ) => ({
   useDefaultAgencyInfo: {
+    id: 'collection-use-default-agency',
     value: true,
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   collectorAgency: {
+    id: 'collection-collector-agency',
     value: defaultAgency,
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   locationCode: {
+    id: 'collection-location-code',
     value: defaultCode,
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   startDate: {
+    id: 'collection-start-date',
     value: '',
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   endDate: {
+    id: 'collection-end-date',
     value: '',
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   numberOfContainers: {
+    id: 'collection-num-of-container',
     value: '1',
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   volumePerContainers: {
+    id: 'collection-vol-per-container',
     value: '1',
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   volumeOfCones: {
+    id: 'collection-vol-of-cones',
     value: '1',
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   selectedCollectionCodes: {
+    id: 'collection-selected-collection-code',
     value: [],
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''
     }
   },
   comments: {
+    id: 'collection-comments',
     value: '',
-    ref: useRef(null),
     invalid: {
       isInvalid: false,
       invalidText: ''

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
@@ -17,82 +17,52 @@ export const initCollectionState = (
   useDefaultAgencyInfo: {
     id: 'collection-use-default-agency',
     value: true,
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   collectorAgency: {
     id: 'collection-collector-agency',
     value: defaultAgency,
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   locationCode: {
     id: 'collection-location-code',
     value: defaultCode,
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   startDate: {
     id: 'collection-start-date',
     value: '',
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   endDate: {
     id: 'collection-end-date',
     value: '',
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   numberOfContainers: {
     id: 'collection-num-of-container',
     value: '1',
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   volumePerContainers: {
     id: 'collection-vol-per-container',
     value: '1',
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   volumeOfCones: {
     id: 'collection-vol-of-cones',
     value: '1',
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   selectedCollectionCodes: {
     id: 'collection-selected-collection-code',
     value: [],
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   },
   comments: {
     id: 'collection-comments',
     value: '',
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
+    isInvalid: false
   }
 });
 

--- a/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
+++ b/frontend/src/views/Seedlot/SeedlotRegistrationForm/utils.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { OrchardForm } from '../../../components/SeedlotRegistrationSteps/OrchardStep/definitions';
 import {
   ownerTemplate,
@@ -7,94 +6,22 @@ import {
 import { notificationCtrlObj } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/constants';
 import { RowDataDictType } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/definitions';
 import { getMixRowTemplate } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/utils';
-import {
-  FormInvalidationObj, OwnershipInvalidObj, ParentTreeStepDataObj
-} from './definitions';
+import { FormInvalidationObj, OwnershipInvalidObj, ParentTreeStepDataObj } from './definitions';
 
 export const initCollectionState = (
   defaultAgency: string,
   defaultCode: string
 ) => ({
-  useDefaultAgencyInfo: {
-    value: true,
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  collectorAgency: {
-    value: defaultAgency,
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  locationCode: {
-    value: defaultCode,
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  startDate: {
-    value: '',
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  endDate: {
-    value: '',
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  numberOfContainers: {
-    value: '1',
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  volumePerContainers: {
-    value: '1',
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  volumeOfCones: {
-    value: '1',
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  selectedCollectionCodes: {
-    value: [],
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  },
-  comments: {
-    value: '',
-    ref: useRef(null),
-    invalid: {
-      isInvalid: false,
-      invalidText: ''
-    }
-  }
+  useDefaultAgencyInfo: true,
+  collectorAgency: defaultAgency,
+  locationCode: defaultCode,
+  startDate: '',
+  endDate: '',
+  numberOfContainers: '1',
+  volumePerContainers: '1',
+  volumeOfCones: '1',
+  selectedCollectionCodes: [],
+  comments: ''
 });
 
 export const initOwnershipState = (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Implements #448 

This PR accomplishes the following:
1. Refactor data structures used in Collection Step
2. Refactor input data handling in Collection Step
3. Provides validation for each input
4. Verify the validity and completeness to be displayed on the progress indicator

### The Problem
Currently, the collection step (and other steps) uses up to 3 objects to manage input data:
1.  `allStepData.collection` aka `state` - this stores all the input values
5. `validationObj` - this stores input validation objects
6. `refControl` - this stores the `ref` for each input

This creates a lot of dependencies for each input, thus making it hard to manage and devs need to constantly make sure that each one of those objects are updated after one input is changed.

### The Solution
Combine the validation obj and input value together in the following way:
```
 [input name]: { 
    id: string        // used for element id, more on this later
    value: string  // used to store input value
    isInvalid: boolean // store the validity of the input
}
```
This makes it possible for the parent component `SeedlotRegistrationForm` to access all 3 values within one object, and that can be used to validate the validity and completeness of a step. 

Note that `useRef()` is no longer used in this step. Initially, I wanted to store each `ref` within an input's object, but a ref cannot be copied, that makes updating a state way too complicated. 
After many trials, research and debate with myself, I decided to go with the old fashioned way to focus on an element when needed, by using `getElementById().focus()`. It is not an ideal solution, but it's the cleanest. 

### The Other Problem
In Collection Step, every input change is handled through ONE function `handleForm()`. TBH I was in favour of this way of handling data. However, this makes the code extremely hard to read and maintain. Many `if` statements have to condensed into one function. 

### The Other Problem's Solution
Each input now has its own handler, although there is more duplication, but I believe the code is much easier to understand now.

### Progress Indicator (Collection Step) Showcase
1. Incomplete
    - ![image](https://github.com/bcgov/nr-spar/assets/25162561/ee40ea6f-6678-49ab-98be-649f07dfa756)
2. Invalid
    - ![image](https://github.com/bcgov/nr-spar/assets/25162561/02f7ca6f-843e-4c5d-8fb2-6211e0657ab8)
3. Complete
    - ![image](https://github.com/bcgov/nr-spar/assets/25162561/79676b57-e144-4a31-ba08-1f88e0f367fb)

## Story Point
Self estimation: 5
I projected this to be a 3 in the beginning. However, since this is the first validation ticket, some refactors had to be done to do things the smart ways. I would say validation alone is a 3 pointer. Getting the progress indicator's status to update after changing step is a 2 pointer, thus a 5 point issue. 



## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
manual test

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-567-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-567-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-567-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)