### PR TITLE
fix: get oracle test url back on docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ x-frontend: &frontend
       condition: service_started
   environment:
     VITE_SERVER_URL: http://localhost:8090
-    VITE_ORACLE_SERVER_URL: http://localhost:8091
+    VITE_ORACLE_SERVER_URL: https://nr-spar-test-oracle-api.apps.silver.devops.gov.bc.ca
     LOG_LEVEL: debug
     VITE_USER_POOLS_ID: ca-central-1_t2HSZBHur
     VITE_USER_POOLS_WEB_CLIENT_ID: 6jmscjfesregki1pvng2oiopc3
@@ -46,7 +46,7 @@ services:
       ALLOWED_ORIGINS: "http://localhost:*"
       FORESTCLIENTAPI_ADDRESS: https://nr-forest-client-api-prod.api.gov.bc.ca/api
       FORESTCLIENTAPI_KEY: "${FORESTCLIENTAPI_KEY}"
-      ORACLE_SERVER_URL: http://localhost:8091
+      ORACLE_SERVER_URL: https://nr-spar-test-oracle-api.apps.silver.devops.gov.bc.ca
       POSTGRES_HOST: database
       AWS_COGNITO_ISSUER_URI: "${AWS_COGNITO_ISSUER_URI}"
       <<: *db-vars


### PR DESCRIPTION
# Description
Closes no issue;

Simply get `oracle-api` service url `test` back. This change was first addresed when testing FAM so we needed everything running locally, but now we can get it back

### Changelog
#### New
- None

#### Changed
- Docker compose file environment values pointing back to `test` Oracle REST service instead of local.

#### Removed
- None

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
I'll get a gif as soon as I make this extension work =D

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-683-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-683-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-683-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)