### PR TITLE
fix: add cognito idp to connect-src policy

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -23,7 +23,7 @@
 		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
 		X-Content-Type-Options "nosniff"
 		Strict-Transport-Security "max-age=31536000"
-		Content-Security-Policy "base-uri 'self'; connect-src 'self' https://*.gov.bc.ca {$VITE_AWS_DOMAIN} {$VITE_SERVER_URL}; default-src 'self'; font-src 'self' https://1.www.s81c.com/; frame-src 'self' https://*.gov.bc.ca; img-src 'self'; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'unsafe-inline' 'report-sample' 'self'; style-src 'report-sample' 'self'; worker-src 'none';"
+		Content-Security-Policy "base-uri 'self'; connect-src 'self' https://*.gov.bc.ca {$VITE_AWS_DOMAIN} {$VITE_SERVER_URL} https://cognito-idp.ca-central-1.amazonaws.com/; default-src 'self'; font-src 'self' https://1.www.s81c.com/; frame-src 'self' https://*.gov.bc.ca; img-src 'self'; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'unsafe-inline' 'report-sample' 'self'; style-src 'report-sample' 'self'; worker-src 'none';"
 		Referrer-Policy "same-origin"
 	}
 


### PR DESCRIPTION
# Description
Closes #673 

### Changelog
#### New
- Added AWS Cognito Identity Provider address to allowed connect-src on Caddy.

#### Changed
- Caddy file

#### Removed
- None

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

Tested locally with docker compose test version.

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
No gif again, sorry. I guess Encora could be blocking it here, I see no gifs at all, only  that github icon loading :(

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-684-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-684-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-684-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)