### PR TITLE
fix: z-index on favourite activities removed

### DIFF
--- a/frontend/src/components/FavouriteActivities/styles.scss
+++ b/frontend/src/components/FavouriteActivities/styles.scss
@@ -14,7 +14,6 @@
 
 .#{vars.$bcgov-prefix}--row>.favourite-activities-title {
   padding-left: 0.5rem;
-  z-index: 8001; // 1 z-index higher than the side-nav
 }
 
 .favourite-activities-subtitle {


### PR DESCRIPTION
# Description
Closes #[542](https://github.com/orgs/bcgov/projects/35/views/16?pane=issue&itemId=40759287)

### Changelog

#### Removed
- z-index on favourite activities removed

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

