### PR TITLE
Feat/454 step 5 1 to 3 validation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "@vitejs/plugin-react": "^4.0.4",
         "aws-amplify": "^5.3.11",
         "axios": "^1.6.0",
+        "bignumber.js": "^4.0.4",
         "eslint-config-airbnb-typescript": "^17.0.0",
         "jest": "29.7.0",
         "luxon": "^3.4.3",
@@ -13396,6 +13397,14 @@
       "dev": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
+      "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@vitejs/plugin-react": "^4.0.4",
     "aws-amplify": "^5.3.11",
     "axios": "^1.6.0",
+    "bignumber.js": "^4.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "jest": "29.7.0",
     "luxon": "^3.4.3",
@@ -90,7 +91,7 @@
     "js",
     "react"
   ],
-  "author": "Encora Team",
+  "author": "The Government of British Columbia",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bcgov/nr-spar/issues"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,7 +132,7 @@ const App: React.FC = () => {
                     </ProtectedRoute>
                   )}
                 />
-
+                <Route path="/downloads/*" />
                 <Route path="*" element={<Navigate to="/dashboard" replace />} />
               </Route>
               <Route path="/404" element={<FourOhFour />} />

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
@@ -131,6 +131,7 @@ const InputErrorNotification = (
             hideCloseButton
             title={title}
             subtitle={subtitle}
+            hasFocus={false}
           />
         </Column>
       </Row>

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Column, Row, ActionableNotification } from '@carbon/react';
 
 import { InputErrorNotifProps, RowItem, StrTypeRowItem } from './definitions';
-import { errNotifEndMsg, invalidPTNumberMsg } from './constants';
+import { pageText } from './constants';
 
 const InputErrorNotification = (
   { state, headerConfig }: InputErrorNotifProps
@@ -55,7 +55,7 @@ const InputErrorNotification = (
 
       if (invalidFields.length === 1) {
         if (invalidFields[0] === 'parentTreeNumber') {
-          generatedSubTitle = invalidPTNumberMsg;
+          generatedSubTitle = pageText.invalidPTNumberMsg;
         } else {
           generatedSubTitle = `${prefix}${getHeaderName(invalidFields[0])}${suffix}`;
         }
@@ -68,7 +68,7 @@ const InputErrorNotification = (
                 <li key={field}>
                   {
                     field === 'parentTreeNumber'
-                      ? invalidPTNumberMsg
+                      ? pageText.invalidPTNumberMsg
                       : `${prefix}${getHeaderName(field)}${suffix}`
                   }
                 </li>
@@ -82,7 +82,8 @@ const InputErrorNotification = (
         <span>
           {generatedSubTitle}
           <br />
-          {errNotifEndMsg}
+          <br />
+          {pageText.errNotifEndMsg}
         </span>
       );
     };

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
@@ -1,7 +1,3 @@
-// We can have hundreds of rows to check potentially on every render,
-// it's nice to have performance in mind here, hence the disabling.
-/* eslint-disable no-labels */
-/* eslint-disable no-restricted-syntax */
 import React, { useState, useEffect } from 'react';
 import { Column, Row, ActionableNotification } from '@carbon/react';
 

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/InputErrorNotification.tsx
@@ -1,0 +1,146 @@
+// We can have hundreds of rows to check potentially on every render,
+// it's nice to have performance in mind here, hence the disabling.
+/* eslint-disable no-labels */
+/* eslint-disable no-restricted-syntax */
+import React, { useState, useEffect } from 'react';
+import { Column, Row, ActionableNotification } from '@carbon/react';
+
+import { InputErrorNotifProps, RowItem, StrTypeRowItem } from './definitions';
+import { errNotifEndMsg, invalidPTNumberMsg } from './constants';
+
+const InputErrorNotification = (
+  { state, headerConfig }: InputErrorNotifProps
+) => {
+  const [hasError, setHasError] = useState(false);
+  const [title, setTitle] = useState('');
+  const [subtitle, setSubtitle] = useState<string | JSX.Element | null>(null);
+
+  useEffect(() => {
+    const getHeaderName = (field: keyof StrTypeRowItem): string => {
+      let name = headerConfig.filter((header) => header.id === field)[0].name.toLowerCase();
+      if (name.startsWith('smp')) {
+        name = name.substring(0, 3).toUpperCase() + name.substring(3);
+      }
+      return name;
+    };
+
+    const generateTitle = (
+      invalidFields: (keyof StrTypeRowItem)[]
+    ): string => {
+      const prefix = 'Invalid ';
+      const suffix = ' entries';
+      let generatedTitle = '';
+      if (invalidFields.length === 1) {
+        generatedTitle = `${prefix}${getHeaderName(invalidFields[0])}${suffix}`;
+      } else {
+        generatedTitle += prefix;
+        const numOfFields = invalidFields.length;
+        // eslint-disable-next-line no-plusplus
+        for (let i = 0; i < numOfFields; i++) {
+          if (i === numOfFields - 1) {
+            // Get rid of the comma.
+            generatedTitle = generatedTitle.slice(0, -2);
+            generatedTitle += ` and ${getHeaderName(invalidFields[i])}`;
+          } else {
+            generatedTitle += `${getHeaderName(invalidFields[i])}, `;
+          }
+        }
+        generatedTitle += suffix;
+      }
+      return generatedTitle;
+    };
+
+    const generateSubTitle = (
+      invalidFields: (keyof StrTypeRowItem)[]
+    ): string | JSX.Element => {
+      let generatedSubTitle: string | JSX.Element = '';
+      const prefix = 'One or more of the ';
+      const suffix = ' values are invalid.';
+
+      if (invalidFields.length === 1) {
+        if (invalidFields[0] === 'parentTreeNumber') {
+          generatedSubTitle = invalidPTNumberMsg;
+        } else {
+          generatedSubTitle = `${prefix}${getHeaderName(invalidFields[0])}${suffix}`;
+        }
+      } else {
+        // Generate bullet points;
+        generatedSubTitle = (
+          <ul>
+            {
+              invalidFields.map((field) => (
+                <li key={field}>
+                  {
+                    field === 'parentTreeNumber'
+                      ? invalidPTNumberMsg
+                      : `${prefix}${getHeaderName(field)}${suffix}`
+                  }
+                </li>
+              ))
+            }
+          </ul>
+        );
+      }
+
+      return (
+        <span>
+          {generatedSubTitle}
+          <br />
+          {errNotifEndMsg}
+        </span>
+      );
+    };
+
+    let hasErrorInTabs = false;
+
+    const invalidDataFields: (keyof StrTypeRowItem)[] = [];
+
+    // Check errors in both tabs.
+    const compTabsData = Object.values(state.tableRowData);
+    const mixTabsData = Object.values(state.mixTabData);
+
+    const allData = compTabsData.concat(mixTabsData);
+
+    if (allData.length > 0) {
+      const rowKeys = Object.keys(allData[0]) as (keyof RowItem)[];
+
+      allData.forEach((row) => {
+        rowKeys.forEach((key) => {
+          if (key !== 'rowId' && key !== 'isMixTab') {
+            if (row[key].isInvalid && !invalidDataFields.includes(key)) {
+              invalidDataFields.push(key);
+              hasErrorInTabs = true;
+            }
+          }
+        });
+      });
+    }
+
+    setHasError(hasErrorInTabs);
+    if (hasErrorInTabs) {
+      setTitle(generateTitle(invalidDataFields));
+      setSubtitle(generateSubTitle(invalidDataFields));
+    }
+  }, [state]);
+
+  if (hasError) {
+    return (
+      <Row className="notification-row">
+        <Column>
+          <ActionableNotification
+            kind="error"
+            lowContrast
+            actionButtonLabel=""
+            hideCloseButton
+            title={title}
+            subtitle={subtitle}
+          />
+        </Column>
+      </Row>
+    );
+  }
+
+  return null;
+};
+
+export default InputErrorNotification;

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/index.tsx
@@ -22,7 +22,7 @@ import '../styles.scss';
 
 export const renderColOptions = (
   headerConfig: Array<HeaderObj>,
-  currentTab: keyof TabTypes,
+  currentTab: TabTypes,
   setHeaderConfig: Function
 ) => {
   const toggleableCols = headerConfig
@@ -211,7 +211,7 @@ const renderTableCell = (
 };
 
 export const renderTableBody = (
-  currentTab: keyof TabTypes,
+  currentTab: TabTypes,
   slicedRows: Array<RowItem>,
   mixTabRows: Array<RowItem>,
   headerConfig: Array<HeaderObj>,
@@ -277,7 +277,7 @@ export const renderTableBody = (
 
 export const renderNotification = (
   state: ParentTreeStepDataObj,
-  currentTab: keyof TabTypes,
+  currentTab: TabTypes,
   orchardsData: Array<OrchardObj>,
   setStepData: Function
 ) => {
@@ -325,7 +325,7 @@ export const renderNotification = (
 
 export const renderPagination = (
   state: ParentTreeStepDataObj,
-  currentTab: keyof TabTypes,
+  currentTab: TabTypes,
   currPageSize: number,
   setCurrentPage: Function,
   setCurrPageSize: Function,

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
@@ -4,6 +4,11 @@ import {
   AllParentTreeMap, RowDataDictType, RowItem, StrTypeRowItem
 } from '../definitions';
 import { getMixRowTemplate, calcSum, populateStrInputId } from '../utils';
+import {
+  CONE_COUNT_MAX, CONE_COUNT_MIN, NON_ORCHARD_CONTAM_MAX,
+  NON_ORCHARD_CONTAM_MIN, POLLEN_COUNT_MAX, POLLEN_COUNT_MIN,
+  SMP_SUCCESS_PERC_MAX, SMP_SUCCESS_PERC_MIN, VOLUME_MAX, VOLUME_MIN
+} from '../constants';
 
 export const isPtNumberInvalid = (ptNumber: string, allParentTreeData: AllParentTreeMap) => (
   !Object.keys(allParentTreeData).includes(ptNumber)
@@ -91,30 +96,50 @@ const calculateSmpRow = (
   return clonedData;
 };
 
-const isConeCountInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: 0, max: 10000 })
+export const isConeCountInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: CONE_COUNT_MIN, max: CONE_COUNT_MAX })
 );
 
-const isPollenCountInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: 0, max: 10000 })
+export const getConeCountErrMsg = (value: string): string => (
+  `"${value}" is an invalid entry. Please provide a valid cone count value between ${CONE_COUNT_MIN} and ${CONE_COUNT_MAX}.`
+);
+
+export const isPollenCountInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: POLLEN_COUNT_MIN, max: POLLEN_COUNT_MAX })
+);
+
+export const getPollenCountErrMsg = (value: string): string => (
+  `"${value}" is an invalid entry. Please provide a valid pollen count value between ${POLLEN_COUNT_MIN} and ${POLLEN_COUNT_MAX}.`
 );
 
 /**
  * SMP success on parent (%)
  */
-const isSmpSuccInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: 0, max: 100 })
+export const isSmpSuccInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: SMP_SUCCESS_PERC_MIN, max: SMP_SUCCESS_PERC_MAX })
+);
+
+export const getSmpSuccErrMsg = (value: string): string => (
+  `"${value}" is an invalid entry. Please provide a valid SMP success on parent (%) value between ${SMP_SUCCESS_PERC_MIN} and ${SMP_SUCCESS_PERC_MAX}.`
 );
 
 /**
  * Non-orchard pollen contam. (%)
  */
-const isNonOrchardContamInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: 0, max: 100 })
+export const isNonOrchardContamInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: NON_ORCHARD_CONTAM_MIN, max: NON_ORCHARD_CONTAM_MAX })
 );
 
-const isVolumeInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: 0, max: 10000 })
+export const getNonOrchardContamErrMsg = (value: string): string => (
+  `"${value}" is an invalid entry. Please provide a valid Non-orchard pollen contam. (%) value between ${NON_ORCHARD_CONTAM_MIN} and ${NON_ORCHARD_CONTAM_MAX}.`
+);
+
+export const isVolumeInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: VOLUME_MIN, max: VOLUME_MAX })
+);
+
+export const getVolumeErrMsg = (value: string): string => (
+  `"${value}" is an invalid entry. Please provide a valid volume value between ${VOLUME_MIN} and ${VOLUME_MAX}.`
 );
 
 // Validate and populate inputs
@@ -155,28 +180,28 @@ export const handleInput = (
   if (colName === 'coneCount') {
     isInvalid = isConeCountInvalid(inputValue);
     if (isInvalid) {
-      errMsg = 'Bad cone';
+      errMsg = getConeCountErrMsg(inputValue);
     }
   }
 
   if (colName === 'pollenCount') {
     isInvalid = isPollenCountInvalid(inputValue);
     if (isInvalid) {
-      errMsg = 'Bad pollen';
+      errMsg = getPollenCountErrMsg(inputValue);
     }
   }
 
   if (colName === 'smpSuccessPerc') {
     isInvalid = isSmpSuccInvalid(inputValue);
     if (isInvalid) {
-      errMsg = 'Bad smp';
+      errMsg = getSmpSuccErrMsg(inputValue);
     }
   }
 
   if (colName === 'nonOrchardPollenContam') {
     isInvalid = isNonOrchardContamInvalid(inputValue);
     if (isInvalid) {
-      errMsg = 'Bad contam';
+      errMsg = getNonOrchardContamErrMsg(inputValue);
     }
   }
 
@@ -184,7 +209,7 @@ export const handleInput = (
     mixTabData = calculateSmpRow(inputValue, rowData, state.mixTabData, applicableGenWorths);
     isInvalid = isVolumeInvalid(inputValue);
     if (isInvalid) {
-      errMsg = 'Bad volume';
+      errMsg = getVolumeErrMsg(inputValue);
     }
   }
 

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
@@ -98,12 +98,12 @@ const calculateSmpRow = (
   return clonedData;
 };
 
-const getPTNumberErrMsg = (value: string): string => (
+export const getPTNumberErrMsg = (value: string): string => (
   `"${value}" is an invalid parent tree number. Please provide a valid parent tree number and review the number you have entered.`
 );
 
 export const isConeCountInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: CONE_COUNT_MIN, max: CONE_COUNT_MAX })
+  value === '' ? false : !validator.isInt(value, { min: CONE_COUNT_MIN, max: CONE_COUNT_MAX })
 );
 
 export const getConeCountErrMsg = (value: string): string => (
@@ -111,7 +111,7 @@ export const getConeCountErrMsg = (value: string): string => (
 );
 
 export const isPollenCountInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: POLLEN_COUNT_MIN, max: POLLEN_COUNT_MAX })
+  value === '' ? false : !validator.isInt(value, { min: POLLEN_COUNT_MIN, max: POLLEN_COUNT_MAX })
 );
 
 export const getPollenCountErrMsg = (value: string): string => (
@@ -122,7 +122,7 @@ export const getPollenCountErrMsg = (value: string): string => (
  * SMP success on parent (%)
  */
 export const isSmpSuccInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: SMP_SUCCESS_PERC_MIN, max: SMP_SUCCESS_PERC_MAX })
+  value === '' ? false : !validator.isInt(value, { min: SMP_SUCCESS_PERC_MIN, max: SMP_SUCCESS_PERC_MAX })
 );
 
 export const getSmpSuccErrMsg = (value: string): string => (
@@ -133,7 +133,7 @@ export const getSmpSuccErrMsg = (value: string): string => (
  * Non-orchard pollen contam. (%)
  */
 export const isNonOrchardContamInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: NON_ORCHARD_CONTAM_MIN, max: NON_ORCHARD_CONTAM_MAX })
+  value === '' ? false : !validator.isInt(value, { min: NON_ORCHARD_CONTAM_MIN, max: NON_ORCHARD_CONTAM_MAX })
 );
 
 export const getNonOrchardContamErrMsg = (value: string): string => (
@@ -141,7 +141,7 @@ export const getNonOrchardContamErrMsg = (value: string): string => (
 );
 
 export const isVolumeInvalid = (value: string): boolean => (
-  !validator.isInt(value, { min: VOLUME_MIN, max: VOLUME_MAX })
+  value === '' ? false : !validator.isInt(value, { min: VOLUME_MIN, max: VOLUME_MAX })
 );
 
 export const getVolumeErrMsg = (value: string): string => (

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
@@ -1,5 +1,7 @@
 import validator from 'validator';
+
 import { ParentTreeStepDataObj } from '../../../../views/Seedlot/SeedlotRegistrationForm/definitions';
+
 import {
   AllParentTreeMap, RowDataDictType, RowItem, StrTypeRowItem
 } from '../definitions';
@@ -96,6 +98,10 @@ const calculateSmpRow = (
   return clonedData;
 };
 
+const getPTNumberErrMsg = (value: string): string => (
+  `"${value}" is an invalid parent tree number. Please provide a valid parent tree number and review the number you have entered.`
+);
+
 export const isConeCountInvalid = (value: string): boolean => (
   !validator.isInt(value, { min: CONE_COUNT_MIN, max: CONE_COUNT_MAX })
 );
@@ -171,6 +177,7 @@ export const handleInput = (
         );
         const rowVolume = Number(rowData.volume).toString();
         mixTabData = calculateSmpRow(rowVolume, rowData, mixTabData, applicableGenWorths);
+        errMsg = getPTNumberErrMsg(inputValue);
       }
     } else {
       mixTabData[rowData.rowId] = cleanRowData(rowData.rowId);

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
@@ -1,3 +1,4 @@
+import validator from 'validator';
 import { ParentTreeStepDataObj } from '../../../../views/Seedlot/SeedlotRegistrationForm/definitions';
 import {
   AllParentTreeMap, RowDataDictType, RowItem, StrTypeRowItem
@@ -90,6 +91,32 @@ const calculateSmpRow = (
   return clonedData;
 };
 
+const isConeCountInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: 0, max: 10000 })
+);
+
+const isPollenCountInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: 0, max: 10000 })
+);
+
+/**
+ * SMP success on parent (%)
+ */
+const isSmpSuccInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: 0, max: 100 })
+);
+
+/**
+ * Non-orchard pollen contam. (%)
+ */
+const isNonOrchardContamInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: 0, max: 100 })
+);
+
+const isVolumeInvalid = (value: string): boolean => (
+  !validator.isInt(value, { min: 0, max: 10000 })
+);
+
 // Validate and populate inputs
 export const handleInput = (
   rowData: RowItem,
@@ -104,6 +131,7 @@ export const handleInput = (
   const tableRowData = { ...clonedState.tableRowData };
   let isInvalid = false;
   let isDuplicate = false;
+  let errMsg = '';
   if (colName === 'parentTreeNumber') {
     if (inputValue.length !== 0) {
       isInvalid = isPtNumberInvalid(inputValue, state.allParentTreeData);
@@ -123,14 +151,50 @@ export const handleInput = (
       mixTabData[rowData.rowId] = cleanRowData(rowData.rowId);
     }
   }
-  if (colName === 'volume') {
-    mixTabData = calculateSmpRow(inputValue, rowData, state.mixTabData, applicableGenWorths);
+
+  if (colName === 'coneCount') {
+    isInvalid = isConeCountInvalid(inputValue);
+    if (isInvalid) {
+      errMsg = 'Bad cone';
+    }
   }
 
+  if (colName === 'pollenCount') {
+    isInvalid = isPollenCountInvalid(inputValue);
+    if (isInvalid) {
+      errMsg = 'Bad pollen';
+    }
+  }
+
+  if (colName === 'smpSuccessPerc') {
+    isInvalid = isSmpSuccInvalid(inputValue);
+    if (isInvalid) {
+      errMsg = 'Bad smp';
+    }
+  }
+
+  if (colName === 'nonOrchardPollenContam') {
+    isInvalid = isNonOrchardContamInvalid(inputValue);
+    if (isInvalid) {
+      errMsg = 'Bad contam';
+    }
+  }
+
+  if (colName === 'volume') {
+    mixTabData = calculateSmpRow(inputValue, rowData, state.mixTabData, applicableGenWorths);
+    isInvalid = isVolumeInvalid(inputValue);
+    if (isInvalid) {
+      errMsg = 'Bad volume';
+    }
+  }
+
+  // Set isInvalid and errMsg
   if (rowData.isMixTab) {
     mixTabData[rowData.rowId][colName].isInvalid = isInvalid || isDuplicate;
+    mixTabData[rowData.rowId][colName].errMsg = errMsg;
   } else {
     tableRowData[rowData.parentTreeNumber.value][colName].isInvalid = isInvalid;
+    tableRowData[rowData.parentTreeNumber.value][colName].errMsg = errMsg;
   }
   clonedState.mixTabData = mixTabData;
   clonedState.tableRowData = tableRowData;

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/UploadWarnNotification.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/UploadWarnNotification.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable no-plusplus */
+import React, { useEffect, useState } from 'react';
+import { Column, Row, ActionableNotification } from '@carbon/react';
+
+import { UploadWarnNotifProps } from './definitions';
+import { MAX_VISIBLE_PT_NUMBERS, pageText } from './constants';
+
+const UploadWarnNotification = (
+  { invalidPTNumbers, setInvalidPTNumbers }: UploadWarnNotifProps
+) => {
+  const [subtitle, setSubtitle] = useState<JSX.Element | null>(null);
+  const [hasEllipsis, setHasEllipsis] = useState(false);
+
+  useEffect(() => {
+    if (invalidPTNumbers.length > 0) {
+      let subtitlePartTwo: JSX.Element | string = 'Invalid Parent tree numbers: ';
+      if (invalidPTNumbers.length === 1) {
+        subtitlePartTwo += `${invalidPTNumbers[0]}.`;
+      } else if (invalidPTNumbers.length <= MAX_VISIBLE_PT_NUMBERS) {
+        for (let i = 0; i < invalidPTNumbers.length; i++) {
+          if (i === invalidPTNumbers.length - 1) {
+            // Get rid of the comma.
+            subtitlePartTwo = subtitlePartTwo.slice(0, -2);
+            subtitlePartTwo += ` and ${invalidPTNumbers[i]}`;
+          } else {
+            subtitlePartTwo += `${invalidPTNumbers[i]}, `;
+          }
+        }
+        subtitlePartTwo += '.';
+      } else {
+        setHasEllipsis(true);
+        const remainder = invalidPTNumbers.length - MAX_VISIBLE_PT_NUMBERS;
+        for (let i = 0; i < MAX_VISIBLE_PT_NUMBERS; i++) {
+          subtitlePartTwo += `${invalidPTNumbers[i]}, `;
+        }
+
+        const subtitlePartTwoText = `${subtitlePartTwo.slice(0, -2)} and ${remainder} more.`;
+
+        subtitlePartTwo = (
+          <span>
+            {subtitlePartTwoText}
+            <button type="button" onClick={() => setHasEllipsis((prev) => (!prev))}>
+              {
+                hasEllipsis
+                  ? 'See all invalid parent tree numbers'
+                  : 'See less invalid parent tree numbers'
+              }
+            </button>
+          </span>
+        );
+      }
+
+      setSubtitle(
+        <span>
+          {pageText.warnNotification.subtitlePartOne}
+          <br />
+          <br />
+          {subtitlePartTwo}
+        </span>
+      );
+    }
+  }, [invalidPTNumbers]);
+
+  if (invalidPTNumbers.length > 0) {
+    return (
+      <Row className="notification-row">
+        <Column>
+          <ActionableNotification
+            kind="warning"
+            lowContrast
+            actionButtonLabel=""
+            title={pageText.warnNotification.title}
+            subtitle={subtitle}
+            onClose={() => setInvalidPTNumbers([])}
+          />
+        </Column>
+      </Row>
+    );
+  }
+
+  return null;
+};
+
+export default UploadWarnNotification;

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/UploadWarnNotification.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/UploadWarnNotification.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-plusplus */
 import React, { useEffect, useState } from 'react';
-import { Column, Row, ActionableNotification } from '@carbon/react';
+import {
+  Button, Column, Row, ActionableNotification
+} from '@carbon/react';
 
 import { UploadWarnNotifProps } from './definitions';
 import { MAX_VISIBLE_PT_NUMBERS, pageText } from './constants';
@@ -8,15 +10,15 @@ import { MAX_VISIBLE_PT_NUMBERS, pageText } from './constants';
 const UploadWarnNotification = (
   { invalidPTNumbers, setInvalidPTNumbers }: UploadWarnNotifProps
 ) => {
-  const [subtitle, setSubtitle] = useState<JSX.Element | null>(null);
-  const [hasEllipsis, setHasEllipsis] = useState(false);
+  const [subtitle, setSubtitle] = useState<JSX.Element | string>('');
+  const [showLess, setShowLess] = useState(true);
 
-  useEffect(() => {
+  const configSubtitle = () => {
     if (invalidPTNumbers.length > 0) {
       let subtitlePartTwo: JSX.Element | string = 'Invalid Parent tree numbers: ';
       if (invalidPTNumbers.length === 1) {
         subtitlePartTwo += `${invalidPTNumbers[0]}.`;
-      } else if (invalidPTNumbers.length <= MAX_VISIBLE_PT_NUMBERS) {
+      } else if (invalidPTNumbers.length <= MAX_VISIBLE_PT_NUMBERS || !showLess) {
         for (let i = 0; i < invalidPTNumbers.length; i++) {
           if (i === invalidPTNumbers.length - 1) {
             // Get rid of the comma.
@@ -28,37 +30,24 @@ const UploadWarnNotification = (
         }
         subtitlePartTwo += '.';
       } else {
-        setHasEllipsis(true);
         const remainder = invalidPTNumbers.length - MAX_VISIBLE_PT_NUMBERS;
         for (let i = 0; i < MAX_VISIBLE_PT_NUMBERS; i++) {
           subtitlePartTwo += `${invalidPTNumbers[i]}, `;
         }
-
-        const subtitlePartTwoText = `${subtitlePartTwo.slice(0, -2)} and ${remainder} more.`;
-
-        subtitlePartTwo = (
-          <span>
-            {subtitlePartTwoText}
-            <button type="button" onClick={() => setHasEllipsis((prev) => (!prev))}>
-              {
-                hasEllipsis
-                  ? 'See all invalid parent tree numbers'
-                  : 'See less invalid parent tree numbers'
-              }
-            </button>
-          </span>
-        );
+        subtitlePartTwo = `${subtitlePartTwo.slice(0, -2)} and ${remainder} more. `;
       }
-
-      setSubtitle(
-        <span>
-          {pageText.warnNotification.subtitlePartOne}
-          <br />
-          <br />
-          {subtitlePartTwo}
-        </span>
-      );
+      setSubtitle(subtitlePartTwo);
     }
+  };
+
+  const toggleEllipisis = () => setShowLess((prev) => !prev);
+
+  useEffect(() => {
+    configSubtitle();
+  }, [invalidPTNumbers, showLess]);
+
+  useEffect(() => {
+    setShowLess(true);
   }, [invalidPTNumbers]);
 
   if (invalidPTNumbers.length > 0) {
@@ -70,8 +59,38 @@ const UploadWarnNotification = (
             lowContrast
             actionButtonLabel=""
             title={pageText.warnNotification.title}
-            subtitle={subtitle}
+            subtitle={(
+              <span>
+                {pageText.warnNotification.subtitlePartOne}
+                <br />
+                <br />
+                {subtitle}
+                {
+                  invalidPTNumbers.length > MAX_VISIBLE_PT_NUMBERS
+                    ? (
+                      <Button
+                        className="ghost-button-underlined"
+                        kind="ghost"
+                        onClick={(e: React.ChangeEvent<HTMLButtonElement>) => {
+                          toggleEllipisis();
+                          // Without this blur,
+                          // the page will keep focusing on the close button for some reason.
+                          e.target.blur();
+                        }}
+                      >
+                        {
+                          showLess
+                            ? 'See all invalid parent tree numbers'
+                            : 'See less invalid parent tree numbers'
+                        }
+                      </Button>
+                    )
+                    : null
+                }
+              </span>
+            )}
             onClose={() => setInvalidPTNumbers([])}
+            hasFocus={false}
           />
         </Column>
       </Row>

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -18,23 +18,27 @@ export const EMPTY_NUMBER_STRING = '';
 
 export const VOLUME_MIN = 0;
 
-export const VOLUME_MAX = 10000;
+export const VOLUME_MAX = 999999;
 
 export const NON_ORCHARD_CONTAM_MIN = 0;
 
 export const NON_ORCHARD_CONTAM_MAX = 100;
 
-export const SMP_SUCCESS_PERC_MIN = 0;
+export const SMP_SUCCESS_PERC_MIN = 1;
 
-export const SMP_SUCCESS_PERC_MAX = 100;
+export const SMP_SUCCESS_PERC_MAX = 25;
 
-export const POLLEN_COUNT_MIN = 0;
+export const SMP_SUCCESS_PERC_MAX_PW = 100;
 
-export const POLLEN_COUNT_MAX = 1000;
+export const POLLEN_COUNT_MIN = '0';
 
-export const CONE_COUNT_MIN = 0;
+export const POLLEN_COUNT_MAX = '9999999999.9999999999';
 
-export const CONE_COUNT_MAX = 1000;
+export const CONE_COUNT_MIN = '0';
+
+export const CONE_COUNT_MAX = '9999999999.9999999999';
+
+export const MAX_DECIMAL_DIGITS = 10;
 
 export const MAX_VISIBLE_PT_NUMBERS = 10;
 

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -36,6 +36,8 @@ export const CONE_COUNT_MIN = 0;
 
 export const CONE_COUNT_MAX = 1000;
 
+export const MAX_VISIBLE_PT_NUMBERS = 10;
+
 export const getDownloadUrl = (tabType: string) => {
   if (tabType === 'Calculation of SMP mix' || tabType === 'mixTab') {
     return '/downloads/SMP_Mix_Volume_template.csv';
@@ -141,6 +143,14 @@ const getPageText = () => ({
   },
   emptySection: {
     title: 'Nothing to show yet!'
+  },
+  invalidPTNumberMsg: 'One or more of the parent tree numbers entered are invalid because these numbers might not exist within your orchard composition.',
+  errNotifEndMsg: 'Please review your entries and remember to check all pages.',
+  warnNotification: {
+    title: 'Invalid parent tree number detected',
+    subtitlePartOne: 'The uploaded file contains one or more parent tree numbers that are not part of your orchard composition. '
+      + 'As a result, the corresponding information for that parent tree number has not been added to the table. '
+      + 'Please ensure that the parent tree numbers in your uploaded file match the ones present in your orchard composition.'
   }
 });
 
@@ -760,10 +770,3 @@ export const getEmptySectionDescription = (setStep: Function) => (
     Please, fill the orchard ID to complete the cone and pollen table.
   </span>
 );
-
-/**
- * Used in the erro notification box;
- */
-export const invalidPTNumberMsg = 'One or more of the parent tree numbers entered are invalid because these numbers might not exist within your orchard composition.';
-
-export const errNotifEndMsg = 'Please review your entries and remember to check all pages.';

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -16,6 +16,26 @@ export const DEFAULT_PAGE_NUMBER = 1;
 
 export const EMPTY_NUMBER_STRING = '';
 
+export const VOLUME_MIN = 0;
+
+export const VOLUME_MAX = 10000;
+
+export const NON_ORCHARD_CONTAM_MIN = 0;
+
+export const NON_ORCHARD_CONTAM_MAX = 100;
+
+export const SMP_SUCCESS_PERC_MIN = 0;
+
+export const SMP_SUCCESS_PERC_MAX = 100;
+
+export const POLLEN_COUNT_MIN = 0;
+
+export const POLLEN_COUNT_MAX = 1000;
+
+export const CONE_COUNT_MIN = 0;
+
+export const CONE_COUNT_MAX = 1000;
+
 export const getDownloadUrl = (tabType: string) => {
   if (tabType === 'Calculation of SMP mix' || tabType === 'mixTab') {
     return '/downloads/SMP_Mix_Volume_template.csv';

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -760,3 +760,10 @@ export const getEmptySectionDescription = (setStep: Function) => (
     Please, fill the orchard ID to complete the cone and pollen table.
   </span>
 );
+
+/**
+ * Used in the erro notification box;
+ */
+export const invalidPTNumberMsg = 'One or more of the parent tree numbers entered are invalid because these numbers might not exist within your orchard composition.';
+
+export const errNotifEndMsg = 'Please review your entries and remember to check all pages.';

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
@@ -135,3 +135,12 @@ export type UploadWarnNotifProps = {
   invalidPTNumbers: string[],
   setInvalidPTNumbers: React.Dispatch<React.SetStateAction<string[]>>
 }
+
+export type EditableCellProps = {
+  rowData: RowItem,
+  header: HeaderObj,
+  applicableGenWorths: string[],
+  state: ParentTreeStepDataObj,
+  setStepData: Function,
+  seedlotSpecies: MultiOptionsObj
+};

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
@@ -2,11 +2,7 @@ import { StringInputType } from '../../../types/FormInputType';
 import InfoDisplayObj from '../../../types/InfoDisplayObj';
 import { ParentTreeGeneticQualityType } from '../../../types/ParentTreeGeneticQualityType';
 
-export type TabTypes = {
-  coneTab: 'coneTab',
-  successTab: 'successTab',
-  mixTab: 'mixTab'
-};
+export type TabTypes = 'coneTab' | 'successTab' | 'mixTab';
 
 export type StrTypeRowItem = {
   parentTreeNumber: StringInputType,

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
@@ -1,6 +1,17 @@
 import { StringInputType } from '../../../types/FormInputType';
 import InfoDisplayObj from '../../../types/InfoDisplayObj';
+import MultiOptionsObj from '../../../types/MultiOptionsObject';
 import { ParentTreeGeneticQualityType } from '../../../types/ParentTreeGeneticQualityType';
+import { ParentTreeStepDataObj } from '../../../views/Seedlot/SeedlotRegistrationForm/definitions';
+import { OrchardObj } from '../OrchardStep/definitions';
+
+export type ParentTreeStepProps = {
+  seedlotSpecies: MultiOptionsObj
+  state: ParentTreeStepDataObj;
+  setStep: Function
+  setStepData: Function;
+  orchards: Array<OrchardObj>;
+}
 
 export type TabTypes = 'coneTab' | 'successTab' | 'mixTab';
 
@@ -112,4 +123,9 @@ export type MixUploadResponse = {
 
 export type AllParentTreeMap = {
   [key: string]: ParentTreeGeneticQualityType
+}
+
+export type InputErrorNotifProps = {
+  state: ParentTreeStepDataObj;
+  headerConfig: HeaderObj[];
 }

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { StringInputType } from '../../../types/FormInputType';
 import InfoDisplayObj from '../../../types/InfoDisplayObj';
 import MultiOptionsObj from '../../../types/MultiOptionsObject';
@@ -128,4 +129,9 @@ export type AllParentTreeMap = {
 export type InputErrorNotifProps = {
   state: ParentTreeStepDataObj;
   headerConfig: HeaderObj[];
+}
+
+export type UploadWarnNotifProps = {
+  invalidPTNumbers: string[],
+  setInvalidPTNumbers: React.Dispatch<React.SetStateAction<string[]>>
 }

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -13,10 +13,8 @@ import {
   View, Settings, Upload, Renew, Add
 } from '@carbon/icons-react';
 import { getAllParentTrees } from '../../../api-service/orchardAPI';
-import MultiOptionsObj from '../../../types/MultiOptionsObject';
 import DescriptionBox from '../../DescriptionBox';
 import InfoSection from '../../InfoSection';
-import { ParentTreeStepDataObj } from '../../../views/Seedlot/SeedlotRegistrationForm/definitions';
 import { postFile } from '../../../api-service/seedlotAPI';
 import postForCalculation from '../../../api-service/geneticWorthAPI';
 import CheckboxType from '../../../types/CheckboxType';
@@ -39,7 +37,7 @@ import {
   PopSizeAndDiversityConfig, getDownloadUrl, fileConfigTemplate, getEmptySectionDescription
 } from './constants';
 import {
-  TabTypes, HeaderObj, RowItem
+  TabTypes, HeaderObj, RowItem, ParentTreeStepProps
 } from './definitions';
 import {
   getTabString, processOrchards, combineObjectValues, calcSummaryItems,
@@ -49,14 +47,7 @@ import {
 } from './utils';
 
 import './styles.scss';
-
-interface ParentTreeStepProps {
-  seedlotSpecies: MultiOptionsObj
-  state: ParentTreeStepDataObj;
-  setStep: Function
-  setStepData: Function;
-  orchards: Array<OrchardObj>;
-}
+import InputErrorNotification from './InputErrorNotification';
 
 const ParentTreeStep = (
   {
@@ -280,6 +271,7 @@ const ParentTreeStep = (
                   }
                 </Column>
               </Row>
+              <InputErrorNotification state={state} headerConfig={headerConfig} />
               {
                 currentTab === 'successTab'
                   ? (

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -212,7 +212,8 @@ const ParentTreeStep = (
         headerConfig,
         currentTab,
         setStepData,
-        setInvalidPTNumbers
+        setInvalidPTNumbers,
+        seedlotSpecies
       );
     },
     onError: (err: AxiosError) => {
@@ -310,7 +311,12 @@ const ParentTreeStep = (
                         </Column>
                       </Row>
                       {
-                        renderDefaultInputs(isSMPDefaultValChecked, state, setStepData)
+                        renderDefaultInputs(
+                          isSMPDefaultValChecked,
+                          state,
+                          setStepData,
+                          seedlotSpecies
+                        )
                       }
                     </>
                   )
@@ -430,7 +436,8 @@ const ParentTreeStep = (
                                   headerConfig,
                                   applicableGenWorths,
                                   state,
-                                  setStepData
+                                  setStepData,
+                                  seedlotSpecies
                                 )
                             }
                           </Table>

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -48,6 +48,7 @@ import {
 
 import './styles.scss';
 import InputErrorNotification from './InputErrorNotification';
+import UploadWarnNotification from './UploadWarnNotification';
 
 const ParentTreeStep = (
   {
@@ -95,6 +96,9 @@ const ParentTreeStep = (
   // Options are disabled if users have not typed in one or more valid orchards
   const [disableOptions, setDisableOptions] = useState(true);
   const [applicableGenWorths, setApplicableGenWorths] = useState<string[]>([]);
+  // Array that stores invalid p.t. numbers uploaded from users from composition tabs
+  const [invalidPTNumbers, setInvalidPTNumbers] = useState<string[]>([]);
+
   const emptySectionDescription = getEmptySectionDescription(setStep);
 
   // Link reference to trigger click event
@@ -202,7 +206,14 @@ const ParentTreeStep = (
     onSuccess: (res) => {
       resetFileUploadConfig();
       setIsUploadOpen(false);
-      fillCompostitionTables(res.data, state, headerConfig, currentTab, setStepData);
+      fillCompostitionTables(
+        res.data,
+        state,
+        headerConfig,
+        currentTab,
+        setStepData,
+        setInvalidPTNumbers
+      );
     },
     onError: (err: AxiosError) => {
       const msg = (err.response as AxiosResponse).data.message;
@@ -272,6 +283,10 @@ const ParentTreeStep = (
                 </Column>
               </Row>
               <InputErrorNotification state={state} headerConfig={headerConfig} />
+              <UploadWarnNotification
+                invalidPTNumbers={invalidPTNumbers}
+                setInvalidPTNumbers={setInvalidPTNumbers}
+              />
               {
                 currentTab === 'successTab'
                   ? (
@@ -366,7 +381,7 @@ const ParentTreeStep = (
                           kind="primary"
                           renderIcon={Upload}
                           onClick={() => setIsUploadOpen(true)}
-                          disabled={disableOptions}
+                          disabled={disableOptions || !allParentTreeQuery.isFetched}
                         >
                           Upload from file
                         </Button>

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -68,7 +68,7 @@ const ParentTreeStep = (
   }: ParentTreeStepProps
 ) => {
   const [orchardsData, setOrchardsData] = useState<Array<OrchardObj>>([]);
-  const [currentTab, setCurrentTab] = useState<keyof TabTypes>('coneTab');
+  const [currentTab, setCurrentTab] = useState<TabTypes>('coneTab');
   const [headerConfig, setHeaderConfig] = useState<Array<HeaderObj>>(
     structuredClone(headerTemplate)
   );

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/styles.scss
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/styles.scss
@@ -175,6 +175,19 @@
     .#{vars.$bcgov-prefix}--text-input {
       padding: 0 1rem;
     }
+
+    .input-error-tooltip {
+      width: 100%;
+
+      .#{vars.$bcgov-prefix}--tooltip-trigger__wrapper {
+        width: 100%;
+      }
+
+      .#{vars.$bcgov-prefix}--form-requirement{
+        display: none;
+      }
+    }
+
   }
 
   .#{vars.$bcgov-prefix}--overflow-menu__wrapper .#{vars.$bcgov-prefix}--btn--disabled {

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/styles.scss
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/styles.scss
@@ -114,6 +114,10 @@
       display: none;
     }
 
+    .#{vars.$bcgov-prefix}--actionable-notification__text-wrapper {
+      padding: 0.9375rem 0;
+    }
+
     .notification-subtitle {
       @include type.type-style('body-compact-01');
     }
@@ -121,6 +125,11 @@
     .notification-link {
       color: var(--#{vars.$bcgov-prefix}-link-primary);
       text-decoration: underline;
+    }
+
+    ul {
+      list-style-type: disc;
+      list-style-position: inside;
     }
   }
 }
@@ -183,7 +192,7 @@
         width: 100%;
       }
 
-      .#{vars.$bcgov-prefix}--form-requirement{
+      .#{vars.$bcgov-prefix}--form-requirement {
         display: none;
       }
     }

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/styles.scss
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/styles.scss
@@ -84,6 +84,12 @@
       margin-block-start: 0.0625rem;
     }
   }
+
+  .ghost-button-underlined{
+    padding: 0;
+    min-height: fit-content;
+    text-decoration: underline;
+  }
 }
 
 .parent-tree-tab-container {

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -267,7 +267,7 @@ export const generateDefaultRows = (numOfRows: number): RowDataDictType => {
 export const cleanTable = (
   state: ParentTreeStepDataObj,
   headerConfig: HeaderObj[],
-  currentTab: keyof TabTypes,
+  currentTab: TabTypes,
   setStepData: Function
 ): ParentTreeStepDataObj => {
   const clonedState = structuredClone(state);
@@ -306,7 +306,7 @@ export const fillCompostitionTables = (
   data: CompUploadResponse[],
   state: ParentTreeStepDataObj,
   headerConfig: HeaderObj[],
-  currentTab: keyof TabTypes,
+  currentTab: TabTypes,
   setStepData: Function
 ) => {
   // Store parent tree numbers that does not exist in the orchards
@@ -341,7 +341,7 @@ export const fillCompostitionTables = (
 export const toggleNotification = (
   notifType: string,
   state: ParentTreeStepDataObj,
-  currentTab: keyof TabTypes,
+  currentTab: TabTypes,
   setStepData: Function
 ) => {
   const modifiedState = { ...state };

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -182,7 +182,7 @@ export const calcMixTabInfoItems = (
   }
 };
 
-const populateStrInputId = (idPrefix: string, row: RowItem): RowItem => {
+export const populateStrInputId = (idPrefix: string, row: RowItem): RowItem => {
   const newRow = structuredClone(row);
   Object.keys(newRow).forEach((key) => {
     const rowKey = key as keyof RowItem;

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -299,11 +299,12 @@ export const applyValueToAll = (
   field: keyof StrTypeRowItem,
   value: string,
   state: ParentTreeStepDataObj,
-  setStepData: Function
+  setStepData: Function,
+  seedlotSpecies: MultiOptionsObj
 ) => {
   const clonedState = structuredClone(state);
   const parentTreeNumbers = Object.keys(clonedState.tableRowData);
-  const isInvalid = field === 'smpSuccessPerc' ? isSmpSuccInvalid(value) : isNonOrchardContamInvalid(value);
+  const isInvalid = field === 'smpSuccessPerc' ? isSmpSuccInvalid(value, seedlotSpecies.code === 'PW') : isNonOrchardContamInvalid(value);
   const errMsg = field === 'smpSuccessPerc' ? getSmpSuccErrMsg(value) : getNonOrchardContamErrMsg(value);
   parentTreeNumbers.forEach((number) => {
     clonedState.tableRowData[number][field].value = value;
@@ -319,7 +320,8 @@ export const fillCompostitionTables = (
   headerConfig: HeaderObj[],
   currentTab: TabTypes,
   setStepData: Function,
-  setInvalidPTNumbers: React.Dispatch<React.SetStateAction<string[]>>
+  setInvalidPTNumbers: React.Dispatch<React.SetStateAction<string[]>>,
+  seedlotSpecies: MultiOptionsObj
 ) => {
   // Store parent tree numbers that does not exist in the orchards
   const invalidParentTreeNumbers: Array<string> = [];
@@ -349,7 +351,7 @@ export const fillCompostitionTables = (
 
       // SMP Success percentage
       const smpSuccessValue = row.smpSuccess.toString();
-      isInvalid = isSmpSuccInvalid(smpSuccessValue);
+      isInvalid = isSmpSuccInvalid(smpSuccessValue, seedlotSpecies.code === 'PW');
       clonedState.tableRowData[parentTreeNumber].smpSuccessPerc.value = smpSuccessValue;
       clonedState.tableRowData[parentTreeNumber].smpSuccessPerc.isInvalid = isInvalid;
       clonedState.tableRowData[parentTreeNumber].smpSuccessPerc
@@ -465,24 +467,6 @@ export const configHeaderOpt = (
     setGenWorthInfoItems(clonedGwItems);
     setWeightedGwInfoItems(clonedWeightedGwItems);
   }
-};
-
-export const setInputChange = (
-  rowData: RowItem,
-  colName: keyof StrTypeRowItem,
-  value: string,
-  state: ParentTreeStepDataObj,
-  setStepData: Function
-) => {
-  // Using structuredClone so useEffect on state.tableRowData can be triggered
-  const clonedState = structuredClone(state);
-  if (rowData.isMixTab) {
-    clonedState.mixTabData[rowData.rowId][colName].value = value;
-  } else if (!rowData.isMixTab) {
-    clonedState.tableRowData[rowData.parentTreeNumber.value][colName].value = value;
-  }
-
-  setStepData(clonedState);
 };
 
 export const fillCalculatedInfo = (

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -302,8 +302,12 @@ export const applyValueToAll = (
 ) => {
   const clonedState = structuredClone(state);
   const parentTreeNumbers = Object.keys(clonedState.tableRowData);
+  const isInvalid = field === 'smpSuccessPerc' ? isSmpSuccInvalid(value) : isNonOrchardContamInvalid(value);
+  const errMsg = field === 'smpSuccessPerc' ? getSmpSuccErrMsg(value) : getNonOrchardContamErrMsg(value);
   parentTreeNumbers.forEach((number) => {
     clonedState.tableRowData[number][field].value = value;
+    clonedState.tableRowData[number][field].isInvalid = isInvalid;
+    clonedState.tableRowData[number][field].errMsg = errMsg;
   });
   setStepData(clonedState);
 };

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -6,7 +6,13 @@ import MultiOptionsObj from '../../../types/MultiOptionsObject';
 import { recordKeys } from '../../../utils/RecordUtils';
 import { GenWorthCalcPayload, CalcPayloadResType } from '../../../types/GeneticWorthTypes';
 
-import { isPtNumberInvalid, populateRowData } from './TableComponents/utils';
+import {
+  getConeCountErrMsg, getNonOrchardContamErrMsg, getPollenCountErrMsg,
+  getSmpSuccErrMsg, getVolumeErrMsg, isConeCountInvalid,
+  isNonOrchardContamInvalid, isPollenCountInvalid,
+  isPtNumberInvalid, isSmpSuccInvalid, isVolumeInvalid,
+  populateRowData
+} from './TableComponents/utils';
 import { OrchardObj } from '../OrchardStep/definitions';
 
 import {
@@ -317,13 +323,40 @@ export const fillCompostitionTables = (
 
   data.forEach((row: CompUploadResponse) => {
     const parentTreeNumber = row.parentTreeNumber.toString();
+    // If the clone nubmer exist from user file then fill in the values
     if (Object.prototype.hasOwnProperty.call(clonedState.tableRowData, parentTreeNumber)) {
-      // If the clone nubmer exist from user file then fill in the values
-      clonedState.tableRowData[parentTreeNumber].coneCount.value = row.coneCount.toString();
-      clonedState.tableRowData[parentTreeNumber].pollenCount.value = row.pollenCount.toString();
-      clonedState.tableRowData[parentTreeNumber].smpSuccessPerc.value = row.smpSuccess.toString();
-      clonedState.tableRowData[parentTreeNumber]
-        .nonOrchardPollenContam.value = row.pollenContamination.toString();
+      // Cone count
+      const coneCountValue = row.coneCount.toString();
+      let isInvalid = isConeCountInvalid(coneCountValue);
+      clonedState.tableRowData[parentTreeNumber].coneCount.value = coneCountValue;
+      clonedState.tableRowData[parentTreeNumber].coneCount.isInvalid = isInvalid;
+      clonedState.tableRowData[parentTreeNumber].coneCount
+        .errMsg = isInvalid ? getConeCountErrMsg(coneCountValue) : '';
+
+      // Pollen count
+      const pollenCountValue = row.pollenCount.toString();
+      isInvalid = isPollenCountInvalid(pollenCountValue);
+      clonedState.tableRowData[parentTreeNumber].pollenCount.value = pollenCountValue;
+      clonedState.tableRowData[parentTreeNumber].pollenCount.isInvalid = isInvalid;
+      clonedState.tableRowData[parentTreeNumber].pollenCount
+        .errMsg = isInvalid ? getPollenCountErrMsg(pollenCountValue) : '';
+
+      // SMP Success percentage
+      const smpSuccessValue = row.smpSuccess.toString();
+      isInvalid = isSmpSuccInvalid(smpSuccessValue);
+      clonedState.tableRowData[parentTreeNumber].smpSuccessPerc.value = smpSuccessValue;
+      clonedState.tableRowData[parentTreeNumber].smpSuccessPerc.isInvalid = isInvalid;
+      clonedState.tableRowData[parentTreeNumber].smpSuccessPerc
+        .errMsg = isInvalid ? getSmpSuccErrMsg(smpSuccessValue) : '';
+
+      // Non orchard pollen contamination percentage
+      const nonOrchardContamValue = row.pollenContamination.toString();
+      isInvalid = isNonOrchardContamInvalid(nonOrchardContamValue);
+      clonedState.tableRowData[parentTreeNumber].nonOrchardPollenContam
+        .value = nonOrchardContamValue;
+      clonedState.tableRowData[parentTreeNumber].nonOrchardPollenContam.isInvalid = isInvalid;
+      clonedState.tableRowData[parentTreeNumber].nonOrchardPollenContam
+        .errMsg = isInvalid ? getNonOrchardContamErrMsg(nonOrchardContamValue) : '';
     } else {
       invalidParentTreeNumbers.push(parentTreeNumber);
     }
@@ -579,6 +612,8 @@ export const fillMixTable = (
     newRow.rowId = String(index);
     newRow.parentTreeNumber.value = ptNumber;
     newRow.volume.value = String(row.pollenVolume);
+    newRow.volume.isInvalid = isVolumeInvalid(newRow.volume.value);
+    newRow.volume.errMsg = newRow.volume.isInvalid ? getVolumeErrMsg(newRow.volume.value) : '';
 
     // Validate pt number
     const isPtInvalid = isPtNumberInvalid(ptNumber, state.allParentTreeData);

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import InfoDisplayObj from '../../../types/InfoDisplayObj';
 import { sliceTableRowData } from '../../../utils/PaginationUtils';
 import { ParentTreeStepDataObj } from '../../../views/Seedlot/SeedlotRegistrationForm/definitions';
@@ -11,7 +12,7 @@ import {
   getSmpSuccErrMsg, getVolumeErrMsg, isConeCountInvalid,
   isNonOrchardContamInvalid, isPollenCountInvalid,
   isPtNumberInvalid, isSmpSuccInvalid, isVolumeInvalid,
-  populateRowData
+  populateRowData, getPTNumberErrMsg
 } from './TableComponents/utils';
 import { OrchardObj } from '../OrchardStep/definitions';
 
@@ -317,7 +318,8 @@ export const fillCompostitionTables = (
   state: ParentTreeStepDataObj,
   headerConfig: HeaderObj[],
   currentTab: TabTypes,
-  setStepData: Function
+  setStepData: Function,
+  setInvalidPTNumbers: React.Dispatch<React.SetStateAction<string[]>>
 ) => {
   // Store parent tree numbers that does not exist in the orchards
   const invalidParentTreeNumbers: Array<string> = [];
@@ -368,11 +370,7 @@ export const fillCompostitionTables = (
 
   setStepData(clonedState);
 
-  if (invalidParentTreeNumbers.length > 0) {
-    // A temporary solution to let users know they have invalid clone numbers
-    // eslint-disable-next-line no-alert
-    alert(`The following clone numbers cannot be found: ${invalidParentTreeNumbers}`);
-  }
+  setInvalidPTNumbers(invalidParentTreeNumbers.sort((a, b) => Number(a) - Number(b)));
 };
 
 export const toggleNotification = (
@@ -622,7 +620,7 @@ export const fillMixTable = (
     // Validate pt number
     const isPtInvalid = isPtNumberInvalid(ptNumber, state.allParentTreeData);
     newRow.parentTreeNumber.isInvalid = isPtInvalid;
-
+    newRow.parentTreeNumber.errMsg = isPtInvalid ? getPTNumberErrMsg(ptNumber) : '';
     // Populate data such as gw value
     if (!isPtInvalid) {
       newRow = populateRowData(newRow, ptNumber, state);

--- a/frontend/src/types/FormInputType.ts
+++ b/frontend/src/types/FormInputType.ts
@@ -3,6 +3,7 @@ import MultiOptionsObj from './MultiOptionsObject';
 export type FormInputType = {
   id: string;
   isInvalid: boolean;
+  errMsg?: string;
 };
 
 export type OptionsInputType = FormInputType & { value: MultiOptionsObj };


### PR DESCRIPTION
# Description
Closes #454 

### Changelog
#### New
- Some validation functions and error message generators
- New Warn and Error notification components

#### Changed
- Added an optional `errMSg: string` to the FormInputType, so error messages can be displayed in a more dynamic manner. This is mostly used for the table cell error message.
- removed the onChange calls for `TextInputs` in the table. Everything will be handled via onBlur

#### Testing
This task took a little longer for the following reasons: LOTS of cases to account for, such as uploading different csv files should change the error and warnings too. 

Here are some files that you can use for testing of the warning notification(Table 1&2):
- [11.csv](https://github.com/bcgov/nr-spar/files/13666554/11.csv) 11 non valid parent trees
- [fewer_than_10.csv](https://github.com/bcgov/nr-spar/files/13666558/fewer_than_10.csv) fewer than 10 valid parent trees
- [more_than_11.csv](https://github.com/bcgov/nr-spar/files/13666559/more_than_11.csv)

For SMP mix table:
- [SMP_Mix_Volume_template (3).csv](https://github.com/bcgov/nr-spar/files/13666566/SMP_Mix_Volume_template.3.csv)




### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media3.giphy.com/media/bEs40jYsdQjmM/giphy-downsized-medium.gif" width="200"/>
