### PR TITLE
fix/568 bug smp mix template downloading wrong format

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -39,13 +39,13 @@
 	route /Seedlot_composition_template.csv {
 		uri strip_prefix /Seedlot_composition_template.csv
 		header Content-Type text/csv
-		file_server */Seedlot_composition_template.csv
+		file_server /public/downloads/Seedlot_composition_template.csv
 	}
 
 	route /SMP_Mix_Volume_template.csv {
 		uri strip_prefix /SMP_Mix_Volume_template.csv
 		header Content-Type text/csv
-		file_server */SMP_Mix_Volume_template.csv
+		file_server /public/downloads/SMP_Mix_Volume_template.csv
 	}
 
 	file_server

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -36,5 +36,17 @@
 		try_files {path} {path}/ {file} /index.html
 	}
 
+	route /Seedlot_composition_template.csv {
+		uri strip_prefix /Seedlot_composition_template.csv
+		header Content-Type text/csv
+		file_server */Seedlot_composition_template.csv
+	}
+
+	route /SMP_Mix_Volume_template.csv {
+		uri strip_prefix /SMP_Mix_Volume_template.csv
+		header Content-Type text/csv
+		file_server */SMP_Mix_Volume_template.csv
+	}
+
 	file_server
 }

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -77,10 +77,15 @@ const getNotificationSubtitle = (tabType: string) => {
         + "do use the SPAR's spreadsheet template. "
       }
       <Link
+        type="text/csv"
         className="notification-link"
         to={getDownloadUrl(tabType)}
         target="_blank"
-        download
+        download={
+          (tabType === 'Calculation of SMP mix' || tabType === 'mixTab')
+            ? 'SMP_Mix_Volume_template.csv'
+            : 'Seedlot_composition_template.csv'
+        }
       >
         {`Download ${downloadName} template`}
       </Link>


### PR DESCRIPTION
Probably, the problem is on the `Content-Type` set to `text/html`, trying to fix it with changes on routes in Caddy.

The problem:
![Screenshot from 2023-12-20 18-01-33](https://github.com/bcgov/nr-spar/assets/105936322/60054d65-5ff2-4a35-b32b-c56efd24450a)

Needs testing on test environment.

<img width="300" src="https://media0.giphy.com/media/7TEVbGzXlMLkY/giphy.gif"/>

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-721-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-721-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-721-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)