### PR TITLE
619 mock dashboard cypress test

### DIFF
--- a/frontend/cypress/e2e/smoke-test/dashboard-page.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/dashboard-page.cy.ts
@@ -31,25 +31,22 @@ describe('Dashboard page test', () => {
       .should('have.text', dashboardPageData.secondSectionSubtitle);
   });
 
-  it('should be able to favourite the seedlots page', () => {
-    // Navigate to Seedlot page
-    cy.navigateTo(NavigationLabels.Seedlots);
-    // Favourite Seedlot page
-    cy.get('.title-favourite')
-      .find(`.${prefix}--popover-container`)
-      .click();
-    // Navigate to Dashboard page
-    cy.navigateTo(NavigationLabels.Dashboard);
-    // Check if seedlot card is appearing at favourites activities
-    cy.get('.favourite-activities-cards')
-      .find('.fav-card-content')
-      .find('.fav-card-title-large')
-      .contains('Seedlots')
-      .click();
-    cy.isPageTitle(NavigationLabels.Seedlots);
-  });
-
   it('should be able to favourite the a class seedlot page', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/favourite-activities'
+      },
+      {
+        fixture: 'favourite-activities/a-class.json'
+      }
+    ).as('interceptedGet');
+
+    cy.intercept({
+      method: 'POST',
+      path: '/api/favourite-activities'
+    }).as('interceptedPost');
+
     // Navigate to Seedlot page
     cy.navigateTo(NavigationLabels.Seedlots);
 
@@ -76,6 +73,21 @@ describe('Dashboard page test', () => {
   });
 
   it('should be able to favourite my seedlot page', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/favourite-activities'
+      },
+      {
+        fixture: 'favourite-activities/my-seedlots.json'
+      }
+    ).as('interceptedGet');
+
+    cy.intercept({
+      method: 'POST',
+      path: '/api/favourite-activities'
+    }).as('interceptedPost');
+
     // Navigate to My seedlot page
     cy.navigateTo(NavigationLabels.Seedlots);
     cy.get('.seedlot-activities-cards')
@@ -103,19 +115,15 @@ describe('Dashboard page test', () => {
   });
 
   it('should be able to highlight favourite cards at dashboard', () => {
-  // Highlight Seedlots Card
-    cy.get('.favourite-activities-cards')
-      .find('.fav-card-main:first')
-      .find('.fav-card-overflow')
-      .click();
-    cy.get(`.${prefix}--overflow-menu-options__option-content`)
-      .contains('Highlight shortcut')
-      .click();
-
-    // Check if the Seedlots card is unique and highlighted
-    cy.get('.fav-card-main-highlighted')
-      .should('have.length', 1)
-      .should('contain.text', 'Seedlots');
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/favourite-activities'
+      },
+      {
+        fixture: 'favourite-activities/my-seedlots-highlighted.json'
+      }
+    ).as('interceptedGet');
 
     // Highlight Create A Class Seedlot card
     cy.get('.favourite-activities-cards')
@@ -133,6 +141,22 @@ describe('Dashboard page test', () => {
   });
 
   it('should delete my seedlots card from favourite activities', () => {
+    const test = 'cypress/fixture/favourite-activities/my-seedlots.json';
+    cy.intercept(
+      {
+        method: 'GET',
+        path: '/api/favourite-activities'
+      },
+      {
+        fixture: test
+      }
+    ).as('interceptedGet');
+
+    cy.intercept({
+      method: 'DELETE',
+      path: '/api/favourite-activities'
+    }).as('interceptedPost');
+
     // Delete My Seedlots card
     cy.get('.favourite-activities-cards')
       .find('.fav-card-main:first')
@@ -154,19 +178,6 @@ describe('Dashboard page test', () => {
       .contains('Delete shortcut')
       .click();
     cy.get('.fav-card-main-highlighted')
-      .should('have.length', 0);
-  });
-
-  it('should delete seedlots card from favourite activities', () => {
-    // Delete Seedlots card
-    cy.get('.favourite-activities-cards')
-      .find('.fav-card-main:first')
-      .find('.fav-card-overflow')
-      .click();
-    cy.get(`.${prefix}--overflow-menu-options__option-content`)
-      .contains('Delete shortcut')
-      .click();
-    cy.get('.fav-card-main')
       .should('have.length', 0);
   });
 

--- a/frontend/cypress/e2e/smoke-test/dashboard-page.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/dashboard-page.cy.ts
@@ -35,7 +35,7 @@ describe('Dashboard page test', () => {
     cy.intercept(
       {
         method: 'GET',
-        path: '/api/favourite-activities'
+        path: '**/api/favourite-activities'
       },
       {
         fixture: 'favourite-activities/a-class.json'
@@ -44,7 +44,7 @@ describe('Dashboard page test', () => {
 
     cy.intercept({
       method: 'POST',
-      path: '/api/favourite-activities'
+      path: '**/api/favourite-activities'
     }).as('interceptedPost');
 
     // Navigate to Seedlot page
@@ -76,7 +76,7 @@ describe('Dashboard page test', () => {
     cy.intercept(
       {
         method: 'GET',
-        path: '/api/favourite-activities'
+        path: '**/api/favourite-activities'
       },
       {
         fixture: 'favourite-activities/my-seedlots.json'
@@ -85,7 +85,7 @@ describe('Dashboard page test', () => {
 
     cy.intercept({
       method: 'POST',
-      path: '/api/favourite-activities'
+      path: '**/api/favourite-activities'
     }).as('interceptedPost');
 
     // Navigate to My seedlot page
@@ -118,7 +118,7 @@ describe('Dashboard page test', () => {
     cy.intercept(
       {
         method: 'GET',
-        path: '/api/favourite-activities'
+        path: '**/api/favourite-activities'
       },
       {
         fixture: 'favourite-activities/my-seedlots-highlighted.json'
@@ -141,20 +141,19 @@ describe('Dashboard page test', () => {
   });
 
   it('should delete my seedlots card from favourite activities', () => {
-    const test = 'cypress/fixture/favourite-activities/my-seedlots.json';
     cy.intercept(
       {
         method: 'GET',
-        path: '/api/favourite-activities'
+        path: '**/api/favourite-activities'
       },
       {
-        fixture: test
+        fixture: 'favourite-activities/my-seedlots.json'
       }
     ).as('interceptedGet');
 
     cy.intercept({
       method: 'DELETE',
-      path: '/api/favourite-activities'
+      path: '**/api/favourite-activities'
     }).as('interceptedPost');
 
     // Delete My Seedlots card

--- a/frontend/cypress/e2e/smoke-test/dashboard-page.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/dashboard-page.cy.ts
@@ -13,6 +13,21 @@ describe('Dashboard page test', () => {
     cy.fixture('dashboard-page').then((fData) => {
       dashboardPageData = fData;
     });
+    cy.intercept({
+      method: 'GET',
+      path: '**/api/favourite-activities'
+    }, (req) => {
+      req.reply(
+        {
+          body: [{
+            id: 239,
+            userId: 'IDIR@TEST',
+            activity: 'mySeedlots',
+            highlighted: false
+          }]
+        }
+      );
+    }).as('interceptedGet');
     cy.login();
     cy.visit('/');
     cy.url().should('contains', '/dashboard');
@@ -31,20 +46,27 @@ describe('Dashboard page test', () => {
       .should('have.text', dashboardPageData.secondSectionSubtitle);
   });
 
-  it('should be able to favourite the a class seedlot page', () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        path: '**/api/favourite-activities'
-      },
-      {
-        fixture: 'favourite-activities/a-class.json'
-      }
-    ).as('interceptedGet');
-
+  it('should be able to favourite the Register A-class seedlot page', () => {
     cy.intercept({
       method: 'POST',
       path: '**/api/favourite-activities'
+    }, (req) => {
+      req.reply(
+        {
+          body: [{
+            id: 239,
+            userId: 'IDIR@TEST',
+            activity: 'mySeedlots',
+            highlighted: false
+          }, {
+            id: 238,
+            userId: 'IDIR@TEST',
+            activity: 'registerAClass',
+            highlighted: false
+          }
+          ]
+        }
+      );
     }).as('interceptedPost');
 
     // Navigate to Seedlot page
@@ -58,6 +80,28 @@ describe('Dashboard page test', () => {
     cy.get('.title-favourite')
       .find(`.${prefix}--popover-container`)
       .click();
+    cy.reload();
+    cy.intercept({
+      method: 'GET',
+      path: '**/api/favourite-activities'
+    }, (req) => {
+      req.reply(
+        {
+          body: [{
+            id: 239,
+            userId: 'IDIR@TEST',
+            activity: 'mySeedlots',
+            highlighted: false
+          }, {
+            id: 238,
+            userId: 'IDIR@TEST',
+            activity: 'registerAClass',
+            highlighted: false
+          }
+          ]
+        }
+      );
+    }).as('interceptedGetAfter');
 
     // Navigate to Dashboard page
     cy.navigateTo(NavigationLabels.Dashboard);
@@ -73,21 +117,27 @@ describe('Dashboard page test', () => {
   });
 
   it('should be able to favourite my seedlot page', () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        path: '**/api/favourite-activities'
-      },
-      {
-        fixture: 'favourite-activities/my-seedlots.json'
-      }
-    ).as('interceptedGet');
-
     cy.intercept({
       method: 'POST',
       path: '**/api/favourite-activities'
+    }, (req) => {
+      req.reply(
+        {
+          body: [{
+            id: 239,
+            userId: 'IDIR@TEST',
+            activity: 'mySeedlots',
+            highlighted: false
+          }, {
+            id: 238,
+            userId: 'IDIR@TEST',
+            activity: 'registerAClass',
+            highlighted: false
+          }
+          ]
+        }
+      );
     }).as('interceptedPost');
-
     // Navigate to My seedlot page
     cy.navigateTo(NavigationLabels.Seedlots);
     cy.get('.seedlot-activities-cards')
@@ -99,6 +149,28 @@ describe('Dashboard page test', () => {
     cy.get('.title-favourite')
       .find(`.${prefix}--popover-container`)
       .click();
+
+    cy.intercept({
+      method: 'GET',
+      path: '**/api/favourite-activities'
+    }, (req) => {
+      req.reply(
+        {
+          body: [{
+            id: 239,
+            userId: 'IDIR@TEST',
+            activity: 'mySeedlots',
+            highlighted: false
+          }, {
+            id: 238,
+            userId: 'IDIR@TEST',
+            activity: 'registerAClass',
+            highlighted: false
+          }
+          ]
+        }
+      );
+    }).as('interceptedGetAfter');
 
     // Navigate to Dashboard page
     cy.navigateTo(NavigationLabels.Dashboard);
@@ -115,15 +187,21 @@ describe('Dashboard page test', () => {
   });
 
   it('should be able to highlight favourite cards at dashboard', () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        path: '**/api/favourite-activities'
-      },
-      {
-        fixture: 'favourite-activities/my-seedlots-highlighted.json'
-      }
-    ).as('interceptedGet');
+    cy.intercept({
+      method: 'PUT',
+      path: '**/api/favourite-activities/**'
+    }, (req) => {
+      req.reply(
+        {
+          body: {
+            id: 239,
+            userId: 'IDIR@TEST',
+            activity: 'mySeedlots',
+            highlighted: true
+          }
+        }
+      );
+    }).as('interceptedPut');
 
     // Highlight Create A Class Seedlot card
     cy.get('.favourite-activities-cards')
@@ -134,10 +212,28 @@ describe('Dashboard page test', () => {
       .contains('Highlight shortcut')
       .click();
 
-    // Check if the Create A Class Seedlot card is unique and highlighted
+    cy.reload();
+    cy.intercept({
+      method: 'GET',
+      path: '**/api/favourite-activities'
+    }, (req) => {
+      req.reply(
+        {
+          body: [{
+            id: 239,
+            userId: 'IDIR@TEST',
+            activity: 'mySeedlots',
+            highlighted: true
+          }
+          ]
+        }
+      );
+    }).as('interceptedGetAfter');
+
+    // Check if My Seedlots card is unique and highlighted
     cy.get('.fav-card-main-highlighted')
       .should('have.length', 1)
-      .should('contain.text', 'Create A-class seedlot');
+      .should('contain.text', 'My Seedlots');
   });
 
   it('should delete my seedlots card from favourite activities', () => {
@@ -165,7 +261,7 @@ describe('Dashboard page test', () => {
       .contains('Delete shortcut')
       .click();
     cy.get('.fav-card-main')
-      .should('have.length', 1);
+      .should('have.length', 0);
   });
 
   it('should delete a class seedlot card from favourite activities', () => {
@@ -178,9 +274,7 @@ describe('Dashboard page test', () => {
       .click();
     cy.get('.fav-card-main-highlighted')
       .should('have.length', 0);
-  });
 
-  it('should display empty section', () => {
     cy.get('.empty-section-title')
       .should('contain.text', "You don't have any favourites to show yet!");
   });

--- a/frontend/cypress/fixtures/favourite-activities/a-class.json
+++ b/frontend/cypress/fixtures/favourite-activities/a-class.json
@@ -1,0 +1,8 @@
+[
+    {
+        "id": 238,
+        "userId": "IDIR@TEST",
+        "activity": "registerAClass",
+        "highlighted": false
+    }
+]

--- a/frontend/cypress/fixtures/favourite-activities/my-seedlots-highlighted.json
+++ b/frontend/cypress/fixtures/favourite-activities/my-seedlots-highlighted.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": 238,
+        "userId": "IDIR@TEST",
+        "activity": "registerAClass",
+        "highlighted": true
+    },
+    {
+        "id": 239,
+        "userId": "IDIR@TEST",
+        "activity": "mySeedlots",
+        "highlighted": false
+    }
+]

--- a/frontend/cypress/fixtures/favourite-activities/my-seedlots.json
+++ b/frontend/cypress/fixtures/favourite-activities/my-seedlots.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": 238,
+        "userId": "IDIR@TEST",
+        "activity": "registerAClass",
+        "highlighted": false
+    },
+    {
+        "id": 239,
+        "userId": "IDIR@TEST",
+        "activity": "mySeedlots",
+        "highlighted": false
+    }
+]


### PR DESCRIPTION
# Description
Closes #619 

### Changelog
- Intercept every call related to favourite activities
- Now using mocked data on dashboard tests

#### Removed
- Tests related to Main seedlot dashboard

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [x] 🤖 Added tests

#### OBS:
I had to put some reloads in the tests, because in fact the **before each get intercept** wasn't working because it was missing a [ ], after I fixed this, this intercept started to be called all the time and the "InterceptGetAfter" wasn't having any effect. I don't know if it's OK to have reloads in tests, so I thought it would be better to draw attention to this.

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media0.giphy.com/media/AyhyKY14ZXfxe/giphy.gif"/>

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-spar-725-backend.apps.silver.devops.gov.bc.ca/)
[Frontend](https://nr-spar-725-frontend.apps.silver.devops.gov.bc.ca/)
[Oracle-API](https://nr-spar-725-oracle-api.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)