### PR TITLE
fix: fixing button style at register seedlot page

### DIFF
--- a/frontend/src/views/Seedlot/CreateAClass/styles.scss
+++ b/frontend/src/views/Seedlot/CreateAClass/styles.scss
@@ -25,8 +25,4 @@
       flex-direction: column;
     }
   }
-
-  .submit-button {
-    width: 100%;
-  }
 }


### PR DESCRIPTION
# Description
Small adjustment to a button on the "Create A Class Seedlot" page, the button was breaking into two lines in some resolutions.

Closes #[#771](https://github.com/bcgov/nr-spar/issues/771)

### Changelog

#### Removed
- Style removed at create A class seedlot (100% width was breaking the button)

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media3.giphy.com/media/jR4qTrQOQ3wNDFtLHr/giphy.gif"/>