### PR TITLE
fix: enable backend rest api to report apache maven plugins validations

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -58,7 +58,6 @@ jobs:
             -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
             -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}'
-          triggers: ('common/' 'database/' 'backend/' 'frontend/' 'oracle-api/')
 
   builds:
     name: Builds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,13 @@ services:
       <<: *db-vars
     ports: ["8090:8090", "5005:5005"]
     image: maven:3.9.6-eclipse-temurin-17
-    entrypoint: mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005"
+    entrypoint:
+      - "/bin/sh"
+      - -ecx
+      - |
+        mvn -ntp spring-boot:run \
+        -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005" \
+        -Dmaven.plugin.validation=VERBOSE
     working_dir: /app
     volumes: ["./backend:/app"]
     healthcheck:


### PR DESCRIPTION
# Description
Closes #201 

### Changelog
#### New
- None.

#### Changed
- The `docker-compose.yml` file.

#### Removed
- None.

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->
⚠️ Note that the change was made only for `backend`, no need to do it for Oracle. Since having it enable for one of them should be enough.

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media1.giphy.com/media/fTtNMQ737dqZCkg4dk/giphy.gif"/>

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-46-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-46-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-46-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-46-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-46-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-46-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)