### PR TITLE
Fix/842 Empty orchard bug

### DIFF
--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -157,7 +157,8 @@ const getPageText = () => ({
     secondaryButtonText: 'Cancel'
   },
   emptySection: {
-    title: 'Nothing to show yet!'
+    title: 'Nothing to show yet!',
+    emptyOrchard: 'Empty orchard(s)!'
   },
   invalidPTNumberMsg: 'One or more of the parent tree numbers entered are invalid because these numbers might not exist within your orchard composition.',
   errNotifEndMsg: 'Please review your entries and remember to check all pages.',
@@ -783,5 +784,11 @@ export const getEmptySectionDescription = (setStep: Function) => (
     &quot;.
     <br />
     Please, fill the orchard ID to complete the cone and pollen table.
+  </span>
+);
+
+export const noParentTreeDescription = (
+  <span>
+    No parent tree found under selected orchard(s)
   </span>
 );

--- a/frontend/src/types/ParentTreeGeneticQualityType.ts
+++ b/frontend/src/types/ParentTreeGeneticQualityType.ts
@@ -18,6 +18,9 @@ export type SingleParentTreeGeneticObj = {
   geneticQualityValue: number;
 };
 
+/**
+ * The type returned from get parent trees by species endpoint.
+ */
 export type ParentTreeGeneticQualityType = {
   [key: string]: any;
   parentTreeId: number;


### PR DESCRIPTION
# Description
Closes #842 

### Changelog
#### New
- Empty section that informs users the orchard is empty

#### Changed
- The logic that process parent tree data

#### Removed
- None

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media0.giphy.com/media/42wQXwITfQbDGKqUP7/giphy.gif" width="150" />

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-43-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-43-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-43-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)