### PR TITLE
feat: update seedlot with spz information

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
@@ -4,6 +4,7 @@ import ca.bc.gov.backendstartapi.dto.DescribedEnumDto;
 import ca.bc.gov.backendstartapi.dto.FavouriteActivityCreateDto;
 import ca.bc.gov.backendstartapi.dto.FavouriteActivityUpdateDto;
 import ca.bc.gov.backendstartapi.dto.ForestClientDto;
+import ca.bc.gov.backendstartapi.dto.SeedPlanZoneDto;
 import ca.bc.gov.backendstartapi.vo.parser.ConeAndPollenCount;
 import ca.bc.gov.backendstartapi.vo.parser.SmpMixVolume;
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
@@ -18,6 +19,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
   FavouriteActivityUpdateDto.class,
   ForestClientDto.class,
   ConeAndPollenCount.class,
+  SeedPlanZoneDto.class,
   SmpMixVolume.class,
 })
 @ImportRuntimeHints(value = {HttpServletRequestRuntimeHint.class})

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/dto/SeedPlanZoneDto.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/dto/SeedPlanZoneDto.java
@@ -1,12 +1,16 @@
 package ca.bc.gov.backendstartapi.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /** This class represents a JSON response when requesting SPZ information from a SPU. */
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "represents a JSON response when requesting SPZ information from a SPU.")
 public class SeedPlanZoneDto {
 

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/dto/SeedPlanZoneDto.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/dto/SeedPlanZoneDto.java
@@ -1,0 +1,43 @@
+package ca.bc.gov.backendstartapi.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+/** This class represents a JSON response when requesting SPZ information from a SPU. */
+@Getter
+@Setter
+@Schema(description = "represents a JSON response when requesting SPZ information from a SPU.")
+public class SeedPlanZoneDto {
+
+  @Schema(
+      description = "A unique identifier which is assigned to a Seed Planning Unit.",
+      example = "7")
+  private Integer seedPlanUnitId;
+
+  @Schema(
+      description = "A unique identifier which is assigned to a Seed Planning Zone.",
+      example = "40")
+  private Integer seedPlanZoneId;
+
+  @Schema(description = "A code describing various Genetic Classes.", example = "A")
+  private Character geneticClassCode;
+
+  @Schema(description = "A code describing various Seed Planning Zones.", example = "M")
+  private String seedPlanZoneCode;
+
+  @Schema(description = "A code describing various Vegetation Species.", example = "FDC")
+  private String vegetationCode;
+
+  @Schema(
+      description =
+          "Minimum elevation (metres) for a specific elevation band for the Seed Planning Unit",
+      example = "0")
+  private Integer elevationMin;
+
+  @Schema(
+      description =
+          "Maximum elevation (metres) for a specific elevation band for the Seed Planning Unit",
+      example = "700")
+  private Integer elevationMax;
+}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/entity/SeedlotSeedPlanZoneEntity.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/entity/SeedlotSeedPlanZoneEntity.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 
 /** This class represents a Seedlot Seed Plan Zone entity. */
 @Entity
-@Table(name = "seedlot_smp_mix")
+@Table(name = "seedlot_seed_plan_zone")
 @IdClass(SeedlotSeedPlanZoneId.class)
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @RequiredArgsConstructor

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
@@ -9,7 +9,6 @@ import ca.bc.gov.backendstartapi.dto.SameSpeciesTreeDto;
 import ca.bc.gov.backendstartapi.dto.SeedPlanZoneDto;
 import ca.bc.gov.backendstartapi.filter.RequestCorrelation;
 import ca.bc.gov.backendstartapi.security.LoggedUserService;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -165,8 +164,13 @@ public class OracleApiProvider implements Provider {
         "Starting {} - {} request to {}", PROVIDER, "getSpzInformationBySpuIds", oracleApiUrl);
 
     try {
-      Map<String, Object[]> uriVars = new HashMap<>();
-      uriVars.put("spuIds", spuIds.toArray());
+      StringBuilder sb = new StringBuilder();
+      for (Integer id : spuIds) {
+        if (!sb.isEmpty()) {
+          sb.append(",");
+        }
+        sb.append(id);
+      }
 
       ResponseEntity<List<SeedPlanZoneDto>> seedPlanZoneResult =
           restTemplate.exchange(
@@ -174,7 +178,7 @@ public class OracleApiProvider implements Provider {
               HttpMethod.GET,
               new HttpEntity<>(addHttpHeaders()),
               new ParameterizedTypeReference<List<SeedPlanZoneDto>>() {},
-              uriVars);
+              createParamsMap("spuIds", sb.toString()));
       List<SeedPlanZoneDto> list = seedPlanZoneResult.getBody();
       int size = list == null ? 0 : list.size();
       SparLog.info("GET SPZ from Oracle - Success response with {} record(s)!", size);

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
@@ -6,8 +6,10 @@ import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.OrchardSpuDto;
 import ca.bc.gov.backendstartapi.dto.ParentTreeDto;
 import ca.bc.gov.backendstartapi.dto.SameSpeciesTreeDto;
+import ca.bc.gov.backendstartapi.dto.SeedPlanZoneDto;
 import ca.bc.gov.backendstartapi.filter.RequestCorrelation;
 import ca.bc.gov.backendstartapi.security.LoggedUserService;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -148,6 +150,38 @@ public class OracleApiProvider implements Provider {
     } catch (HttpClientErrorException httpExc) {
       SparLog.error(
           "POST spu to oracle to get parent trees with vegCode - Response code error: {}, {}",
+          httpExc.getStatusCode(),
+          httpExc.getMessage());
+      throw new ResponseStatusException(httpExc.getStatusCode(), httpExc.getMessage());
+    }
+  }
+
+  @Override
+  public List<SeedPlanZoneDto> getSpzInformationBySpuIds(List<Integer> spuIds) {
+    String oracleApiUrl =
+        String.format("%s/api/orchards/spz-information-by-spu-ids/{spuIds}", rootUri);
+
+    SparLog.info(
+        "Starting {} - {} request to {}", PROVIDER, "getSpzInformationBySpuIds", oracleApiUrl);
+
+    try {
+      Map<String, Object[]> uriVars = new HashMap<>();
+      uriVars.put("spuIds", spuIds.toArray());
+
+      ResponseEntity<List<SeedPlanZoneDto>> seedPlanZoneResult =
+          restTemplate.exchange(
+              oracleApiUrl,
+              HttpMethod.GET,
+              new HttpEntity<>(addHttpHeaders()),
+              new ParameterizedTypeReference<List<SeedPlanZoneDto>>() {},
+              uriVars);
+      List<SeedPlanZoneDto> list = seedPlanZoneResult.getBody();
+      int size = list == null ? 0 : list.size();
+      SparLog.info("GET SPZ from Oracle - Success response with {} record(s)!", size);
+      return list;
+    } catch (HttpClientErrorException httpExc) {
+      SparLog.error(
+          "GET SPZ from Oracle - Response code error: {}, {}",
           httpExc.getStatusCode(),
           httpExc.getMessage());
       throw new ResponseStatusException(httpExc.getStatusCode(), httpExc.getMessage());

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/provider/Provider.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/provider/Provider.java
@@ -5,6 +5,7 @@ import ca.bc.gov.backendstartapi.dto.ForestClientLocationDto;
 import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.OrchardSpuDto;
 import ca.bc.gov.backendstartapi.dto.SameSpeciesTreeDto;
+import ca.bc.gov.backendstartapi.dto.SeedPlanZoneDto;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,10 @@ public interface Provider {
 
   default List<SameSpeciesTreeDto> findParentTreesByVegCode(
       String vegCode, Map<String, String> orchardSpuMap) {
+    return List.of();
+  }
+
+  default List<SeedPlanZoneDto> getSpzInformationBySpuIds(List<Integer> spuIds) {
     return List.of();
   }
 

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/repository/SeedlotSeedPlanZoneEntityRepository.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/repository/SeedlotSeedPlanZoneEntityRepository.java
@@ -1,0 +1,9 @@
+package ca.bc.gov.backendstartapi.repository;
+
+import ca.bc.gov.backendstartapi.entity.SeedlotSeedPlanZoneEntity;
+import ca.bc.gov.backendstartapi.entity.seedlot.idclass.SeedlotSeedPlanZoneId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** This interface holds methods for handling {@link SeedlotSeedPlanZoneEntity} in the database. */
+public interface SeedlotSeedPlanZoneEntityRepository
+    extends JpaRepository<SeedlotSeedPlanZoneEntity, SeedlotSeedPlanZoneId> {}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotOrchardService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotOrchardService.java
@@ -44,8 +44,7 @@ public class SeedlotOrchardService {
         formStep4.orchardsId().size(),
         seedlot.getId());
 
-    List<SeedlotOrchard> seedlotOrchards =
-        seedlotOrchardRepository.findAllBySeedlot_id(seedlot.getId());
+    List<SeedlotOrchard> seedlotOrchards = getAllSeedlotOrchardBySeedlotNumber(seedlot.getId());
 
     if (!seedlotOrchards.isEmpty()) {
       SparLog.info(
@@ -89,5 +88,15 @@ public class SeedlotOrchardService {
     }
 
     seedlotOrchardRepository.saveAll(seedlotOrchards);
+  }
+
+  /**
+   * Get all {@link SeedlotOrchard} given a {@link Seedlot} id (seedlot number).
+   *
+   * @param seedlotNumber the seedlot id
+   * @return A List of SeedlotOrchard containing the found records or an empty list.
+   */
+  public List<SeedlotOrchard> getAllSeedlotOrchardBySeedlotNumber(String seedlotNumber) {
+    return seedlotOrchardRepository.findAllBySeedlot_id(seedlotNumber);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -292,9 +292,9 @@ public class SeedlotService {
   }
 
   private void setSeedlotSpzInformation(Seedlot seedlot) {
-    if (!seedlot.getSeedlotSource().getSeedlotSourceCode().equals("TST")) {
+    if (!seedlot.getSeedlotSource().getSeedlotSourceCode().equals("TPT")) {
       SparLog.warn(
-          "Skipping SPZ information for seedlot {}, due the seedlot source code not be tested!",
+          "Skipping SPZ information for seedlot {}, due the seedlot source code not being tested!",
           seedlot.getId());
       return;
     }

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -347,6 +347,7 @@ public class SeedlotService {
               spz.getSeedPlanZoneCode(),
               spz.getSeedPlanZoneId(),
               classEntity.orElseThrow(InvalidSeedlotRequestException::new));
+      spzEntity.setAuditInformation(new AuditInformation(loggedUserService.getLoggedUserId()));
 
       seedlotSeedPlanZoneEntityRepository.saveAndFlush(spzEntity);
 

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
@@ -14,6 +14,7 @@ import ca.bc.gov.backendstartapi.dto.SeedlotFormOrchardDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormOwnershipDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormParentTreeSmpDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormSubmissionDto;
+import ca.bc.gov.backendstartapi.entity.SeedlotSourceEntity;
 import ca.bc.gov.backendstartapi.entity.SeedlotStatusEntity;
 import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
 import ca.bc.gov.backendstartapi.exception.ConeCollectionMethodNotFoundException;
@@ -22,8 +23,11 @@ import ca.bc.gov.backendstartapi.exception.SeedlotFormValidationException;
 import ca.bc.gov.backendstartapi.exception.SeedlotNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SeedlotParentTreeNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SmpMixNotFoundException;
+import ca.bc.gov.backendstartapi.provider.Provider;
+import ca.bc.gov.backendstartapi.repository.ActiveOrchardSeedPlanningUnitRepository;
 import ca.bc.gov.backendstartapi.repository.GeneticClassRepository;
 import ca.bc.gov.backendstartapi.repository.SeedlotRepository;
+import ca.bc.gov.backendstartapi.repository.SeedlotSeedPlanZoneEntityRepository;
 import ca.bc.gov.backendstartapi.repository.SeedlotSourceRepository;
 import ca.bc.gov.backendstartapi.repository.SeedlotStatusRepository;
 import ca.bc.gov.backendstartapi.security.LoggedUserService;
@@ -71,6 +75,12 @@ class SeedlotFormPutTest {
   @Mock SeedlotParentTreeSmpMixService seedlotParentTreeSmpMixService;
 
   @Mock SeedlotStatusService seedlotStatusService;
+
+  @Mock ActiveOrchardSeedPlanningUnitRepository activeOrchardSeedPlanningUnitRepository;
+
+  @Mock SeedlotSeedPlanZoneEntityRepository seedlotSeedPlanZoneEntityRepository;
+
+  @Mock Provider oracleApiProvider;
 
   private SeedlotService seedlotService;
 
@@ -173,7 +183,10 @@ class SeedlotFormPutTest {
             smpMixService,
             smpMixGeneticQualityService,
             seedlotParentTreeSmpMixService,
-            seedlotStatusService);
+            seedlotStatusService,
+            activeOrchardSeedPlanningUnitRepository,
+            seedlotSeedPlanZoneEntityRepository,
+            oracleApiProvider);
   }
 
   @Test
@@ -308,6 +321,9 @@ class SeedlotFormPutTest {
   @DisplayName("Seedlot form submit - Success")
   void submitSeedlotForm_happyPath_shouldSucceed() {
     Seedlot seedlot = new Seedlot("5432");
+    SeedlotSourceEntity seedSource = new SeedlotSourceEntity();
+    seedSource.setSeedlotSourceCode("UNT");
+    seedlot.setSeedlotSource(seedSource);
     when(seedlotRepository.findById("5432")).thenReturn(Optional.of(seedlot));
 
     doNothing().when(seedlotCollectionMethodService).saveSeedlotFormStep1(any(), any());

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -17,8 +17,11 @@ import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
 import ca.bc.gov.backendstartapi.exception.InvalidSeedlotRequestException;
 import ca.bc.gov.backendstartapi.exception.SeedlotNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SeedlotSourceNotFoundException;
+import ca.bc.gov.backendstartapi.provider.Provider;
+import ca.bc.gov.backendstartapi.repository.ActiveOrchardSeedPlanningUnitRepository;
 import ca.bc.gov.backendstartapi.repository.GeneticClassRepository;
 import ca.bc.gov.backendstartapi.repository.SeedlotRepository;
+import ca.bc.gov.backendstartapi.repository.SeedlotSeedPlanZoneEntityRepository;
 import ca.bc.gov.backendstartapi.repository.SeedlotSourceRepository;
 import ca.bc.gov.backendstartapi.repository.SeedlotStatusRepository;
 import ca.bc.gov.backendstartapi.security.LoggedUserService;
@@ -68,6 +71,12 @@ class SeedlotServiceTest {
 
   @Mock SeedlotStatusService seedlotStatusService;
 
+  @Mock ActiveOrchardSeedPlanningUnitRepository activeOrchardSeedPlanningUnitRepository;
+
+  @Mock SeedlotSeedPlanZoneEntityRepository seedlotSeedPlanZoneEntityRepository;
+
+  @Mock Provider oracleApiProvider;
+
   private SeedlotService seedlotService;
 
   private static final String BAD_REQUEST_STR = "400 BAD_REQUEST \"Invalid Seedlot request\"";
@@ -100,7 +109,10 @@ class SeedlotServiceTest {
             smpMixService,
             smpMixGeneticQualityService,
             seedlotParentTreeSmpMixService,
-            seedlotStatusService);
+            seedlotStatusService,
+            activeOrchardSeedPlanningUnitRepository,
+            seedlotSeedPlanZoneEntityRepository,
+            oracleApiProvider);
   }
 
   @Test


### PR DESCRIPTION
# Description
Closes #794 

### Changelog
#### New
- Methods for fetching SPZ information from Oracle;

#### Changed
- Oracle provider class
- SeedlotService when saving the form

#### Removed
- None;

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media4.giphy.com/media/cRH5deQTgTMR2/giphy.gif"/>

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-11-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-11-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-11-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)