### PR TITLE
Fix/883 empty orchard switch bug

### DIFF
--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -65,7 +65,9 @@ const ParentTreeStep = () => {
     seedlotSpecies
   } = useContext(ClassAContext);
 
-  const [orchardsData, setOrchardsData] = useState<Array<OrchardObj>>([]);
+  const [orchardsData, setOrchardsData] = useState<Array<OrchardObj>>(
+    () => processOrchards(orchards)
+  );
   const [currentTab, setCurrentTab] = useState<TabTypes>('coneTab');
   const [headerConfig, setHeaderConfig] = useState<Array<HeaderObj>>(
     structuredClone(headerTemplate)
@@ -177,7 +179,7 @@ const ParentTreeStep = () => {
    * Re-populate table if it is emptied by users and data is cached
    */
   useEffect(() => {
-    const disabled = processOrchards(orchards).length === 0;
+    const disabled = orchardsData.length === 0;
     if (
       !disabled
       && Object.keys(state.tableRowData).length === 0


### PR DESCRIPTION
# Description
Closes #883 

### Changelog
#### New
- None

#### Changed
- How the orchards state object is initialized in step 5.

#### Removed
- None

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media1.giphy.com/media/fGYwgR6JfchZ6/giphy.gif" width="120"/>

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-34-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-34-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-34-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)