### PR TITLE
Fix/882 frontend responsiveness updates

### DIFF
--- a/frontend/src/components/Card/FavouriteCard/index.tsx
+++ b/frontend/src/components/Card/FavouriteCard/index.tsx
@@ -7,6 +7,7 @@ import * as Icons from '@carbon/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FavActivityType } from '../../../types/FavActivityTypes';
 import { patchFavAct, deleteFavAct } from '../../../api-service/favouriteActivitiesAPI';
+
 import './styles.scss';
 
 interface FavouriteCardProps {

--- a/frontend/src/components/Card/SmallCard/index.tsx
+++ b/frontend/src/components/Card/SmallCard/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import * as Icons from '@carbon/icons-react';
+import * as Pictograms from '@carbon/pictograms-react';
+import { Tile } from '@carbon/react';
+import { useNavigate } from 'react-router-dom';
+
+import './styles.scss';
+
+type SmallCardProps = {
+  header: string,
+  actionBtn: JSX.Element
+  path: string,
+  image: string,
+  isIcon: boolean
+}
+
+const SmallCard = ({
+  header, actionBtn, path, isIcon, image
+}: SmallCardProps) => {
+  const navigate = useNavigate();
+
+  const Img = isIcon ? Icons[image] : Pictograms[image];
+
+  return (
+    <Tile className="small-card" onClick={() => navigate(path)}>
+      <div className="image-header">
+        <Img className="image" />
+        <p className="header">{header}</p>
+      </div>
+      <div className="action-btn">
+        {actionBtn}
+      </div>
+    </Tile>
+  );
+};
+
+export default SmallCard;

--- a/frontend/src/components/Card/SmallCard/styles.scss
+++ b/frontend/src/components/Card/SmallCard/styles.scss
@@ -1,0 +1,34 @@
+@use '@carbon/type';
+@use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
+
+.small-card {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 4rem;
+  background: var(--#{vars.$bcgov-prefix}-layer-02, #FFF);
+  border-radius: 0.25rem;
+  border: 0.0625rem solid var(--#{vars.$bcgov-prefix}-subtle-02, #DFDFE1);
+  margin-top: 0.5rem;
+
+  .image-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+      stroke-width: 0.01875rem;
+      fill: var(--#{vars.$bcgov-prefix}-link-primary, #005CB8);
+      stroke: var(--#{vars.$bcgov-prefix}-link-primary, #005CB8);
+    }
+
+    .header {
+      @include type.type-style('heading-02');
+      margin-left: 0.75rem;
+    }
+  }
+}

--- a/frontend/src/components/Card/StandardCard/index.tsx
+++ b/frontend/src/components/Card/StandardCard/index.tsx
@@ -9,8 +9,11 @@ import * as Pictograms from '@carbon/pictograms-react';
 import ActivityHistory from '../../ActivityHistory';
 
 import ActivityHistoryItems from '../../../mock-server/fixtures/ActivityHistoryItems';
+import useWindowSize from '../../../hooks/UseWindowSize';
+import { MEDIUM_SCREEN_WIDTH } from '../../../shared-constants/shared-constants';
 
 import EmptySection from '../../EmptySection';
+import SmallCard from '../SmallCard';
 
 import './styles.scss';
 
@@ -29,7 +32,28 @@ const StandardCard = ({
   header, description, url, image, type, isEmpty, emptyTitle, emptyDescription
 }: StandardCardProps) => {
   const navigate = useNavigate();
-  const Image = Pictograms[image];
+  const Image = image ? Pictograms[image] : null;
+
+  const windowSize = useWindowSize();
+
+  const ActionBtn = (
+    <IconButton className="std-card-button" kind="ghost" label="Go" align="bottom" onClick={() => { navigate(`${url}`); }}>
+      <Icons.ArrowRight />
+    </IconButton>
+  );
+
+  if (windowSize.innerWidth < MEDIUM_SCREEN_WIDTH) {
+    return (
+      <SmallCard
+        header={header}
+        actionBtn={ActionBtn}
+        path={url}
+        image={image}
+        isIcon={false}
+      />
+    );
+  }
+
   return (
     <Tile className="std-card-main" onClick={() => navigate(url)}>
       <div className="std-card-header">
@@ -40,12 +64,13 @@ const StandardCard = ({
           </div>
         </div>
         {
-          !isEmpty
-          && (
-          <IconButton className="std-card-button" kind="ghost" label="Go" align="bottom" onClick={() => { navigate(`${url}`); }}>
-            <Icons.ArrowRight />
-          </IconButton>
-          )
+          isEmpty
+            ? null
+            : (
+              <IconButton className="std-card-button" kind="ghost" label="Go" align="bottom" onClick={() => { navigate(`${url}`); }}>
+                <Icons.ArrowRight />
+              </IconButton>
+            )
         }
       </div>
       {

--- a/frontend/src/components/Card/StandardCard/styles.scss
+++ b/frontend/src/components/Card/StandardCard/styles.scss
@@ -7,10 +7,6 @@
   margin-bottom: 0.25rem;
 }
 
-.std-card-title {
-  width: 15rem;
-}
-
 p.std-card-title {
   @include type.type-style('heading-03');
 }

--- a/frontend/src/components/Card/StandardCard/styles.scss
+++ b/frontend/src/components/Card/StandardCard/styles.scss
@@ -20,8 +20,7 @@ p.std-card-title {
   display: flex;
   flex-direction: column;
   padding: 1.25rem 1rem;
-  margin: 0.5rem 2rem 0.5rem 0;
-  width: 20.25rem;
+  width: 100%;
   height: 22.5625rem;
   background: var(--#{vars.$bcgov-prefix}-layer-02);
   border: 1px solid var(--#{vars.$bcgov-prefix}-border-subtle-02);
@@ -29,6 +28,7 @@ p.std-card-title {
   flex: none;
   order: 0;
   flex-grow: 0;
+  margin-top: 1rem;
 }
 
 .std-card-main:hover {
@@ -40,12 +40,12 @@ p.std-card-title {
   display: inline-block;
 }
 
-.std-card-header > h5 {
+.std-card-header>h5 {
   font-weight: 700;
   display: block;
 }
 
-.std-card-description > p {
+.std-card-description>p {
   font-size: 0.875rem;
   margin-bottom: auto;
   color: var(--#{vars.$bcgov-prefix}-text-secondary);
@@ -58,16 +58,16 @@ p.std-card-title {
 }
 
 .std-card-pictogram {
-  width: 9.75rem !important;
-  height: 9.75rem !important;
-  padding: 0rem !important;
-  margin-bottom: 1.25rem !important;
+  width: 9.75rem;
+  height: 9.75rem;
+  padding: 0rem;
+  margin-bottom: 1.25rem;
   color: var(--#{vars.$bcgov-prefix}-focus);
   position: absolute;
   bottom: 0;
 }
 
-.#{vars.$bcgov-prefix}--overflow-menu.#{vars.$bcgov-prefix}--overflow-menu--open >svg {
+.#{vars.$bcgov-prefix}--overflow-menu.#{vars.$bcgov-prefix}--overflow-menu--open>svg {
   fill: var(--#{vars.$bcgov-prefix}-icon-primary);
 }
 

--- a/frontend/src/components/FavouriteActivities/index.tsx
+++ b/frontend/src/components/FavouriteActivities/index.tsx
@@ -13,10 +13,14 @@ import Card from '../Card/FavouriteCard';
 import EmptySection from '../EmptySection';
 import Subtitle from '../Subtitle';
 import { getFavAct } from '../../api-service/favouriteActivitiesAPI';
+import useWindowSize from '../../hooks/UseWindowSize';
 
 import './styles.scss';
+import { MEDIUM_SCREEN_WIDTH } from '../../shared-constants/shared-constants';
 
 const FavouriteActivities = () => {
+  const windowSize = useWindowSize();
+
   const favActQueryKey = ['favourite-activities'];
 
   const favActQuery = useQuery({
@@ -25,7 +29,12 @@ const FavouriteActivities = () => {
   });
 
   return (
-    <Row className="favourite-activities">
+    <Row
+      className={
+        `favourite-activities ${windowSize.innerWidth < MEDIUM_SCREEN_WIDTH
+          ? 'favourite-activities-sm-padding' : 'favourite-activities-padding'}`
+      }
+    >
       <Column sm={4} md={8} lg={16} xlg={4} className="favourite-activities-title">
         <h2>My favourite activities</h2>
         <Subtitle text="Quick access to your favourite activities." className="favourite-activities-subtitle" />
@@ -34,31 +43,37 @@ const FavouriteActivities = () => {
           align="top"
           label="You can add a shortcut to your favourite activity by clicking on the heart icon inside each page."
         >
-          <button className="tooltip-button" type="button">
+          <button className="tooltip-button" type="button" aria-label="tooltip-button">
             <Information />
           </button>
         </Tooltip>
       </Column>
       <Column sm={4} md={8} lg={16} xlg={12} className="favourite-activities-cards">
         <Row>
-          {favActQuery.isLoading ? <Loading withOverlay={false} /> : null}
-          {favActQuery.isSuccess && favActQuery.data && (
-            (favActQuery.data.length === 0)
-              ? (
-                <EmptySection
-                  icon="Application"
-                  title="You don't have any favourites to show yet!"
-                  description="You can favourite your most used activities by clicking on the heart icon
+          {
+            favActQuery.isLoading ? <Loading withOverlay={false} /> : null
+          }
+          {
+            favActQuery.isSuccess
+            && favActQuery.data
+            && (
+              favActQuery.data.length === 0
+                ? (
+                  <EmptySection
+                    icon="Application"
+                    title="You don't have any favourites to show yet!"
+                    description="You can favourite your most used activities by clicking on the heart icon
                 inside each page"
-                />
-              ) : favActQuery.data.map((favObject, index) => (
-                <Card
-                  key={favObject.type}
-                  favObject={favObject}
-                  index={index}
-                />
-              ))
-          )}
+                  />
+                ) : favActQuery.data.map((favObject, index) => (
+                  <Card
+                    key={favObject.type}
+                    favObject={favObject}
+                    index={index}
+                  />
+                ))
+            )
+          }
         </Row>
       </Column>
     </Row>

--- a/frontend/src/components/FavouriteActivities/index.tsx
+++ b/frontend/src/components/FavouriteActivities/index.tsx
@@ -43,7 +43,7 @@ const FavouriteActivities = () => {
           align="top"
           label="You can add a shortcut to your favourite activity by clicking on the heart icon inside each page."
         >
-          <button className="tooltip-button" type="button" aria-label="tooltip-button">
+          <button className="tooltip-button" type="button" aria-label="favourite activity description tooltip">
             <Information />
           </button>
         </Tooltip>
@@ -62,8 +62,8 @@ const FavouriteActivities = () => {
                   <EmptySection
                     icon="Application"
                     title="You don't have any favourites to show yet!"
-                    description="You can favourite your most used activities by clicking on the heart icon
-                inside each page"
+                    description="You can favourite your most used
+                    activities by clicking on the heart icon inside each page"
                   />
                 ) : favActQuery.data.map((favObject, index) => (
                   <Card

--- a/frontend/src/components/FavouriteActivities/styles.scss
+++ b/frontend/src/components/FavouriteActivities/styles.scss
@@ -4,33 +4,47 @@
 
 .favourite-activities {
   background-color: var(--#{vars.$bcgov-prefix}-layer-01);
+
+  .favourite-activities-title {
+    h2 {
+      @include type.type-style('heading-03');
+    }
+
+    padding-bottom: 2rem;
+  }
+
+  .favourite-activities-subtitle {
+    display: inline;
+  }
+
+  .tooltip-button {
+    padding: 0;
+    border: 0;
+    background: transparent;
+  }
+
+  button.tooltip-button>svg {
+    color: var(--#{vars.$bcgov-prefix}-text-secondary);
+  }
+
+  .favourite-activity-tooltip {
+    top: 0.1875rem;
+    padding-left: 0.3125rem;
+  }
+
+  .favourite-activities-cards {
+    padding-inline: 0;
+  }
+
+  .card-column {
+    padding: 0 1rem 0 0;
+  }
+}
+
+.favourite-activities-sm-padding{
+  padding: 2rem 1rem;
+}
+
+.favourite-activities-padding{
   padding: 2rem;
-}
-
-.favourite-activities-title>h2 {
-  @include type.type-style('heading-03');
-  margin-bottom: 0.5rem;
-}
-
-.#{vars.$bcgov-prefix}--row>.favourite-activities-title {
-  padding-left: 0.5rem;
-}
-
-.favourite-activities-subtitle {
-  display: inline;
-}
-
-.tooltip-button {
-  padding: 0;
-  border: 0;
-  background: transparent;
-}
-
-button.tooltip-button>svg {
-  color: var(--#{vars.$bcgov-prefix}-text-secondary);
-}
-
-.favourite-activity-tooltip {
-  top: 0.1875rem;
-  padding-left: 0.3125rem;
 }

--- a/frontend/src/components/SeedlotActivities/constants.ts
+++ b/frontend/src/components/SeedlotActivities/constants.ts
@@ -1,0 +1,52 @@
+import PathConstants from '../../routes/pathConstants';
+
+export const cards = [
+  {
+    id: '1',
+    image: 'Agriculture',
+    header: 'Register an A-class seedlot',
+    description:
+      'Register a seedlot which has been collected in an orchard from parent trees',
+    link: PathConstants.SEEDLOTS_A_CLASS_CREATION,
+    highlighted: false,
+    isEmpty: false,
+    emptyTitle: '',
+    emptyDescription: ''
+  },
+  {
+    id: '2',
+    image: 'Farm_01',
+    header: 'Register a B-class seedlot',
+    description:
+      'Register a seedlot which has been collected from a natural stand',
+    link: '#',
+    highlighted: false,
+    isEmpty: false,
+    emptyTitle: '',
+    emptyDescription: ''
+  },
+  {
+    id: '3',
+    image: 'Sprout',
+    header: 'My seedlots',
+    description:
+      'Consult and manage your own seedlots',
+    link: PathConstants.MY_SEEDLOTS,
+    highlighted: false,
+    isEmpty: false,
+    emptyTitle: '',
+    emptyDescription: ''
+  },
+  {
+    id: '4',
+    image: 'TimeLapse',
+    header: 'Activity history',
+    description:
+      'Get updates your latest seedlot related activities',
+    link: '#',
+    highlighted: false,
+    isEmpty: false,
+    emptyTitle: '',
+    emptyDescription: ''
+  }
+];

--- a/frontend/src/components/SeedlotActivities/index.tsx
+++ b/frontend/src/components/SeedlotActivities/index.tsx
@@ -1,82 +1,31 @@
 import React from 'react';
 
-import { Row } from '@carbon/react';
+import { Row, Column } from '@carbon/react';
 
 import StandardCard from '../Card/StandardCard';
-
-import PathConstants from '../../routes/pathConstants';
+import { cards } from './constants';
 
 import './styles.scss';
 
-const SeedlotActivities = () => {
-  const cards = [
+const SeedlotActivities = () => (
+  <Row className="seedlot-activities-cards">
     {
-      id: '1',
-      image: 'Agriculture',
-      header: 'Register an A-class seedlot',
-      description:
-        'Register a seedlot which has been collected in an orchard from parent trees',
-      link: PathConstants.SEEDLOTS_A_CLASS_CREATION,
-      highlighted: false,
-      isEmpty: false,
-      emptyTitle: '',
-      emptyDescription: ''
-    },
-    {
-      id: '2',
-      image: 'Farm_01',
-      header: 'Register a B-class seedlot',
-      description:
-        'Register a seedlot which has been collected from a natural stand',
-      link: '#',
-      highlighted: false,
-      isEmpty: false,
-      emptyTitle: '',
-      emptyDescription: ''
-    },
-    {
-      id: '3',
-      image: 'Sprout',
-      header: 'My seedlots',
-      description:
-        'Consult and manage your own seedlots',
-      link: PathConstants.MY_SEEDLOTS,
-      highlighted: false,
-      isEmpty: false,
-      emptyTitle: '',
-      emptyDescription: ''
-    },
-    {
-      id: '4',
-      image: '',
-      header: 'Activity history',
-      description:
-        'Get updates your latest seedlot related activities',
-      link: '#',
-      highlighted: false,
-      isEmpty: false,
-      emptyTitle: '',
-      emptyDescription: ''
+      cards.map((card) => (
+        <Column sm={4} md={4} lg={8} xlg={8} max={4} key={card.id}>
+          <StandardCard
+            type={card.id}
+            image={card.image}
+            header={card.header}
+            description={card.description}
+            url={card.link}
+            isEmpty={card.isEmpty}
+            emptyTitle={card.emptyTitle}
+            emptyDescription={card.emptyDescription}
+          />
+        </Column>
+      ))
     }
-  ];
-
-  return (
-    <Row className="seedlot-activities-cards">
-      {cards.map((card) => (
-        <StandardCard
-          key={card.id}
-          type={card.id}
-          image={card.image}
-          header={card.header}
-          description={card.description}
-          url={card.link}
-          isEmpty={card.isEmpty}
-          emptyTitle={card.emptyTitle}
-          emptyDescription={card.emptyDescription}
-        />
-      ))}
-    </Row>
-  );
-};
+  </Row>
+);
 
 export default SeedlotActivities;

--- a/frontend/src/components/SeedlotActivities/styles.scss
+++ b/frontend/src/components/SeedlotActivities/styles.scss
@@ -1,4 +1,5 @@
+@use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
+
 .seedlot-activities-cards {
-  margin-left: 2rem;
-  margin-right: 2.5rem;
+  margin: 1rem 1.5rem 2rem 1.5rem;
 }

--- a/frontend/src/components/StatusTag/styles.scss
+++ b/frontend/src/components/StatusTag/styles.scss
@@ -1,3 +1,4 @@
 .status-tag {
   white-space: nowrap;
+  margin: 0;
 }

--- a/frontend/src/views/Seedlot/MySeedlots/index.tsx
+++ b/frontend/src/views/Seedlot/MySeedlots/index.tsx
@@ -15,6 +15,8 @@ import PageTitle from '../../../components/PageTitle';
 import AuthContext from '../../../contexts/AuthContext';
 import SeedlotTable from '../../../components/SeedlotTable';
 import PathConstants from '../../../routes/pathConstants';
+import useWindowSize from '../../../hooks/UseWindowSize';
+import { MEDIUM_SCREEN_WIDTH } from '../../../shared-constants/shared-constants';
 
 import { tableText } from './constants';
 
@@ -22,6 +24,7 @@ import './styles.scss';
 
 const MySeedlots = () => {
   const navigate = useNavigate();
+  const windowSize = useWindowSize();
   const { user } = useContext(AuthContext);
 
   const userId = user?.userId ?? '';
@@ -34,7 +37,7 @@ const MySeedlots = () => {
         </Breadcrumb>
       </Row>
       <Row className="my-seedlot-title">
-        <Column sm={4} md={6} lg={14} xlg={12}>
+        <Column className="no-padding-col" sm={4} md={6} lg={12} xlg={12}>
           <PageTitle
             title={tableText.pageTitle}
             subtitle={tableText.pageSubtitle}
@@ -42,12 +45,12 @@ const MySeedlots = () => {
             activity="mySeedlots"
           />
         </Column>
-        <Column sm={4} md={2} lg={2} xlg={4}>
+        <Column className="no-padding-col" sm={4} md={2} lg={4} xlg={4}>
           <Button
             kind="primary"
             onClick={() => { navigate(PathConstants.SEEDLOTS_A_CLASS_CREATION); }}
             size="lg"
-            className="btn-my-seedlot"
+            className={`reg-seedlot-btn ${windowSize.innerWidth >= MEDIUM_SCREEN_WIDTH ? 'reg-btn-float-right' : null}`}
             renderIcon={Add}
           >
             {tableText.buttonText}

--- a/frontend/src/views/Seedlot/MySeedlots/styles.scss
+++ b/frontend/src/views/Seedlot/MySeedlots/styles.scss
@@ -1,22 +1,29 @@
 @use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
 
 .my-seedlot-content {
+  padding-inline: 0;
+
   .my-seedlot-breadcrumb {
-    padding-left: 1rem;
-    margin-bottom: 0.5rem;
+    margin: 0 2.5rem 0.5rem 2.5rem;
   }
 
   .title-section {
-    padding-left: 0;
-    margin-left: 0;
+    padding: 0;
   }
 
   .my-seedlot-title {
     justify-content: space-between;
-    margin-bottom: 2rem;
+    margin: 0 2.5rem 2.5rem 2.5rem;
   }
 
-  .btn-my-seedlot {
+  .reg-seedlot-btn {
+    width: fit-content;
+    max-width: 16rem;
+    margin-top: 1rem;
+    text-wrap: nowrap;
+  }
+
+  .reg-btn-float-right {
     float: right;
   }
 
@@ -34,6 +41,10 @@
   }
 
   .my-seedlot-data-table-row {
-    margin: auto -2.5rem;
+    margin-inline: 0;
+  }
+
+  .no-padding-col {
+    padding: 0;
   }
 }

--- a/frontend/src/views/Seedlot/MySeedlots/styles.scss
+++ b/frontend/src/views/Seedlot/MySeedlots/styles.scss
@@ -20,7 +20,7 @@
     width: fit-content;
     max-width: 16rem;
     margin-top: 1rem;
-    text-wrap: nowrap;
+    white-space: nowrap;
   }
 
   .reg-btn-float-right {

--- a/frontend/src/views/Seedlot/SeedlotDashboard/RecentSeedlots/styles.scss
+++ b/frontend/src/views/Seedlot/SeedlotDashboard/RecentSeedlots/styles.scss
@@ -6,14 +6,14 @@
 }
 
 .recent-seedlots {
-  background-color: var(--#{vars.$bcgov-prefix}-layer-02) !important;
-  margin: 1.5rem 2rem 2rem 2rem;
+  background-color: var(--#{vars.$bcgov-prefix}-layer-02);
+  margin: 0 2.5rem;
   border: 1px solid var(--#{vars.$bcgov-prefix}-border-subtle-02);
   border-radius: 4px;
 }
 
 .seedlot-table {
-  padding: 0 !important;
+  padding: 0;
 }
 
 .recent-seedlots-title {
@@ -26,7 +26,7 @@
 }
 
 .recent-seedlots-table {
-  padding: 0 !important;
+  padding: 0;
 }
 
 .empty-recent-seedlots {

--- a/frontend/src/views/Seedlot/SeedlotDashboard/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotDashboard/index.tsx
@@ -12,7 +12,7 @@ import './styles.scss';
 
 const SeedlotDashboard = () => (
   <FlexGrid className="seedlot-page">
-    <Row>
+    <Row className="title-row">
       <PageTitle
         title="Seedlots"
         subtitle="Register and manage your seedlots"

--- a/frontend/src/views/Seedlot/SeedlotDashboard/styles.scss
+++ b/frontend/src/views/Seedlot/SeedlotDashboard/styles.scss
@@ -4,7 +4,12 @@
   padding-left: 0;
   padding-right: 0;
 
+  .title-row {
+    margin: 0;
+    margin-left: 1.5rem;
+  }
+
   .title-section {
-    margin: 0 2.5rem;
+    margin: 0;
   }
 }

--- a/frontend/src/views/Seedlot/SeedlotDashboard/styles.scss
+++ b/frontend/src/views/Seedlot/SeedlotDashboard/styles.scss
@@ -4,12 +4,7 @@
   padding-left: 0;
   padding-right: 0;
 
-  .title-section{
-    padding-left: 0;
-  }
-
-  .#{vars.$bcgov-prefix}--row {
-    margin-left: 2.5rem;
-    margin-right: 2.5rem;
+  .title-section {
+    margin: 0 2.5rem;
   }
 }

--- a/frontend/src/views/Seedlot/SeedlotDetails/SeedlotSummary/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotDetails/SeedlotSummary/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Row, Column } from '@carbon/react';
 
 import { SeedlotDisplayType } from '../../../../types/SeedlotType';
 
@@ -13,71 +14,73 @@ interface SeedlotSummaryProps {
 }
 
 const SeedlotSummary = ({ seedlot, isFetching }: SeedlotSummaryProps) => (
-  <div className="seedlot-summary">
-    <div className="seedlot-summary-title-section">
+  <Row className="seedlot-summary">
+    <Column sm={4} md={8} lg={16} className="seedlot-summary-title-section">
       <p className="seedlot-summary-title">
         Seedlot summary
       </p>
-    </div>
-    <div className="seedlot-summary-info-section">
-      <div className="seedlot-summary-seedlot-number">
-        <p className="seedlot-summary-info-label">
-          Seedlot number
-        </p>
-        {
-          renderFieldValue('seedlotNumber', isFetching, seedlot)
-        }
-      </div>
-      <div className="seedlot-summary-seedlot-class">
-        <p className="seedlot-summary-info-label">
-          Seedlot class
-        </p>
-        {
-          renderFieldValue('seedlotClass', isFetching, seedlot)
-        }
-      </div>
-      <div className="seedlot-summary-seedlot-species">
-        <p className="seedlot-summary-info-label">
-          Seedlot species
-        </p>
-        {
-          renderFieldValue('seedlotSpecies', isFetching, seedlot)
-        }
-      </div>
-      <div className="seedlot-summary-seedlot-status">
-        <p className="seedlot-summary-info-label">
-          Status
-        </p>
-        {
-          renderStatusTag(isFetching, seedlot?.seedlotStatus)
-        }
-      </div>
-      <div className="seedlot-summary-seedlot-created">
-        <p className="seedlot-summary-info-label">
-          Created at
-        </p>
-        {
-          renderFieldValue('createdAt', isFetching, seedlot)
-        }
-      </div>
-      <div className="seedlot-summary-seedlot-modified">
-        <p className="seedlot-summary-info-label">
-          Last updated
-        </p>
-        {
-          renderFieldValue('lastUpdatedAt', isFetching, seedlot)
-        }
-      </div>
-      <div className="seedlot-summary-seedlot-approved">
-        <p className="seedlot-summary-info-label">
-          Approved at
-        </p>
-        {
-          renderFieldValue('approvedAt', isFetching, seedlot)
-        }
-      </div>
-    </div>
-  </div>
+    </Column>
+    <Column sm={4} md={8} lg={16} className="seedlot-summary-info-section">
+      <Row>
+        <Column sm={2} md={2} lg={3} xlg={2} className="info-col">
+          <p className="seedlot-summary-info-label">
+            Seedlot number
+          </p>
+          {
+            renderFieldValue('seedlotNumber', isFetching, seedlot)
+          }
+        </Column>
+        <Column sm={2} md={2} lg={3} xlg={2} className="info-col">
+          <p className="seedlot-summary-info-label">
+            Seedlot class
+          </p>
+          {
+            renderFieldValue('seedlotClass', isFetching, seedlot)
+          }
+        </Column>
+        <Column sm={2} md={2} lg={3} xlg={2} className="info-col">
+          <p className="seedlot-summary-info-label">
+            Seedlot species
+          </p>
+          {
+            renderFieldValue('seedlotSpecies', isFetching, seedlot)
+          }
+        </Column>
+        <Column sm={2} md={2} lg={3} xlg={2} className="info-col">
+          <p className="seedlot-summary-info-label">
+            Status
+          </p>
+          {
+            renderStatusTag(isFetching, seedlot?.seedlotStatus)
+          }
+        </Column>
+        <Column sm={2} md={2} lg={3} xlg={2} className="info-col">
+          <p className="seedlot-summary-info-label">
+            Created at
+          </p>
+          {
+            renderFieldValue('createdAt', isFetching, seedlot)
+          }
+        </Column>
+        <Column sm={2} md={2} lg={3} xlg={2} className="info-col">
+          <p className="seedlot-summary-info-label">
+            Last updated
+          </p>
+          {
+            renderFieldValue('lastUpdatedAt', isFetching, seedlot)
+          }
+        </Column>
+        <Column sm={2} md={2} lg={3} xlg={2} className="info-col">
+          <p className="seedlot-summary-info-label">
+            Approved at
+          </p>
+          {
+            renderFieldValue('approvedAt', isFetching, seedlot)
+          }
+        </Column>
+      </Row>
+    </Column>
+  </Row>
 );
 
 export default SeedlotSummary;

--- a/frontend/src/views/Seedlot/SeedlotDetails/SeedlotSummary/styles.scss
+++ b/frontend/src/views/Seedlot/SeedlotDetails/SeedlotSummary/styles.scss
@@ -5,42 +5,38 @@
   width: auto;
   border: 1px solid var(--#{vars.$bcgov-prefix}-border-subtle-00);
   border-radius: 8px;
-  padding: 2rem;
-  margin-bottom: 3rem;
-}
+  padding: 2rem 1rem;
+  margin-top: 1rem;
+  margin-bottom: 2.5rem;
+  margin-inline: 0;
 
-.seedlot-summary-title {
-  @include type.type-style('heading-02');
-  font-weight: 700;
-  margin-bottom: 0.25rem;
-}
+  .seedlot-summary-title {
+    @include type.type-style('heading-02');
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
 
-.seedlot-summary-title-section {
-  margin-bottom: 2rem;
-}
+  .seedlot-summary-info-section>div {
+    margin-right: 3.5rem;
+  }
 
-.seedlot-summary-info-section {
-  display: flex;
-}
+  .seedlot-summary-info-label {
+    @include type.type-style('label-01');
+    margin-bottom: 0.5rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
-.seedlot-summary-info-section > div {
-  margin-right: 3.5rem;
-}
+  .seedlot-summary-seedlot-status>.seedlot-summary-info-value div.#{vars.$bcgov-prefix}--tag {
+    margin: 0;
+  }
 
-.seedlot-summary-info-label {
-  @include type.type-style('label-01');
-  margin-bottom: 0.5rem;
-}
+  p.seedlot-summary-info-value {
+    @include type.type-style('body-compact-01');
+  }
 
-.seedlot-summary-seedlot-status > .seedlot-summary-info-value div.#{vars.$bcgov-prefix}--tag {
-  margin: 0;
-}
-
-.seedlot-summary-seedlot-status > .seedlot-summary-info-label,
-.seedlot-summary-seedlot-participants > .seedlot-summary-info-label {
-  margin-bottom: 0.25rem;
-}
-
-p.seedlot-summary-info-value {
-  @include type.type-style('body-compact-01');
+  .info-col {
+    margin-top: 2rem;
+  }
 }

--- a/frontend/src/views/Seedlot/SeedlotDetails/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotDetails/index.tsx
@@ -4,8 +4,6 @@ import {
   FlexGrid,
   Row,
   Column,
-  Breadcrumb,
-  BreadcrumbItem,
   Tabs,
   TabList,
   Tab,
@@ -29,13 +27,14 @@ import { convertToApplicantInfoObj, covertRawToDisplayObj } from '../../../utils
 import { getForestClientByNumber } from '../../../api-service/forestClientsAPI';
 import PathConstants from '../../../routes/pathConstants';
 import { addParamToPath } from '../../../utils/PathUtils';
+import { MEDIUM_SCREEN_WIDTH } from '../../../shared-constants/shared-constants';
+import Breadcrumbs from '../../../components/Breadcrumbs';
 
 import SeedlotSummary from './SeedlotSummary';
 import ApplicantInformation from './ApplicantInformation';
 import FormProgress from './FormProgress';
 
 import './styles.scss';
-import { MEDIUM_SCREEN_WIDTH } from '../../../shared-constants/shared-constants';
 
 const SeedlotDetails = () => {
   const navigate = useNavigate();
@@ -130,14 +129,11 @@ const SeedlotDetails = () => {
   return (
     <FlexGrid className="seedlot-details-page">
       <Row className="seedlot-details-breadcrumb">
-        <Breadcrumb>
-          <BreadcrumbItem onClick={() => navigate(PathConstants.SEEDLOTS)}>
-            Seedlots
-          </BreadcrumbItem>
-          <BreadcrumbItem onClick={() => navigate(PathConstants.MY_SEEDLOTS)}>
-            My seedlots
-          </BreadcrumbItem>
-        </Breadcrumb>
+        <Breadcrumbs crumbs={[
+          { name: 'Seedlots', path: PathConstants.SEEDLOTS },
+          { name: 'My seedlots', path: PathConstants.MY_SEEDLOTS }
+        ]}
+        />
       </Row>
       <Row>
         <Column className={windowSize.innerWidth < MEDIUM_SCREEN_WIDTH ? 'summary-title-flex-col' : 'summary-title-flex-row'}>
@@ -162,11 +158,7 @@ const SeedlotDetails = () => {
         </Column>
       </Row>
 
-      <Row className="seedlot-summary-content">
-        <Column sm={4}>
-          <SeedlotSummary seedlot={seedlotData} isFetching={seedlotQuery.isFetching} />
-        </Column>
-      </Row>
+      <SeedlotSummary seedlot={seedlotData} isFetching={seedlotQuery.isFetching} />
 
       <Row className="seedlot-details-content">
         <Column>


### PR DESCRIPTION
# Description
Closes #882, #774 #772 #769 #768

To make PR review easier, I have tagged the issue number in each commit. 

Note that for #774, I can't find the problem of "No edit button" Arthur is referring to. 
And for #772, the table is cut in half but users can scroll horizontally, so I think that's the best and desired behaviour. 

### Changelog
#### New
- New Small Card component, currently being used on the Seedlot Dashboard page. Ideally the Main dashboard's favourite activity cards should use it as well, but too much refactoring is required for that so it'll be something for the future, or a test subject for a potential new team member. 

#### Changed
- Only styles are changed, some elements have been changed to `<Column>` from `<div>`. Nothing functional is changed. 

#### Removed
- None

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media3.giphy.com/media/wotqBCVmRVn2w/giphy.gif" width="200"/>

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-40-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-40-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-40-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)