### PR TITLE
Feat/891 remove the need for bceid test account for cypress

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -155,6 +155,7 @@ jobs:
     env:
       CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
       CYPRESS_USERNAME: ${{ secrets.CYPRESS_USERNAME }}
+      CYPRESS_LOGIN_SERVICE: ${{ vars.CYPRESS_LOGIN_SERVICE }}
       VITE_SERVER_URL: https://${{ github.event.repository.name }}-${{ needs.init.outputs.tag }}-backend.apps.silver.devops.gov.bc.ca
       VITE_ORACLE_SERVER_URL: https://nr-spar-test-oracle-api.apps.silver.devops.gov.bc.ca
       VITE_USER_POOLS_ID: ${{ vars.VITE_USER_POOLS_ID }}

--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -65,8 +65,8 @@ VITE_USER_POOLS_WEB_CLIENT_ID=<pools-web-client-id>
 
 And if you want to run Cypress, please add:
 ```
-CYPRESS_USERNAME=
-CYPRESS_PASSWORD=
+CYPRESS_USERNAME=<YOUR IDIR USERNAME>
+CYPRESS_PASSWORD=<YOUR IDIR PASSWORD>
 ```
 
 > If don't have these values, please reach a member of the team

--- a/frontend/cypress/constants.ts
+++ b/frontend/cypress/constants.ts
@@ -5,5 +5,3 @@ export const THREE_SECONDS = 3 * ONE_SECOND;
 export const FIVE_SECONDS = 5 * ONE_SECOND;
 export const TEN_SECONDS = 10 * ONE_SECOND;
 export const TYPE_DELAY = 50;
-export const USERNAME = 'NRS Load Test-3';
-export const BCEID_NAME = 'LOAD-3-TEST';

--- a/frontend/cypress/e2e/smoke-test/login-page.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/login-page.cy.ts
@@ -1,4 +1,4 @@
-import { BCEID_NAME, FIVE_SECONDS, USERNAME } from '../../constants';
+import { FIVE_SECONDS } from '../../constants';
 
 describe('Login page test', () => {
   let loginPageData: {
@@ -21,7 +21,7 @@ describe('Login page test', () => {
     cy.getByDataTest('landing-desc').should('have.text', loginPageData.description);
   });
 
-  it('should navigate to the user form page IDIR', () => {
+  it('should navigate to the IDIR login page', () => {
     cy.visit('/');
     cy.getByDataTest('landing-button__idir').click();
     cy.url().then((url) => {
@@ -35,7 +35,7 @@ describe('Login page test', () => {
     });
   });
 
-  it('should navigate to the user form page BCeID', () => {
+  it('should navigate to the BCeID login page', () => {
     cy.visit('/');
     cy.getByDataTest('landing-button__bceid').click();
     cy.url().then((url) => {
@@ -54,21 +54,14 @@ describe('Login page test', () => {
     cy.getByDataTest('landing-title').should('have.text', loginPageData.title);
   });
 
-  it('can log in with BCeID and validate user role', () => {
+  it('can log in with BCeID/IDIR and validate user role', () => {
+    const loginService = Cypress.env('LOGIN_SERVICE') === 'BCeID' ? 'BCeID: ' : 'IDIR: ';
     cy.login();
     cy.visit('/dashboard');
     cy.url().should('contains', '/dashboard');
     cy.contains('Main activities');
     cy.getByDataTest('header-button__user').click();
-    cy.get('.user-data').find('p').contains(`BCeID: ${BCEID_NAME}`);
-  });
-
-  it('can log in with BCeID and validate user information', () => {
-    cy.login();
-    cy.visit('/dashboard');
-    cy.url().should('contains', '/dashboard');
-    cy.contains('Main activities');
-    cy.getByDataTest('header-button__user').click();
-    cy.get('.user-data').find('p').contains(USERNAME);
+    cy.get('.user-data').find('p').contains(loginService);
+    cy.get('.user-data').find('p').contains('@');
   });
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -14,20 +14,23 @@ Cypress.Commands.add('login', () => {
     username: Cypress.env('USERNAME'),
     password: Cypress.env('PASSWORD'),
     timeout: HALF_SECOND,
+    loginService: Cypress.env('LOGIN_SERVICE') ?? 'IDIR',
     delay: TYPE_DELAY
   };
 
   cy.session(
     config.username,
     () => {
+      const loginBtnId = `landing-button__${config.loginService.toLowerCase()}`;
+      const loginLogo = `#${config.loginService.toLowerCase()}Logo`;
       cy.clearAllCookies();
       cy.clearAllLocalStorage();
       cy.clearAllSessionStorage();
       cy.visit('/');
-      cy.getByDataTest('landing-button__bceid').click();
+      cy.getByDataTest(loginBtnId).click();
       cy.url().then((url) => {
         if (url.includes('.gov.bc.ca')) {
-          cy.get('#bceidLogo', { timeout: config.timeout }).should('be.visible');
+          cy.get(loginLogo, { timeout: config.timeout }).should('be.visible');
           cy.get('input[name=user]')
             .clear()
             .type(config.username, { delay: config.delay });
@@ -44,7 +47,7 @@ Cypress.Commands.add('login', () => {
                 username, password, delay, timeout
               }
             ) => {
-              cy.get('#bceidLogo', { timeout }).should('be.visible');
+              cy.get(loginLogo, { timeout }).should('be.visible');
               cy.get('input[name=user]')
                 .clear()
                 .type(username, { delay });


### PR DESCRIPTION
# Description
Closes #891
Dev should uses their own IDIR account for local cypress test. Update your `CYPRESS_USERNAME` and `CYPRESS_PASSWORD` accordingly.

GitHub actions will use the BCeID test account.

### Changelog
#### New
- None

#### Changed
- Login through different ID provider depends on the environment

#### Removed
- None

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [x] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media0.giphy.com/media/kYLPweIoQBPcEAcoQ0/giphy-downsized-medium.gif" width="200" />


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-42-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-42-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-42-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)