### PR TITLE
chore(ci): bump PR db PVC size to silence nag emails

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -98,7 +98,7 @@ jobs:
           - name: database
             file: database/openshift.deploy.yml
             parameters:
-              -p DB_PVC_SIZE=128Mi
+              -p DB_PVC_SIZE=192Mi
             overwrite: false
           - name: backend
             file: backend/openshift.deploy.yml

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -35,7 +35,6 @@ parameters:
   - name: DB_PVC_SIZE
     description: Volume space available for data, e.g. 512Mi, 2Gi.
     displayName: Database Volume Capacity
-    required: true
     value: 256Mi
   - name: MIN_REPLICAS
     description: Dummy value for workflow convenience


### PR DESCRIPTION
Nag messages from OCIO are complaining about PVC being near capacity.  We should haven't to adjust, but we do.  Here's the adjustment.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-46-frontend.apps.silver.devops.gov.bc.ca/)
[Backend](https://nr-spar-46-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Oracle-API](https://nr-spar-46-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge-main.yml)