### PR TITLE
feat: Create DB Migration for ETL Tool monitoring tables

### DIFF
--- a/backend/src/main/resources/db/migration/V29__create_etl_tool_monitoring_tables.sql
+++ b/backend/src/main/resources/db/migration/V29__create_etl_tool_monitoring_tables.sql
@@ -1,0 +1,61 @@
+create table if not exists spar.ETL_EXECUTION_MAP(
+interface_id varchar(100) not null,
+source_file varchar(200),
+source_name varchar(100),
+source_table varchar(100),
+target_file varchar(200),
+target_name varchar(100),
+target_table varchar(100),
+truncate_before_run boolean default false not null,
+updated_at  timestamp   default now() not null,
+created_at  timestamp   default now() not null,
+constraint etl_execution_map_pk
+    primary key (interface_id)
+);
+
+comment on table spar.ETL_EXECUTION_MAP is 'ETL Tool monitoring table to store execution details of batch processing interfaces';
+comment on column spar.ETL_EXECUTION_MAP.interface_id               is 'Unique interface name to represent a batch execution';
+comment on column spar.ETL_EXECUTION_MAP.source_file                is 'Source instruction file for batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.source_name                is 'Source name of this batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.source_table               is 'Source table (if it is a single table) of this batch execution';
+comment on column spar.ETL_EXECUTION_MAP.target_file                is 'Target instruction file for batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.target_name                is 'Target name of this batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.target_table               is 'Target table (if it is a single table) of this batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.truncate_before_run        is 'If the target table should be truncated before the batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.updated_at                 is 'Timestamp of the last time this record was updated'; 
+comment on column spar.ETL_EXECUTION_MAP.created_at                 is 'Timestamp of the time this record was created'; 
+
+
+create table spar.ETL_EXECUTION_LOG(
+interface_id varchar(100) not null,
+last_run_ts timestamp,
+current_run_ts timestamp,
+updated_at  timestamp   default now() not null,
+created_at  timestamp   default now() not null
+);
+
+
+comment on table spar.ETL_EXECUTION_LOG is 'ETL Tool monitoring table to store execution current instance of batch processing interfaces';
+comment on column spar.ETL_EXECUTION_LOG.interface_id               is 'Unique interface name to represent a batch execution';
+comment on column spar.ETL_EXECUTION_MAP.last_run_ts                is 'Last timestamp this interface was executed for batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.current_run_ts             is 'Current timestamp this interface was executed of this batch execution'; 
+comment on column spar.ETL_EXECUTION_MAP.updated_at                 is 'Timestamp of the last time this record was updated'; 
+comment on column spar.ETL_EXECUTION_MAP.created_at                 is 'Timestamp of the time this record was created'; 
+
+create table spar.ETL_EXECUTION_LOG_HIST(
+interface_id varchar(100) not null,
+last_run_ts timestamp,
+current_run_ts timestamp,
+execution_details text,
+updated_at  timestamp   default now() not null,
+created_at  timestamp   default now() not null
+);
+
+
+comment on table spar.ETL_EXECUTION_LOG_HIST is 'ETL Tool monitoring table to store all executed instances of batch processing interfaces';
+comment on column spar.ETL_EXECUTION_LOG_HIST.interface_id               is 'Unique interface name to represent a batch execution';
+comment on column spar.ETL_EXECUTION_LOG_HIST.last_run_ts                is 'Last timestamp this interface was executed for batch execution'; 
+comment on column spar.ETL_EXECUTION_LOG_HIST.current_run_ts             is 'Current timestamp this interface was executed of this batch execution'; 
+comment on column spar.ETL_EXECUTION_LOG_HIST.execution_details          is 'Reference text of this interface instance execution'; 
+comment on column spar.ETL_EXECUTION_LOG_HIST.updated_at                 is 'Timestamp of the last time this record was updated'; 
+comment on column spar.ETL_EXECUTION_LOG_HIST.created_at                 is 'Timestamp of the time this record was created'; 


### PR DESCRIPTION
# Description
Create monitoring tables (ETL_EXECUTION_LOG_HIST, ETL_EXECUTION_LOG and ETL_EXECUTION_MAP) to store interface executions of batch processes. 

Refers to issue 35 of old spar-data-sync repo. 

### Changelog
#### New
-

#### Changed
-

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
