### PR TITLE
Fix/redeploy all

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -252,5 +252,5 @@ jobs:
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.component }}
-          target: test
+          target: latest
           tags: prod

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -142,6 +142,7 @@ jobs:
             -p MAX_REPLICAS=2
             -p NAME=${{ github.event.repository.name }}
             -p ZONE=${{ github.event.number }}
+            -p IMAGE_TAG=${{ github.event.number }}
             ${{ matrix.parameters }}
           triggers: ${{ matrix.triggers }}
           verification_path: ${{ matrix.verification_path}}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -85,7 +85,7 @@ objects:
         - name: ${IMAGE_TAG}
           from:
             kind: DockerImage
-            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
+            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
           referencePolicy:
             type: Local
   - apiVersion: v1

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
@@ -195,7 +195,7 @@ public class OracleApiProvider implements Provider {
 
   @Override
   public List<ParentTreeLocInfoDto> getParentTreeLatLongByIdList(List<Integer> ptIds) {
-    String oracleApiUrl = String.format("%s/api/parent-trees/lat-long-elevation", rootUri);
+    String oracleApiUrl = String.format("%s/api/parent-trees/geospatial-data", rootUri);
 
     SparLog.info(
         "Starting {} - {} request to {}", PROVIDER, "getParentTreeLatLongByIdList", oracleApiUrl);

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
@@ -63,7 +63,7 @@ public class ParentTreeService {
 
       parentTreeDto.setLongitudeDegrees(parentTreeDto.getLongitudeDegrees() * -1);
 
-      // mean elevation = parent tree proportion * elevation
+      // weighted elevation = parent tree proportion * elevation
       BigDecimal weightedElevation =
           dto.proportion().multiply(new BigDecimal(parentTreeDto.getElevation()));
       parentTreeDto.setWeightedElevation(weightedElevation);

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -67,7 +67,7 @@ objects:
         - name: ${IMAGE_TAG}
           from:
             kind: DockerImage
-            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
+            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
           referencePolicy:
             type: Local
   - kind: DeploymentConfig

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="BC Seed Planning and Registry 2" />
+  <meta name="description" content="BC Seed Planning and Registry v2" />
   <link rel="manifest" href="/manifest.json" />
   <title>SPAR 2</title>
 </head>

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -75,7 +75,7 @@ objects:
         - name: ${IMAGE_TAG}
           from:
             kind: DockerImage
-            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
+            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
           referencePolicy:
             type: Local
   - apiVersion: v1

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -76,7 +76,7 @@ objects:
         - name: ${IMAGE_TAG}
           from:
             kind: DockerImage
-            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
+            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
           referencePolicy:
             type: Local
   - apiVersion: v1

--- a/oracle-api/src/main/java/ca/bc/gov/backendstartapi/endpoint/ParentTreeEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/backendstartapi/endpoint/ParentTreeEndpoint.java
@@ -34,9 +34,9 @@ public class ParentTreeEndpoint {
    * @param ptIds The {@link ParentTreeEntity} identification list.
    * @return A List of {@link ParentTreeLatLongDto} containing the result rows.
    */
-  @PostMapping("/lat-long-elevation")
+  @PostMapping("/geospatial-data")
   @Operation(
-      summary = "Request lat long for a Parent Tree ID list",
+      summary = "Request geospatial data for a Parent Tree ID list",
       description = "Fetches all lat, long and elevation data given a list of Parent Tree IDs.",
       responses = {
         @ApiResponse(
@@ -49,7 +49,7 @@ public class ParentTreeEndpoint {
       })
   public List<ParentTreeLatLongDto> getLatLongParentTreeData(
       @io.swagger.v3.oas.annotations.parameters.RequestBody(
-              description = "A list of Parent Tree id to fetch lat and long data.",
+              description = "A list of Parent Tree id to fetch geospatial data.",
               required = true)
           @RequestBody
           List<LatLongRequestDto> ptIds) {

--- a/oracle-api/src/test/java/ca/bc/gov/backendstartapi/endpoint/ParentTreeEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/backendstartapi/endpoint/ParentTreeEndpointTest.java
@@ -51,7 +51,7 @@ class ParentTreeEndpointTest {
 
     mockMvc
         .perform(
-            post("/api/parent-trees/lat-long-elevation")
+            post("/api/parent-trees/geospatial-data")
                 .with(csrf().asHeader())
                 .content(postBody.toString())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -82,7 +82,7 @@ class ParentTreeEndpointTest {
 
     mockMvc
         .perform(
-            post("/api/parent-trees/lat-long-elevation")
+            post("/api/parent-trees/geospatial-data")
                 .with(csrf().asHeader())
                 .content(postBody.toString())
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
update workflow to use IMAGE_TAG as image tag, instead of using ZONE where it can be `test` or `prod`.

`test` or `prod` deployments will both be using the `latest` tag by default.
`dev` deployments will be using PR number as the tag 