### PR TITLE
chore(ci): roll tests into .deploy.yml

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -40,123 +40,117 @@ on:
         value: ${{ jobs.deploys.outputs.triggered }}
 
 jobs:
-  check:
+  init:
+    name: Initialize
+    environment: ${{ inputs.environment }}
+    outputs:
+      modded-tag: ${{ steps.mod-tag.outputs.modded-tag }}
+      pr: ${{ steps.pr.outputs.pr }}
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-      - run: |
-          echo "-p TAG=${{ inputs.tag || needs.init.outputs.pr }}"
+      - name: Get PR Number Mod 50
+        if: github.event_name == 'pull_request'
+        id: mod-tag
+        run: echo "modded-tag=$(( ${{ inputs.target || github.event.number }} % 50 ))" >> $GITHUB_OUTPUT
 
-  # init:
-  #   name: Initialize
-  #   environment: ${{ inputs.environment }}
-  #   outputs:
-  #     modded-tag: ${{ steps.mod-tag.outputs.modded-tag }}
-  #     pr: ${{ steps.pr.outputs.pr }}test
-  #   permissions:
-  #     pull-requests: write
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Get PR Number Mod 50
-  #       if: github.event_name == 'pull_request'
-  #       id: mod-tag
-  #       run: echo "modded-tag=$(( ${{ inputs.target || github.event.number }} % 50 ))" >> $GITHUB_OUTPUT
+      # Get PR number for squash merges to main
+      - name: PR Number
+        id: pr
+        uses: bcgov-nr/action-get-pr@v0.0.1
 
-  #     # Get PR number for squash merges to main
-  #     - name: PR Number
-  #       id: pr
-  #       uses: bcgov-nr/action-get-pr@v0.0.1
+      - name: OpenShift Init
+        uses: bcgov-nr/action-deployer-openshift@v2.3.0
+        with:
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
+          oc_token: ${{ secrets.OC_TOKEN }}
+          file: common/openshift.init.yml
+          overwrite: false
+          parameters:
+            -p ZONE=${{ inputs.target || github.event.number }}
+            -p ORACLE_DB_USER=${{ secrets.DB_USER }}
+            -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
+            -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
+            -p AWS_KINESIS_STREAM='${{ secrets.AWS_KINESIS_STREAM }}'
+            -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
+            -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}'
 
-  #     - name: OpenShift Init
-  #       uses: bcgov-nr/action-deployer-openshift@v2.3.0
-  #       with:
-  #         oc_namespace: ${{ vars.OC_NAMESPACE }}
-  #         oc_server: ${{ vars.OC_SERVER }}
-  #         oc_token: ${{ secrets.OC_TOKEN }}
-  #         file: common/openshift.init.yml
-  #         overwrite: false
-  #         parameters:
-  #           -p ZONE=${{ inputs.target || github.event.number }}
-  #           -p ORACLE_DB_USER=${{ secrets.DB_USER }}
-  #           -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
-  #           -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
-  #           -p AWS_KINESIS_STREAM='${{ secrets.AWS_KINESIS_STREAM }}'
-  #           -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
-  #           -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-  #           -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}'
+  deploys:
+    name: Deploys
+    environment: ${{ inputs.environment }}
+    needs: [init]
+    outputs:
+      triggered: ${{ steps.trigger.outputs.triggered }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    strategy:
+      matrix:
+        name: [database, backend, fluentbit, frontend, oracle-api]
+        include:
+          - name: database
+            file: database/openshift.deploy.yml
+            parameters:
+              ${{ github.event_name != 'pull_request' || '-p DB_PVC_SIZE=192Mi' }}
+            overwrite: false
+          - name: backend
+            file: backend/openshift.deploy.yml
+            overwrite: true
+            parameters:
+              -p BUILD=snapshot-${{ inputs.target || github.event.number }}
+              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
+              -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
+              ${{ inputs.target != 'prod' && '' || '-p ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
+            verification_path: "actuator/health"
+          - name: fluentbit
+            file: common/openshift.fluentbit.yml
+            overwrite: true
+          - name: frontend
+            file: frontend/openshift.deploy.yml
+            overwrite: true
+            parameters:
+              -p FAM_MODDED_ZONE=${{ inputs.target || needs.init.outputs.modded-tag }}
+              -p VITE_SPAR_BUILD_VERSION=snapshot-${{ inputs.target || github.event.number }}
+              -p VITE_NRSPARWEBAPP_VERSION=${{ inputs.target || github.event.number }}
+              -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
+              -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
+              ${{ inputs.target != 'prod' && '' || '-p VITE_ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
+          - name: oracle-api
+            file: oracle-api/openshift.deploy.yml
+            overwrite: true
+            parameters:
+              -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
+              -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ inputs.target || github.event.number }}
+              -p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
+            triggers: ('oracle-api/')
+            verification_path: "actuator/health"
+    steps:
+      - uses: bcgov-nr/action-deployer-openshift@v2.3.0
+        id: deploys
+        with:
+          file: ${{ matrix.file }}
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
+          oc_token: ${{ secrets.OC_TOKEN }}
+          overwrite: ${{ matrix.overwrite }}
+          penetration_test: false
+          parameters:
+            ${{ github.event_name != 'pull_request' || '-p MIN_REPLICAS=1' }}
+            ${{ github.event_name != 'pull_request' || '-p MAX_REPLICAS=2' }}
+            -p TAG=${{ inputs.tag || needs.init.outputs.pr }}
+            -p ZONE=${{ inputs.target || github.event.number }}
+            ${{ matrix.parameters }}
+          triggers: ${{ matrix.triggers }}
+          verification_path: ${{ matrix.verification_path }}
 
-  # deploys:
-  #   name: Deploys
-  #   environment: ${{ inputs.environment }}
-  #   needs: [init]
-  #   outputs:
-  #     triggered: ${{ steps.trigger.outputs.triggered }}
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: ${{ inputs.timeout-minutes }}
-  #   strategy:
-  #     matrix:
-  #       name: [database, backend, fluentbit, frontend, oracle-api]
-  #       include:
-  #         - name: database
-  #           file: database/openshift.deploy.yml
-  #           parameters:
-  #             ${{ github.event_name != 'pull_request' || '-p DB_PVC_SIZE=192Mi' }}
-  #           overwrite: false
-  #         - name: backend
-  #           file: backend/openshift.deploy.yml
-  #           overwrite: true
-  #           parameters:
-  #             -p BUILD=snapshot-${{ inputs.target || github.event.number }}
-  #             -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
-  #             -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-  #             ${{ inputs.target != 'prod' && '' || '-p ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
-  #           verification_path: "actuator/health"
-  #         - name: fluentbit
-  #           file: common/openshift.fluentbit.yml
-  #           overwrite: true
-  #         - name: frontend
-  #           file: frontend/openshift.deploy.yml
-  #           overwrite: true
-  #           parameters:
-  #             -p FAM_MODDED_ZONE=${{ inputs.target || needs.init.outputs.modded-tag }}
-  #             -p VITE_SPAR_BUILD_VERSION=snapshot-${{ inputs.target || github.event.number }}
-  #             -p VITE_NRSPARWEBAPP_VERSION=${{ inputs.target || github.event.number }}
-  #             -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
-  #             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
-  #             ${{ inputs.target != 'prod' && '' || '-p VITE_ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
-  #         - name: oracle-api
-  #           file: oracle-api/openshift.deploy.yml
-  #           overwrite: true
-  #           parameters:
-  #             -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-  #             -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ inputs.target || github.event.number }}
-  #             -p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
-  #           triggers: ('oracle-api/')
-  #           verification_path: "actuator/health"
-  #   steps:
-  #     - uses: bcgov-nr/action-deployer-openshift@v2.3.0
-  #       id: deploys
-  #       with:
-  #         file: ${{ matrix.file }}
-  #         oc_namespace: ${{ vars.OC_NAMESPACE }}
-  #         oc_server: ${{ vars.OC_SERVER }}
-  #         oc_token: ${{ secrets.OC_TOKEN }}
-  #         overwrite: ${{ matrix.overwrite }}
-  #         penetration_test: false
-  #         parameters:
-  #           ${{ github.event_name != 'pull_request' || '-p MIN_REPLICAS=1' }}
-  #           ${{ github.event_name != 'pull_request' || '-p MAX_REPLICAS=2' }}
-  #           -p TAG=${{ inputs.tag || needs.init.outputs.pr }}
-  #           -p ZONE=${{ inputs.target || github.event.number }}
-  #           ${{ matrix.parameters }}
-  #         triggers: ${{ matrix.triggers }}
-  #         verification_path: ${{ matrix.verification_path }}
+      - id: trigger
+        run: echo "triggered=${{ steps.deploys.outputs.triggered }}" >> $GITHUB_OUTPUT
 
-  #     - id: trigger
-  #       run: echo "triggered=${{ steps.deploys.outputs.triggered }}" >> $GITHUB_OUTPUT
-
-  # tests:
-  #   name: Tests
-  #   if: inputs.test == 'true' && needs.deploys.outputs.triggered == 'true'
-  #   needs: [deploys]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/.tests.yml
+  tests:
+    name: Tests
+    if: inputs.test == 'true' && needs.deploys.outputs.triggered == 'true'
+    needs: [deploys]
+    secrets: inherit
+    uses: ./.github/workflows/.tests.yml

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -40,117 +40,123 @@ on:
         value: ${{ jobs.deploys.outputs.triggered }}
 
 jobs:
-  init:
-    name: Initialize
-    environment: ${{ inputs.environment }}
-    outputs:
-      modded-tag: ${{ steps.mod-tag.outputs.modded-tag }}
-      pr: ${{ steps.pr.outputs.pr }}test
-    permissions:
-      pull-requests: write
+  check:
     runs-on: ubuntu-22.04
     steps:
-      - name: Get PR Number Mod 50
-        if: github.event_name == 'pull_request'
-        id: mod-tag
-        run: echo "modded-tag=$(( ${{ inputs.target || github.event.number }} % 50 ))" >> $GITHUB_OUTPUT
+      - run: |
+          echo "-p TAG=${{ inputs.tag || needs.init.outputs.pr }}"
 
-      # Get PR number for squash merges to main
-      - name: PR Number
-        id: pr
-        uses: bcgov-nr/action-get-pr@v0.0.1
+  # init:
+  #   name: Initialize
+  #   environment: ${{ inputs.environment }}
+  #   outputs:
+  #     modded-tag: ${{ steps.mod-tag.outputs.modded-tag }}
+  #     pr: ${{ steps.pr.outputs.pr }}test
+  #   permissions:
+  #     pull-requests: write
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Get PR Number Mod 50
+  #       if: github.event_name == 'pull_request'
+  #       id: mod-tag
+  #       run: echo "modded-tag=$(( ${{ inputs.target || github.event.number }} % 50 ))" >> $GITHUB_OUTPUT
 
-      - name: OpenShift Init
-        uses: bcgov-nr/action-deployer-openshift@v2.3.0
-        with:
-          oc_namespace: ${{ vars.OC_NAMESPACE }}
-          oc_server: ${{ vars.OC_SERVER }}
-          oc_token: ${{ secrets.OC_TOKEN }}
-          file: common/openshift.init.yml
-          overwrite: false
-          parameters:
-            -p ZONE=${{ inputs.target || github.event.number }}
-            -p ORACLE_DB_USER=${{ secrets.DB_USER }}
-            -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
-            -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
-            -p AWS_KINESIS_STREAM='${{ secrets.AWS_KINESIS_STREAM }}'
-            -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
-            -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-            -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}'
+  #     # Get PR number for squash merges to main
+  #     - name: PR Number
+  #       id: pr
+  #       uses: bcgov-nr/action-get-pr@v0.0.1
 
-  deploys:
-    name: Deploys
-    environment: ${{ inputs.environment }}
-    needs: [init]
-    outputs:
-      triggered: ${{ steps.trigger.outputs.triggered }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    strategy:
-      matrix:
-        name: [database, backend, fluentbit, frontend, oracle-api]
-        include:
-          - name: database
-            file: database/openshift.deploy.yml
-            parameters:
-              ${{ github.event_name != 'pull_request' || '-p DB_PVC_SIZE=192Mi' }}
-            overwrite: false
-          - name: backend
-            file: backend/openshift.deploy.yml
-            overwrite: true
-            parameters:
-              -p BUILD=snapshot-${{ inputs.target || github.event.number }}
-              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
-              -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-              ${{ inputs.target != 'prod' && '' || '-p ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
-            verification_path: "actuator/health"
-          - name: fluentbit
-            file: common/openshift.fluentbit.yml
-            overwrite: true
-          - name: frontend
-            file: frontend/openshift.deploy.yml
-            overwrite: true
-            parameters:
-              -p FAM_MODDED_ZONE=${{ inputs.target || needs.init.outputs.modded-tag }}
-              -p VITE_SPAR_BUILD_VERSION=snapshot-${{ inputs.target || github.event.number }}
-              -p VITE_NRSPARWEBAPP_VERSION=${{ inputs.target || github.event.number }}
-              -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
-              -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
-              ${{ inputs.target != 'prod' && '' || '-p VITE_ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
-          - name: oracle-api
-            file: oracle-api/openshift.deploy.yml
-            overwrite: true
-            parameters:
-              -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-              -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ inputs.target || github.event.number }}
-              -p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
-            triggers: ('oracle-api/')
-            verification_path: "actuator/health"
-    steps:
-      - uses: bcgov-nr/action-deployer-openshift@v2.3.0
-        id: deploys
-        with:
-          file: ${{ matrix.file }}
-          oc_namespace: ${{ vars.OC_NAMESPACE }}
-          oc_server: ${{ vars.OC_SERVER }}
-          oc_token: ${{ secrets.OC_TOKEN }}
-          overwrite: ${{ matrix.overwrite }}
-          penetration_test: false
-          parameters:
-            ${{ github.event_name != 'pull_request' || '-p MIN_REPLICAS=1' }}
-            ${{ github.event_name != 'pull_request' || '-p MAX_REPLICAS=2' }}
-            -p TAG=${{ inputs.tag || needs.init.outputs.pr }}
-            -p ZONE=${{ inputs.target || github.event.number }}
-            ${{ matrix.parameters }}
-          triggers: ${{ matrix.triggers }}
-          verification_path: ${{ matrix.verification_path }}
+  #     - name: OpenShift Init
+  #       uses: bcgov-nr/action-deployer-openshift@v2.3.0
+  #       with:
+  #         oc_namespace: ${{ vars.OC_NAMESPACE }}
+  #         oc_server: ${{ vars.OC_SERVER }}
+  #         oc_token: ${{ secrets.OC_TOKEN }}
+  #         file: common/openshift.init.yml
+  #         overwrite: false
+  #         parameters:
+  #           -p ZONE=${{ inputs.target || github.event.number }}
+  #           -p ORACLE_DB_USER=${{ secrets.DB_USER }}
+  #           -p ORACLE_DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
+  #           -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
+  #           -p AWS_KINESIS_STREAM='${{ secrets.AWS_KINESIS_STREAM }}'
+  #           -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
+  #           -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+  #           -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}'
 
-      - id: trigger
-        run: echo "triggered=${{ steps.deploys.outputs.triggered }}" >> $GITHUB_OUTPUT
+  # deploys:
+  #   name: Deploys
+  #   environment: ${{ inputs.environment }}
+  #   needs: [init]
+  #   outputs:
+  #     triggered: ${{ steps.trigger.outputs.triggered }}
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: ${{ inputs.timeout-minutes }}
+  #   strategy:
+  #     matrix:
+  #       name: [database, backend, fluentbit, frontend, oracle-api]
+  #       include:
+  #         - name: database
+  #           file: database/openshift.deploy.yml
+  #           parameters:
+  #             ${{ github.event_name != 'pull_request' || '-p DB_PVC_SIZE=192Mi' }}
+  #           overwrite: false
+  #         - name: backend
+  #           file: backend/openshift.deploy.yml
+  #           overwrite: true
+  #           parameters:
+  #             -p BUILD=snapshot-${{ inputs.target || github.event.number }}
+  #             -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
+  #             -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
+  #             ${{ inputs.target != 'prod' && '' || '-p ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
+  #           verification_path: "actuator/health"
+  #         - name: fluentbit
+  #           file: common/openshift.fluentbit.yml
+  #           overwrite: true
+  #         - name: frontend
+  #           file: frontend/openshift.deploy.yml
+  #           overwrite: true
+  #           parameters:
+  #             -p FAM_MODDED_ZONE=${{ inputs.target || needs.init.outputs.modded-tag }}
+  #             -p VITE_SPAR_BUILD_VERSION=snapshot-${{ inputs.target || github.event.number }}
+  #             -p VITE_NRSPARWEBAPP_VERSION=${{ inputs.target || github.event.number }}
+  #             -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
+  #             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
+  #             ${{ inputs.target != 'prod' && '' || '-p VITE_ORACLE_SERVER_URL=https://nr-spar-prod-oracle-api.apps.silver.devops.gov.bc.ca' }}
+  #         - name: oracle-api
+  #           file: oracle-api/openshift.deploy.yml
+  #           overwrite: true
+  #           parameters:
+  #             -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
+  #             -p NR_SPAR_ORACLE_API_VERSION=snapshot-${{ inputs.target || github.event.number }}
+  #             -p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.target || github.event.number }}
+  #           triggers: ('oracle-api/')
+  #           verification_path: "actuator/health"
+  #   steps:
+  #     - uses: bcgov-nr/action-deployer-openshift@v2.3.0
+  #       id: deploys
+  #       with:
+  #         file: ${{ matrix.file }}
+  #         oc_namespace: ${{ vars.OC_NAMESPACE }}
+  #         oc_server: ${{ vars.OC_SERVER }}
+  #         oc_token: ${{ secrets.OC_TOKEN }}
+  #         overwrite: ${{ matrix.overwrite }}
+  #         penetration_test: false
+  #         parameters:
+  #           ${{ github.event_name != 'pull_request' || '-p MIN_REPLICAS=1' }}
+  #           ${{ github.event_name != 'pull_request' || '-p MAX_REPLICAS=2' }}
+  #           -p TAG=${{ inputs.tag || needs.init.outputs.pr }}
+  #           -p ZONE=${{ inputs.target || github.event.number }}
+  #           ${{ matrix.parameters }}
+  #         triggers: ${{ matrix.triggers }}
+  #         verification_path: ${{ matrix.verification_path }}
 
-  tests:
-    name: Tests
-    if: inputs.test == 'true' && needs.deploys.outputs.triggered == 'true'
-    needs: [deploys]
-    secrets: inherit
-    uses: ./.github/workflows/.tests.yml
+  #     - id: trigger
+  #       run: echo "triggered=${{ steps.deploys.outputs.triggered }}" >> $GITHUB_OUTPUT
+
+  # tests:
+  #   name: Tests
+  #   if: inputs.test == 'true' && needs.deploys.outputs.triggered == 'true'
+  #   needs: [deploys]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/.tests.yml

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -18,6 +18,10 @@ on:
         description: Container tag; usually PR number
         required: false
         type: string
+      test:
+        description: Run Cypress tests after deployment?  [true|false]
+        required: false
+        type: string
       triggers:
         description: Paths to trigger a deploy; omit=always; e.g. ('backend/' 'frontend/')
         required: false
@@ -41,7 +45,7 @@ jobs:
     environment: ${{ inputs.environment }}
     outputs:
       modded-tag: ${{ steps.mod-tag.outputs.modded-tag }}
-      pr: ${{ steps.pr.outputs.pr }}
+      pr: ${{ steps.pr.outputs.pr }}test
     permissions:
       pull-requests: write
     runs-on: ubuntu-22.04
@@ -143,3 +147,10 @@ jobs:
 
       - id: trigger
         run: echo "triggered=${{ steps.deploys.outputs.triggered }}" >> $GITHUB_OUTPUT
+
+  tests:
+    name: Tests
+    if: inputs.test == 'true' && needs.deploys.outputs.triggered == 'true'
+    needs: [deploys]
+    secrets: inherit
+    uses: ./.github/workflows/.tests.yml

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -39,7 +39,7 @@ jobs:
   results:
     name: PR Results
     if: always() && !failure()
-    needs: [tests]
+    needs: [deploys]
     runs-on: ubuntu-22.04
     steps:
       - run: echo "Workflow completed successfully!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -39,7 +39,7 @@ jobs:
   results:
     name: PR Results
     if: always() && !failure()
-    needs: [deploys]
+    needs: [builds, deploys]
     runs-on: ubuntu-22.04
     steps:
       - run: echo "Workflow completed successfully!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -9,38 +9,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # builds:
-  #   name: Builds
-  #   runs-on: ubuntu-22.04
-  #   permissions:
-  #     packages: write
-  #   strategy:
-  #     matrix:
-  #       package: [database, backend, frontend, oracle-api]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: bcgov-nr/action-builder-ghcr@v2.0.2
-  #       with:
-  #         package: ${{ matrix.package }}
-  #         tag: ${{ github.event.number }}
-  #         tag_fallback: latest
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         triggers: ('${{ matrix.package }}/')
+  builds:
+    name: Builds
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [database, backend, frontend, oracle-api]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bcgov-nr/action-builder-ghcr@v2.0.2
+        with:
+          package: ${{ matrix.package }}
+          tag: ${{ github.event.number }}
+          tag_fallback: latest
+          token: ${{ secrets.GITHUB_TOKEN }}
+          triggers: ('${{ matrix.package }}/')
 
   deploys:
     name: Deploys
-    # needs: [builds]
+    needs: [builds]
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:
+      test: true
       triggers: ('backend/' 'common/' 'database/' 'frontend/' 'oracle-api/')
-
-  tests:
-    name: Tests
-    if: needs.deploys.outputs.triggered == 'true'
-    needs: [deploys]
-    secrets: inherit
-    uses: ./.github/workflows/.tests.yml
 
   results:
     name: PR Results


### PR DESCRIPTION
Since we may or may not (currently the case for TEST) want to run Cypress tests, they are now controlled with the deployer and `test: true|false`.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-9-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1059-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1059-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)