### PR TITLE
fix(ci): drop brackets from PR template for dynamic lookup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 # Description
-Closes #(issue)
+Closes #issue
 
 ### Changelog
 #### New

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 #### Workflows
 [![Merge](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)
-[![CI](https://github.com/bcgov/nr-spar/actions/workflows/ci.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/ci.yml)
+[![Analysis](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)
 [![Cypress Nightly](https://github.com/bcgov/nr-spar/actions/workflows/cypress-nightly.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/cypress-nightly.yml)
+[![Scheduled](https://github.com/bcgov/nr-spar/actions/workflows/scheduled.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/scheduled.yml)
 
 #### Frontend
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=nr-spar_frontend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=nr-spar_frontend)


### PR DESCRIPTION
# Description
Replacing `#(issue)` with `#issue` in the PR template lets GitHub run a live lookup of PR number by description!

Bonus: Revised badges in README.md.

### Changelog

#### Removed
- goodbye visually appealing, but functionality crippling brackets!

### How was this tested?
- [x] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media4.giphy.com/media/kGLpbileUNXfdb5SKl/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-20-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1070-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1070-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)