### PR TITLE
feat(ci): add workflow_dispatch and ref=demo to merge.yml

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,7 +2,7 @@ name: Merge
 
 on:
   push:
-    branches: [main]
+    branches: [main, demo]
     paths-ignore:
       - '*.md'
       - '.github/**'
@@ -10,37 +10,42 @@ on:
       - '!.github/workflows/**'
   workflow_dispatch:
     inputs:
-      pr_no:
-        description: "PR-numbered container set to deploy"
-        type: number
-        required: true
+      tag:
+        description: "Container tag; e.g. PR number or latest"
+        type: string
+        default: latest
+      target:
+        description: "Non-prod target; e.g. test or demo"
+        type: choice
+        options: ['test', 'demo']
+        default: 'test'
 
 concurrency:
   # Do not interrupt previous workflows
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  # Input, test (if ref=main) or demo
+  target: ${{ inputs.target || github.ref == ${{ github.event.repository.default_branch }} && 'test' || 'demo' }}
+
 jobs:
-  deploys-test:
-    name: TEST
+  # Deploy to TEST or DEMO (both use TEST namespace)
+  deploys:
+    name: ${{ toUpperCase(env.target) }} # Uppercase by convention
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:
       environment: test
-      target: test
+      tag: ${{ inputs.tag }} # Uses PR number if blank
+      target: ${{ env.target }}
       test: true
 
-  # tests:
-  #   name: Tests
-  #   needs: [deploys-test]
-  #   secrets: inherit
-  #   uses: ./.github/workflows/.tests.yml
-  #   with:
-  #     target: test
-
-  deploys-prod:
+  # Only deploy to PROD from the main (default) branch
+  deploy-prod:
     name: PROD
-    needs: [deploys-test]
+    if: github.ref == ${{ github.event.repository.default_branch }}
+    needs: [deploys]
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -44,6 +44,7 @@ jobs:
   results:
     name: PR Results
     if: always() && !failure()
+    # Include all needs that could have failures!
     needs: [builds, deploys, tests]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
# Description
I hate demo environments!  How could you do this to me?!?  Closes #982.

Ideally we won't need a demo environment and can instead point PRs to PRs to PRs until the world is right again.  That could become an issue if PRs become too large, but at least the visibility and paper trails are good.

### Changelog
#### New

- Add workflow_dispatch to main.yml
  - Deploy any tag directly to TEST and then PROD
  - OR deploy to DEMO only
- Add support for demo environment
  - deploy with new dispatch
  - OR push to branch=demo
- Steps to run workflow:
  - Visit Actions > All Workflows > Merge ((here)[https://github.com/bcgov/nr-spar/actions/workflows/merge.yml])
  - Click "Run workflow"
  - Use wizard/pull-down to launch

### How was this tested?
- [x] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media4.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-21-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1071-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1071-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)