### PR TITLE
fix(ci): add run attempt to job runs, avoiding retry collisions

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -180,7 +180,7 @@ jobs:
 
           # Create job
           CRONJOB=${{ github.event.repository.name }}-${{ inputs.target || github.event.number }}-sync
-          RUN_JOB=${CRONJOB}-${{ github.run_number }}
+          RUN_JOB=${CRONJOB}-${{ github.run_number }}-${{ github.run_attempt}}
           oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 
           # Follow

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -24,7 +24,7 @@ parameters:
     value: nr-spar
   - name: TEST_MODE
     description: "Run in test mode"
-    value: "0"
+    value: "1"
 
   ### Usually a bad idea - not recommended
   - name: CRON_MINUTES


### PR DESCRIPTION
# Description

Prevents ETL job collisions on workflow retries.  Speeds up ETL with test mode.

### Changelog

#### Changed
- Appended github.run_attempt to job names
- Dropped ETL runs to just test mode - this can be revisited, likely while optimizing

### How was this tested?
- [x] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/ehJ4vNWRhinhMMvLxp/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-1-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1151-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1151-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)