### PR TITLE
fix(ci): disable ETL

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -153,7 +153,7 @@ jobs:
 
   verify:
     name: Verify ETL
-    # if: inputs.etl == 'true' #&& needs.deploy.outputs.triggered == 'true'
+    if: inputs.etl == 'true'
     environment: ${{ github.event_name == 'pull_request' && '' || inputs.target }}
     needs: [deploy]
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

### Changelog
#### Changed
- re-enabled ETL true|false check in .deploy
- stop ETL from running in main merge workflow

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests (test already there and failing!)

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/S66QQlB9Xb1SsvPvy5/giphy.gif" witdh="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-13-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1163-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1163-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)