### PR TITLE
fix: add area of use reflections

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
@@ -6,6 +6,9 @@ import ca.bc.gov.backendstartapi.dto.FavouriteActivityUpdateDto;
 import ca.bc.gov.backendstartapi.dto.ForestClientDto;
 import ca.bc.gov.backendstartapi.dto.GeospatialOracleResDto;
 import ca.bc.gov.backendstartapi.dto.SeedPlanZoneDto;
+import ca.bc.gov.backendstartapi.dto.oracle.AreaOfUseDto;
+import ca.bc.gov.backendstartapi.dto.oracle.AreaOfUseSpuGeoDto;
+import ca.bc.gov.backendstartapi.dto.oracle.SpzDto;
 import ca.bc.gov.backendstartapi.vo.parser.ConeAndPollenCount;
 import ca.bc.gov.backendstartapi.vo.parser.SmpMixVolume;
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
@@ -23,6 +26,9 @@ import org.springframework.context.annotation.ImportRuntimeHints;
   SeedPlanZoneDto.class,
   SmpMixVolume.class,
   GeospatialOracleResDto.class,
+  AreaOfUseDto.class,
+  AreaOfUseSpuGeoDto.class,
+  SpzDto.class
 })
 @ImportRuntimeHints(value = {HttpServletRequestRuntimeHint.class})
 public class NativeImageConfig {}


### PR DESCRIPTION
add reflection config for area of use dtos for native image

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-32-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1182-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1182-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)