### PR TITLE
fix: area of use dto constructors

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
@@ -6,6 +6,9 @@ import ca.bc.gov.backendstartapi.dto.FavouriteActivityUpdateDto;
 import ca.bc.gov.backendstartapi.dto.ForestClientDto;
 import ca.bc.gov.backendstartapi.dto.GeospatialOracleResDto;
 import ca.bc.gov.backendstartapi.dto.SeedPlanZoneDto;
+import ca.bc.gov.backendstartapi.dto.oracle.AreaOfUseDto;
+import ca.bc.gov.backendstartapi.dto.oracle.AreaOfUseSpuGeoDto;
+import ca.bc.gov.backendstartapi.dto.oracle.SpzDto;
 import ca.bc.gov.backendstartapi.vo.parser.ConeAndPollenCount;
 import ca.bc.gov.backendstartapi.vo.parser.SmpMixVolume;
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
@@ -23,6 +26,9 @@ import org.springframework.context.annotation.ImportRuntimeHints;
   SeedPlanZoneDto.class,
   SmpMixVolume.class,
   GeospatialOracleResDto.class,
+  AreaOfUseDto.class,
+  AreaOfUseSpuGeoDto.class,
+  SpzDto.class
 })
 @ImportRuntimeHints(value = {HttpServletRequestRuntimeHint.class})
 public class NativeImageConfig {}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/dto/oracle/AreaOfUseDto.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/dto/oracle/AreaOfUseDto.java
@@ -2,12 +2,16 @@ package ca.bc.gov.backendstartapi.dto.oracle;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /** This class represents a JSON response when requesting SPZ + SPU information from a SPU id. */
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Schema(
     description = "Represents a JSON response when requesting SPZ + SPU information from a SPU id.")
 public class AreaOfUseDto {

--- a/oracle-api/src/main/java/ca/bc/gov/backendstartapi/dto/AreaOfUseDto.java
+++ b/oracle-api/src/main/java/ca/bc/gov/backendstartapi/dto/AreaOfUseDto.java
@@ -2,12 +2,16 @@ package ca.bc.gov.backendstartapi.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /** This class represents a JSON response when requesting SPZ + SPU information from a SPU id. */
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Schema(
     description = "Represents a JSON response when requesting SPZ + SPU information from a SPU id.")
 public class AreaOfUseDto {


### PR DESCRIPTION
add constructors

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-33-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1183-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1183-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)