### PR TITLE
fix: mock forest client front end

### DIFF
--- a/frontend/src/api-service/applicantAgenciesAPI.ts
+++ b/frontend/src/api-service/applicantAgenciesAPI.ts
@@ -1,13 +1,13 @@
 import { ForestClientType } from '../types/ForestClientTypes/ForestClientType';
-import ApplicantAgenciesItems from './fixtures/MockForestClients';
+import { MockForestClients } from './fixtures/MockForestClients';
 import MultiOptionsObj from '../types/MultiOptionsObject';
 
 const getApplicantAgenciesOptions = (): MultiOptionsObj[] => {
   const options: MultiOptionsObj[] = [];
-  ApplicantAgenciesItems.sort(
+  MockForestClients.sort(
     (a: ForestClientType, b: ForestClientType) => (a.clientName < b.clientName ? -1 : 1)
   );
-  ApplicantAgenciesItems.forEach((agency: ForestClientType) => {
+  MockForestClients.forEach((agency: ForestClientType) => {
     const { clientName } = agency;
     const newAgency: MultiOptionsObj = {
       code: agency.clientNumber,

--- a/frontend/src/api-service/applicantAgenciesAPI.ts
+++ b/frontend/src/api-service/applicantAgenciesAPI.ts
@@ -1,5 +1,5 @@
 import { ForestClientType } from '../types/ForestClientTypes/ForestClientType';
-import ApplicantAgenciesItems from './fixtures/ApplicantAgenciesItems';
+import ApplicantAgenciesItems from './fixtures/MockForestClients';
 import MultiOptionsObj from '../types/MultiOptionsObject';
 
 const getApplicantAgenciesOptions = (): MultiOptionsObj[] => {

--- a/frontend/src/api-service/fixtures/MockForestClients.ts
+++ b/frontend/src/api-service/fixtures/MockForestClients.ts
@@ -1,6 +1,6 @@
 import { ForestClientType } from '../../types/ForestClientTypes/ForestClientType';
 
-const ApplicantAgenciesItems: ForestClientType[] = [
+const MockForestClients: ForestClientType[] = [
   {
     clientNumber: '00149081',
     clientName: 'WESTERN FOREST PRODUCTS INC.',
@@ -48,4 +48,4 @@ const ApplicantAgenciesItems: ForestClientType[] = [
   }
 ];
 
-export default ApplicantAgenciesItems;
+export default MockForestClients;

--- a/frontend/src/api-service/fixtures/MockForestClients.ts
+++ b/frontend/src/api-service/fixtures/MockForestClients.ts
@@ -1,6 +1,6 @@
 import { ForestClientType } from '../../types/ForestClientTypes/ForestClientType';
 
-const MockForestClients: ForestClientType[] = [
+export const MockForestClients: ForestClientType[] = [
   {
     clientNumber: '00149081',
     clientName: 'WESTERN FOREST PRODUCTS INC.',
@@ -48,4 +48,12 @@ const MockForestClients: ForestClientType[] = [
   }
 ];
 
-export default MockForestClients;
+export const UNKOWN_FC: ForestClientType = {
+  clientNumber: '88888888',
+  clientName: 'MOCKED UNKNOWN',
+  legalFirstName: 'John',
+  legalMiddleName: 'Doe',
+  clientStatusCode: 'ACT',
+  clientTypeCode: 'F',
+  acronym: 'UNKNOWN'
+};

--- a/frontend/src/api-service/forestClientsAPI.ts
+++ b/frontend/src/api-service/forestClientsAPI.ts
@@ -1,21 +1,28 @@
 import ApiConfig from './ApiConfig';
 import api from './api';
 import { ForestClientType } from '../types/ForestClientTypes/ForestClientType';
-import MockForestClients from './fixtures/MockForestClients';
+import { MockForestClients, UNKOWN_FC } from './fixtures/MockForestClients';
 import { ForestClientSearchType } from '../types/ForestClientTypes/ForestClientSearchType';
 import { ClientSearchOptions } from '../components/ApplicantAgencyFields/ClientSearchModal/definitions';
 
+// eslint-disable-next-line arrow-body-style, @typescript-eslint/no-unused-vars
 export const getForestClientLocation = (clientNumber: string, locationCode: string) => {
   // TODO: restore this once forest client is back up
   // const url = `${ApiConfig.forestClient}/${clientNumber}/location/${locationCode}`;
   // return api.get(url).then((res) => res.data);
 
-  return MockForestClients.find((fc) => (fc.acronym))
+  return Promise.resolve();
 };
 
+// eslint-disable-next-line arrow-body-style
 export const getForestClientByNumberOrAcronym = (clientNumber: string) => {
-  const url = `${ApiConfig.forestClient}/${clientNumber}`;
-  return api.get(url).then((res): ForestClientType => res.data);
+  // TODO: restore this once forest client is back up
+  // const url = `${ApiConfig.forestClient}/${clientNumber}`;
+  // return api.get(url).then((res): ForestClientType => res.data);
+
+  return Promise.resolve(
+    MockForestClients.find((fc) => fc.clientNumber === clientNumber) ?? UNKOWN_FC
+  );
 };
 
 export const getAllAgencies = (): string[] => {

--- a/frontend/src/api-service/forestClientsAPI.ts
+++ b/frontend/src/api-service/forestClientsAPI.ts
@@ -1,13 +1,16 @@
 import ApiConfig from './ApiConfig';
 import api from './api';
 import { ForestClientType } from '../types/ForestClientTypes/ForestClientType';
-import ApplicantAgenciesItems from './fixtures/ApplicantAgenciesItems';
+import MockForestClients from './fixtures/MockForestClients';
 import { ForestClientSearchType } from '../types/ForestClientTypes/ForestClientSearchType';
 import { ClientSearchOptions } from '../components/ApplicantAgencyFields/ClientSearchModal/definitions';
 
 export const getForestClientLocation = (clientNumber: string, locationCode: string) => {
-  const url = `${ApiConfig.forestClient}/${clientNumber}/location/${locationCode}`;
-  return api.get(url).then((res) => res.data);
+  // TODO: restore this once forest client is back up
+  // const url = `${ApiConfig.forestClient}/${clientNumber}/location/${locationCode}`;
+  // return api.get(url).then((res) => res.data);
+
+  return MockForestClients.find((fc) => (fc.acronym))
 };
 
 export const getForestClientByNumberOrAcronym = (clientNumber: string) => {
@@ -17,10 +20,10 @@ export const getForestClientByNumberOrAcronym = (clientNumber: string) => {
 
 export const getAllAgencies = (): string[] => {
   const options: string[] = [];
-  ApplicantAgenciesItems.sort(
+  MockForestClients.sort(
     (a: ForestClientType, b: ForestClientType) => (a.clientName < b.clientName ? -1 : 1)
   );
-  ApplicantAgenciesItems.forEach((agency: ForestClientType) => {
+  MockForestClients.forEach((agency: ForestClientType) => {
     let clientName = agency.clientName
       .toLowerCase()
       .split(' ')


### PR DESCRIPTION
Forest client is down without a definite time to be up again. 
Mocking the FC api return values on the front-end to unblock dev works. 

The TODO comments is there for use to easily find the code that needs to be restored once FC is up. 
I thought about having an env var on the front-end similar to back-end that can mock return data on the fly, but i don't think it's necessary. 

You might see something like this but it's expected and can be ignored, the purpose of this small PR is to enable devs to gain access to all the pages.

![image](https://github.com/bcgov/nr-spar/assets/25162561/0d78d20b-f940-47d2-bb70-91f87c99866a)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-40-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1190-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Oracle-API](https://nr-spar-1190-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)