### PR TITLE
fix(ci): explicitly scrub needs for failures

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -149,7 +149,7 @@ jobs:
           triggers: ${{ matrix.triggers }}
           verification_path: ${{ matrix.verification_path }}
           verification_retry_attempts: "5"
-          verification_retry_seconds: "15"
+          verification_retry_seconds: "20"
       - id: trigger
         run: echo "triggered=${{ steps.deploys.outputs.triggered }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -42,9 +42,17 @@ jobs:
 
   results:
     name: PR Results
-    if: always() && (!failure()) && (!cancelled())
+    if: always()
     # Include all needs that could have failures!
     needs: [builds, deploys, tests]
     runs-on: ubuntu-22.04
     steps:
-      - run: echo "Workflow completed successfully!"
+      - run: |
+          # View results
+          echo "needs.*.result: ${{ toJson(needs.*.result) }}"
+
+      - if: contains(needs.*.result, 'failure')
+        run: |
+          # Job failure found
+          echo "At least one job has failed"
+          exit 1


### PR DESCRIPTION
# Description
Handles false passes in pr-open.yml.  This had led to breaks in other PRs and TEST.

### Changelog
#### New
- Extra checks and output for PR Results job

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [x] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/3KQ4VNwCrOThC/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-47-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1247-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1247-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)