### PR TITLE
fix: cypress tests and number inputs

### DIFF
--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -39,7 +39,7 @@ jobs:
           node_version: "18"
           commands: |
             npm ci
-            npm run cy:ci || true
+            npm run cy:ci
           dir: frontend
           sonar_args: >
             -Dsonar.organization=bcgov-sonarcloud

--- a/frontend/cypress/e2e/smoke-test/a-class-seedlot-reg-form-collection-interim.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/a-class-seedlot-reg-form-collection-interim.cy.ts
@@ -143,6 +143,9 @@ describe('A Class Seedlot Registration form, Collection and Interim storage', ()
       .find('button.form-action-btn')
       .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('[Collection] Client search modal', () => {
@@ -202,6 +205,9 @@ describe('A Class Seedlot Registration form, Collection and Interim storage', ()
       .find('button.form-action-btn')
       .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('[Collection] Date inputs', () => {
@@ -233,9 +239,12 @@ describe('A Class Seedlot Registration form, Collection and Interim storage', ()
       .find('button.form-action-btn')
       .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
-  it('[Collection] Containers inputs', () => {
+  it.only('[Collection] Containers inputs', () => {
     const fixtureData = regFormData.collector;
     // Invalid collection test, number > 10,000
     cy.get('#collection-num-of-container')
@@ -318,6 +327,9 @@ describe('A Class Seedlot Registration form, Collection and Interim storage', ()
       .find('button.form-action-btn')
       .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('[Collection] Checkbox input', () => {
@@ -415,8 +427,8 @@ describe('A Class Seedlot Registration form, Collection and Interim storage', ()
 
     cy.get('.seedlot-registration-button-row')
       .find('button.form-action-btn')
-      .contains('Save changes')
-      .click();
+      .click()
+      .contains(/Save changes|Changes saved!/g);
   });
 
   it('[Interim storage] Client search modal', () => {
@@ -507,6 +519,9 @@ describe('A Class Seedlot Registration form, Collection and Interim storage', ()
       .find('button.form-action-btn')
       .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('[Interim storage] Radio button', () => {

--- a/frontend/cypress/e2e/smoke-test/a-class-seedlot-reg-form-ownership.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/a-class-seedlot-reg-form-ownership.cy.ts
@@ -157,6 +157,15 @@ describe('A Class Seedlot Registration form, Ownership', () => {
 
     cy.get(`svg.${prefix}--inline-loading__checkmark-container`)
       .should('be.visible');
+
+    // Save changes
+    cy.get('.seedlot-registration-button-row')
+      .find('button.form-action-btn')
+      .contains('Save changes')
+      .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('Client search modal', () => {
@@ -207,6 +216,15 @@ describe('A Class Seedlot Registration form, Ownership', () => {
         cy.get('#ownership-location-code-0')
           .should('have.value', locationCode);
       });
+
+    // Save changes
+    cy.get('.seedlot-registration-button-row')
+      .find('button.form-action-btn')
+      .contains('Save changes')
+      .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('Owner portion %, reserved % and surplus % display default values', () => {
@@ -218,6 +236,15 @@ describe('A Class Seedlot Registration form, Ownership', () => {
 
     cy.get('#ownership-surplus-0')
       .should('have.value', '0');
+
+    // Save changes
+    cy.get('.seedlot-registration-button-row')
+      .find('button.form-action-btn')
+      .contains('Save changes')
+      .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('Edit owner portion %, reserved % and surplus % values', () => {
@@ -281,38 +308,44 @@ describe('A Class Seedlot Registration form, Ownership', () => {
     // Save changes
     cy.get('.seedlot-registration-button-row')
       .find('button.form-action-btn')
-      .contains(/Save changes|Changes saved!/g)
+      .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('Funding source and method of payment default values and change the values', () => {
-    cy.get('#ownership-funding-source-0')
-      .should('have.value', '');
 
-    cy.get('.single-owner-combobox')
-      .eq(0)
-      .find(`button.${prefix}--list-box__menu-icon`)
+    //Expand the funding source combo box
+    cy.get('#ownership-funding-source-0')
+      .should('have.value', '')
       .click();
 
-    cy.get('li#downshift-1-item-5')
+    const fundingSource = 'FTM - Forests for Tomorrow MOF Admin';
+
+    cy.get(`.${prefix}--list-box__menu-item__option`)
+      .contains(fundingSource)
+      .scrollIntoView()
       .click();
 
     cy.get('#ownership-funding-source-0')
-      .should('have.value', 'FTM - Forests for Tomorrow MOF Admin');
+      .should('have.value', fundingSource);
+
+    // Method of Payment
+    cy.get('#ownership-method-payment-0')
+      .should('have.value', '')
+      .click();
+
+    const methodOfPayment = 'CSH - Cash Sale';
+
+    cy.get(`.${prefix}--list-box__menu-item__option`)
+      .contains(methodOfPayment)
+      .scrollIntoView()
+      .click();
 
     cy.get('#ownership-method-payment-0')
-      .should('have.value', '');
-
-    cy.get('.single-owner-combobox')
-      .eq(1)
-      .find(`button.${prefix}--list-box__menu-icon`)
-      .click();
-
-    cy.get('li#downshift-3-item-1')
-      .click();
-
-    cy.get('#ownership-method-payment-0')
-      .should('have.value', 'CSH - Cash Sale');
+      .should('have.value', methodOfPayment);
 
     // Check 'x' button
     cy.get('.single-owner-combobox')
@@ -320,39 +353,44 @@ describe('A Class Seedlot Registration form, Ownership', () => {
       .find('[aria-label="Clear selected item"]')
       .click();
 
-    cy.get('#ownership-funding-source-0')
-      .should('have.value', '');
-
     cy.get('.single-owner-combobox')
       .eq(1)
       .find('[aria-label="Clear selected item"]')
       .click();
 
-    cy.get('#ownership-method-payment-0')
-      .should('have.value', '');
-
     // Enter funding source and method payment values again
-    cy.get('.single-owner-combobox')
-      .eq(0)
-      .find(`button.${prefix}--list-box__menu-icon`)
+    cy.get('#ownership-funding-source-0')
+      .should('have.value', '')
       .click();
 
-    cy.get('li#downshift-1-item-5')
+    cy.get(`.${prefix}--list-box__menu-item__option`)
+      .contains(fundingSource)
+      .scrollIntoView()
       .click();
 
-    cy.get('.single-owner-combobox')
-      .eq(1)
-      .find(`button.${prefix}--list-box__menu-icon`)
+    cy.get('#ownership-funding-source-0')
+      .should('have.value', fundingSource);
+
+    cy.get('#ownership-method-payment-0')
+      .should('have.value', '')
       .click();
 
-    cy.get('li#downshift-3-item-1')
+    cy.get(`.${prefix}--list-box__menu-item__option`)
+      .contains(methodOfPayment)
+      .scrollIntoView()
       .click();
+
+    cy.get('#ownership-method-payment-0')
+      .should('have.value', methodOfPayment);
 
     // Save changes
     cy.get('.seedlot-registration-button-row')
       .find('button.form-action-btn')
-      .contains(/Save changes|Changes saved!/g)
+      .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('Create and delete new owner agency section', () => {
@@ -450,8 +488,11 @@ describe('A Class Seedlot Registration form, Ownership', () => {
     // Save changes
     cy.get('.seedlot-registration-button-row')
       .find('button.form-action-btn')
-      .contains(/Save changes|Changes saved!/g)
+      .contains('Save changes')
       .click();
+
+    cy.get(`.${prefix}--inline-loading__text`)
+      .contains('Changes saved!')
   });
 
   it('Complete checkmark for Ownership step', () => {

--- a/frontend/cypress/e2e/smoke-test/my-seedlots.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/my-seedlots.cy.ts
@@ -19,22 +19,14 @@ describe('My seedlots page', () => {
     });
   });
 
-  it('should render my seedlot page heading', () => {
+  it('Page title', () => {
     cy.get('.my-seedlot-title')
       .find('.title-favourite')
       .children('h1')
       .should('have.text', 'My Seedlots');
   });
 
-  it('arrow button works correctly', () => {
-    // Arrow button test
-    cy.get(`.${prefix}--pagination__right`)
-      .find(`.${prefix}--popover--top-right`)
-      .find(`button.${prefix}--btn--icon-only`)
-      .click({ force: true });
-  });
-
-  it('should sort table columns in ascending and descinding order - Seedlot number', () => {
+  it('Sort table by Seedlot number', () => {
     let ascendingFirstRow: string;
     let descendingFirstRow: string;
 
@@ -73,12 +65,12 @@ describe('My seedlots page', () => {
       .eq(1)
       .find('td:nth-child(1)').then(($seedlotNum) => {
         const descendingSecondRow: string = $seedlotNum.text();
-        // eslint-disable-next-line max-len
-        expect(parseInt(descendingFirstRow, 10)).to.be.greaterThan(parseInt(descendingSecondRow, 10));
+        expect(parseInt(descendingFirstRow, 10))
+          .to.be.greaterThan(parseInt(descendingSecondRow, 10));
       });
   });
 
-  it('should sort table columns in ascending and descinding order - Seedlot species', () => {
+  it('Sort table by Seedlot species', () => {
     let ascendingFirstRow: string;
 
     // Sorting test
@@ -117,7 +109,7 @@ describe('My seedlots page', () => {
       });
   });
 
-  it('should sort table columns in ascending and descinding order - Seedlot status', () => {
+  it('Sort table by Seedlot status', () => {
     let ascendingFirstRow: string;
 
     // Sorting test
@@ -156,7 +148,7 @@ describe('My seedlots page', () => {
       });
   });
 
-  it('should sort table columns in ascending and descinding order - Created at', () => {
+  it('Sort table by Created at', () => {
     let ascendingFirstRow: string;
 
     // Sorting test
@@ -197,7 +189,7 @@ describe('My seedlots page', () => {
       });
   });
 
-  it('should sort table columns in ascending and descinding order - Last updated', () => {
+  it('Sort table by Last updated', () => {
     let ascendingFirstRow: string;
 
     // Sorting test
@@ -238,7 +230,7 @@ describe('My seedlots page', () => {
       });
   });
 
-  it('can use search bar to give correct results', () => {
+  it('Search bar', () => {
     // Search bar test
     cy.get('.my-seedlot-data-table-row').children(`.${prefix}--search`).find('input')
       .type('PLI');
@@ -255,16 +247,20 @@ describe('My seedlots page', () => {
       });
   });
 
-  it('dropdown button and next page functionality', () => {
-    // Dropdown test
+  it('Pagination', () => {
+    // Number of item dropdown
     cy.get(`.${prefix}--pagination__left`)
       .find('select')
       .as('dropdownBtn')
       .select('10');
 
+    // @ngunner15 the drop down is selected with value 10, what we need here is to verify
+    // that the total number of rows on this page is actually 10.
+    // you might be able to do that by checking the total number of <tr> under <tbody>
     cy.get('@dropdownBtn')
       .should('have.value', '10');
-    // Next page test
+
+    // Forward Backward buttons
     cy.get(`.${prefix}--pagination__control-buttons`)
       .find(`button.${prefix}--pagination__button--forward`)
       .click();
@@ -280,9 +276,11 @@ describe('My seedlots page', () => {
     cy.get(`.${prefix}--pagination__right`)
       .find(`select.${prefix}--select-input`)
       .should('have.value', '1');
+
+    // @ngunner15 Need to test the page number dropdown
   });
 
-  it('should be able to select a seedlot row and redirect to its page', () => {
+  it('Select a seedlot row should redirect to its detail page', () => {
     cy.get('table.seedlot-data-table tbody tr')
       .as('tableContent');
 
@@ -299,7 +297,7 @@ describe('My seedlots page', () => {
       });
   });
 
-  it('should have correct number of seedlots', () => {
+  it('Correct number of seedlots', () => {
     cypressSeedlots = NUM_OF_LOOPS * speciesKeys.length;
     //  Check total seedlots
     cy.get(`.${prefix}--pagination__left`)
@@ -314,7 +312,7 @@ describe('My seedlots page', () => {
       });
   });
 
-  it('should click register-a-class button', () => {
+  it('Register a new seedlot button', () => {
     // Button test
     cy.get('.my-seedlot-title')
       .find('button.reg-seedlot-btn')

--- a/frontend/cypress/e2e/smoke-test/seedlot-dashboard.cy.ts
+++ b/frontend/cypress/e2e/smoke-test/seedlot-dashboard.cy.ts
@@ -32,10 +32,10 @@ describe('Seedlot Dashboard test', () => {
     cy.get('.title-section')
       .find('.subtitle-section')
       .should('have.text', seedlotDashboardData.subtitle);
-    cy.get('.recent-seedlots-title')
+    cy.get('.recent-seedlots-title-section')
       .find('h2')
       .should('have.text', seedlotDashboardData.secondSectionTitle);
-    cy.get('.recent-seedlots-title')
+    cy.get('.recent-seedlots-title-section')
       .find('.recent-seedlots-subtitle')
       .should('have.text', seedlotDashboardData.secondSectionSubtitle);
   });

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/index.tsx
@@ -4,6 +4,7 @@ import {
   FlexGrid,
   Column,
   Row,
+  TextInput,
   NumberInput,
   CheckboxGroup,
   Checkbox,
@@ -231,56 +232,56 @@ const CollectionStep = ({ isReview }: CollectionStepProps) => {
       </Row>
       <Row className="collection-step-row">
         <Column sm={4} md={4} lg={8} xlg={6}>
-          <NumberInput
+          <TextInput
             id={state.numberOfContainers.id}
+            type="number"
             name={fieldsConfig.numberOfContainers.name}
             value={state.numberOfContainers.value}
-            label={fieldsConfig.numberOfContainers.labelText}
+            labelText={fieldsConfig.numberOfContainers.labelText}
             readOnly={isFormSubmitted && !isReview}
             invalid={state.numberOfContainers.isInvalid}
             invalidText={fieldsConfig.numberOfContainers.invalidText}
-            onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
+            onWheel={(e: React.ChangeEvent<HTMLInputElement>) => e.target.blur()}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               handleContainerNumAndVol(true, e.target.value);
             }}
-            hideSteppers
-            disableWheel
           />
         </Column>
         <Column sm={4} md={4} lg={8} xlg={6}>
-          <NumberInput
+          <TextInput
             id={state.volumePerContainers.id}
+            type="number"
             name={fieldsConfig.volumePerContainers.name}
             value={state.volumePerContainers.value}
-            label={fieldsConfig.volumePerContainers.labelText}
+            labelText={fieldsConfig.volumePerContainers.labelText}
             readOnly={isFormSubmitted && !isReview}
             invalid={state.volumePerContainers.isInvalid}
             invalidText={fieldsConfig.volumePerContainers.invalidText}
-            onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
+            onWheel={(e: React.ChangeEvent<HTMLInputElement>) => e.target.blur()}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               handleContainerNumAndVol(false, e.target.value);
             }}
-            hideSteppers
-            disableWheel
           />
         </Column>
       </Row>
       <Row className="collection-step-row">
         <Column sm={4} md={4} lg={16} xlg={12}>
-          <NumberInput
+          <TextInput
             id={state.volumeOfCones.id}
+            type="number"
             name={fieldsConfig.volumeOfCones.name}
             value={state.volumeOfCones.value}
-            label={fieldsConfig.volumeOfCones.labelText}
+            labelText={fieldsConfig.volumeOfCones.labelText}
             invalid={state.volumeOfCones.isInvalid}
             invalidText={fieldsConfig.volumeOfCones.invalidText}
             helperText={isReview ? null : fieldsConfig.volumeOfCones.helperText}
             warn={isCalcWrong}
             readOnly={isFormSubmitted && !isReview}
             warnText={fieldsConfig.volumeOfCones.warnText}
-            onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
+            onWheel={(e: React.ChangeEvent<HTMLInputElement>) => e.target.blur()}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               handleVolOfCones(e.target.value);
             }}
-            hideSteppers
-            disableWheel
           />
         </Column>
       </Row>

--- a/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/styles.scss
+++ b/frontend/src/components/SeedlotRegistrationSteps/CollectionStep/styles.scss
@@ -1,14 +1,16 @@
 @use '@carbon/type';
 @use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
 
-.collection-step-container{
+.collection-step-container {
   padding: 0;
 
   .collection-step-row {
     margin-bottom: 1.5rem;
+
     h2 {
       @include type.type-style('heading-03');
     }
+
     .#{vars.$bcgov-prefix}--date-picker--single {
       width: 100%;
 
@@ -20,6 +22,15 @@
 
     fieldset .subtitle-section {
       margin-bottom: 0.5rem;
+    }
+
+    input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    input[type=number] {
+      -moz-appearance: textfield;
     }
   }
 

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/SingleOwnerInfo/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/SingleOwnerInfo/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { UseQueryResult } from '@tanstack/react-query';
 import {
   NumberInput,
+  TextInput,
   FlexGrid,
   Column,
   ComboBox,
@@ -90,6 +91,7 @@ const SingleOwnerInfo = ({
   const handleReservedAndSurplus = (field: string, value: string) => {
     const clonedState = structuredClone(ownerInfo);
     const isReserved = field === 'reservedPerc';
+    console.log(value);
 
     // First validate the format of what is set on the value and
     // get the correct error message
@@ -165,95 +167,58 @@ const SingleOwnerInfo = ({
             />
           </Column>
           <Column className={`single-owner-info-col ${colsClass}`} xs={4} sm={4} md={4} lg={4}>
-            <NumberInput
+            <TextInput
               id={ownerInfo.ownerPortion.id}
               name="ownerPortion"
-              label={inputText.portion.label}
+              labelText={inputText.portion.label}
               defaultValue={ownerInfo.ownerPortion.value}
-              hideSteppers
-              max={100}
-              min={0}
               onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
                 // The guard is needed here because onClick also trigger the onChange method
                 // but it does not pass in any value
-                if (e?.target?.name && e?.target?.value) {
+                if (e?.target?.name) {
                   handleOwnerPortion(e.target.value);
                 }
               }}
               invalid={ownerInfo.ownerPortion.isInvalid}
               invalidText={ownerPortionInvalidText}
-              onClick={
-                (
-                  _e: React.MouseEvent<HTMLButtonElement>,
-                  target: NumStepperVal | undefined
-                ) => {
-                  // A guard is needed here because any click on the input will emit a
-                  //   click event, not necessarily the + - buttons
-                  if (target?.value) {
-                    handleOwnerPortion(String(target.value));
-                  }
-                }
-              }
               readOnly={readOnly && !isReview}
             />
           </Column>
           <Column className={`single-owner-info-col ${colsClass}`} xs={4} sm={4} md={4} lg={4}>
             <div className="reserved-perc-container">
               <div className="reserved-surplus-input">
-                <NumberInput
+                <TextInput
                   id={ownerInfo.reservedPerc.id}
+                  type="number"
                   name="reservedPerc"
-                  label={inputText.reserved.label}
+                  labelText={inputText.reserved.label}
                   value={ownerInfo.reservedPerc.value}
-                  hideSteppers
-                  max={100}
-                  min={0}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    if (e?.target?.name && e?.target?.value) {
+                    if (e?.target?.name) {
                       handleReservedAndSurplus(e.target.name, e.target.value);
                     }
                   }}
+                  onWheel={(e: React.ChangeEvent<HTMLInputElement>) => e.target.blur()}
                   invalid={ownerInfo.reservedPerc.isInvalid}
                   invalidText={reservedInvalidText}
-                  onClick={
-                    (
-                      _e: React.MouseEvent<HTMLButtonElement>,
-                      target: NumStepperVal | undefined
-                    ) => {
-                      if (target?.value) {
-                        handleReservedAndSurplus('reservedPerc', String(target.value));
-                      }
-                    }
-                  }
                   readOnly={readOnly && !isReview}
                 />
               </div>
               <div className="reserved-surplus-input">
-                <NumberInput
+                <TextInput
                   id={ownerInfo.surplusPerc.id}
+                  type="number"
                   name="surplusPerc"
-                  label={inputText.surplus.label}
+                  labelText={inputText.surplus.label}
                   value={ownerInfo.surplusPerc.value}
-                  hideSteppers
-                  max={100}
-                  min={0}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    if (e?.target?.name && e?.target?.value) {
+                    if (e?.target?.name) {
                       handleReservedAndSurplus(e.target.name, e.target.value);
                     }
                   }}
+                  onWheel={(e: React.ChangeEvent<HTMLInputElement>) => e.target.blur()}
                   invalid={ownerInfo.surplusPerc.isInvalid}
                   invalidText={surplusInvalidText}
-                  onClick={
-                    (
-                      _e: React.MouseEvent<HTMLButtonElement>,
-                      target: NumStepperVal | undefined
-                    ) => {
-                      if (target?.value) {
-                        handleReservedAndSurplus('surplusPerc', String(target.value));
-                      }
-                    }
-                  }
                   readOnly={readOnly && !isReview}
                 />
               </div>

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/SingleOwnerInfo/styles.scss
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/SingleOwnerInfo/styles.scss
@@ -31,11 +31,24 @@
     }
 
     &.default-owner-col {
-      padding-top: 3.05rem
+      padding-top: 3.05rem;
     }
 
     &.other-owners-col {
       padding-top: 0.1rem;
+    }
+
+    .default-owner-col,
+    .other-owners-col {
+
+      input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      input[type=number] {
+        -moz-appearance: textfield;
+      }
     }
   }
 
@@ -77,6 +90,15 @@
 
   .reserved-surplus-input {
     width: 49.75%;
+
+    input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    input[type=number] {
+      -moz-appearance: textfield;
+    }
   }
 
   .owner-mod-btn {
@@ -84,6 +106,7 @@
   }
 
   .owner-code-text-input {
+
     input::-webkit-outer-spin-button,
     input::-webkit-inner-spin-button {
       -webkit-appearance: none;

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/utils.ts
@@ -69,8 +69,22 @@ const isDecimalValid = (value: string): boolean => {
 };
 
 export const validatePerc = (value: string): SingleInvalidObj => {
-  let invalidText = inputText.twoDecimal;
-  let isInvalid = !isDecimalValid(value);
+  let invalidText = inputText.lowerThan;
+  let isInvalid = true;
+
+  if (!value) {
+    return {
+      isInvalid,
+      invalidText
+    }
+  }
+
+  isInvalid = !isDecimalValid(value);
+
+  if (isInvalid) {
+    invalidText = inputText.twoDecimal;
+  }
+
   if (!isInvalid) {
     if (Number(value) > 100) {
       isInvalid = true;


### PR DESCRIPTION
# Description
Closes N/A
Our cypress have been failing silently, this PR is to address the issue.

- Cypress should fail if a test fails

- Fixed a problem where clearing a number input will make it default to '0', then typing '02' will sometimes making it '020' thus affecting the values to be tested. This is nearly impossible to happen with human input but it happens with Cypress. 

- Renamed some tests so it's more straight to the point

- Restructured the test that checks funding source and method of payment

- Improved the save checking logic
 


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-0-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1250-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1250-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)