### PR TITLE
chore(ci): Renovate exclude vite-plugin-istanbul

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,15 @@
   "description": "Presets from https://github.com/bcgov/renovate-config",
   "extends": [
     "github>bcgov/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Ignore vite-plugin-istanbul 6.0.0",
+      "matchCurrentVersion": "6.0.0",
+      "matchPackageNames": [
+        "vite-plugin-istanbul"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
# Description

### Changelog
#### New
- Excluded frontend's vite-plugin-istanbul v6.0.0 from Renovate

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/xZsLh7B3KMMyUptD9D/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-10-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1260-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1260-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)