### PR TITLE
feat: 1211 display and edit bec values

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -728,12 +728,20 @@ public class SeedlotService {
             .findOrchardById(primaryOrchardId)
             .orElseThrow(OracleApiProviderException::new);
 
+    ActiveOrchardSpuEntity primarySeedPlanUnit =
+        orchardService
+            .findSpuIdByOrchard(primaryOrchardId)
+            .orElseThrow(NoSpuForOrchardException::new);
+
+    Integer primarySpuId = primarySeedPlanUnit.getSeedPlanningUnitId();
+
     // Not sure why it's called Bgc in seedlot instead of Bec in orchard
     seedlot.setBgcZoneCode(orchardDto.becZoneCode());
     seedlot.setBgcZoneDescription(orchardDto.becZoneDescription());
     seedlot.setBgcSubzoneCode(orchardDto.becSubzoneCode());
     seedlot.setVariant(orchardDto.variant());
     seedlot.setBecVersionId(orchardDto.becVersionId());
+    seedlot.setSeedPlanUnitId(primarySpuId);
 
     SparLog.info("BEC values set");
   }

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
@@ -434,6 +434,7 @@ class SeedlotFormPutTest {
         Optional.of(new ActiveOrchardSpuEntity(primaryOrchardId, activeSpuId, true, false, false));
     when(orchardService.findSpuIdByOrchardWithActive(primaryOrchardId, true))
         .thenReturn(activeSpuOptional);
+    when(orchardService.findSpuIdByOrchard(primaryOrchardId)).thenReturn(activeSpuOptional);
 
     AreaOfUseDto areaOfUseDto = new AreaOfUseDto();
     AreaOfUseSpuGeoDto areaOfUseSpuGeoDto = new AreaOfUseSpuGeoDto(1, 100, null, null, 3, 5);
@@ -537,10 +538,10 @@ class SeedlotFormPutTest {
     assertEquals(oracleOrchardRet.becVersionId(), seedlot.getBecVersionId());
     // Declared Seedlot Value
     assertEquals(
-        loggedUserService.getLoggedUserId(),
-        seedlot.getDeclarationOfTrueInformationUserId());
+        loggedUserService.getLoggedUserId(), seedlot.getDeclarationOfTrueInformationUserId());
     assertTrue(
-        LocalDateTime.now().minusSeconds(15L).isBefore(
-            seedlot.getDeclarationOfTrueInformationTimestamp()));
+        LocalDateTime.now()
+            .minusSeconds(15L)
+            .isBefore(seedlot.getDeclarationOfTrueInformationTimestamp()));
   }
 }

--- a/frontend/src/api-service/seedPlanUnitAPI.ts
+++ b/frontend/src/api-service/seedPlanUnitAPI.ts
@@ -1,7 +1,0 @@
-import ApiConfig from './ApiConfig';
-import api from './api';
-
-export const getSpuById = (spuId: string) => {
-  const url = `${ApiConfig.seedPlanUnit}/${spuId}`;
-  return api.get(url).then((res) => res.data);
-};

--- a/frontend/src/api-service/seedPlanUnitAPI.ts
+++ b/frontend/src/api-service/seedPlanUnitAPI.ts
@@ -1,0 +1,7 @@
+import ApiConfig from './ApiConfig';
+import api from './api';
+
+export const getSpuById = (spuId: string) => {
+  const url = `${ApiConfig.seedPlanUnit}/${spuId}`;
+  return api.get(url).then((res) => res.data);
+};

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/TableComponents/utils.ts
@@ -1,5 +1,4 @@
 import validator from 'validator';
-import BigNumber from 'bignumber.js';
 
 import { ParentTreeStepDataObj } from '../../../../views/Seedlot/ContextContainerClassA/definitions';
 
@@ -13,6 +12,7 @@ import {
   SMP_SUCCESS_PERC_MAX, SMP_SUCCESS_PERC_MAX_PW, SMP_SUCCESS_PERC_MIN, VOLUME_MAX, VOLUME_MIN
 } from '../constants';
 import MultiOptionsObj from '../../../../types/MultiOptionsObject';
+import { isFloatWithinRange } from '../../../../utils/NumberUtils';
 
 export const isPtNumberInvalid = (ptNumber: string, allParentTreeData: AllParentTreeMap) => (
   !Object.keys(allParentTreeData).includes(ptNumber)
@@ -105,14 +105,6 @@ const calculateSmpRow = (
 
 export const getPTNumberErrMsg = (value: string): string => (
   `"${value}" is an invalid parent tree number. Please provide a valid parent tree number and review the number you have entered.`
-);
-
-/**
- * A float validator, the validator.isFloat() cannot handle high precision comparing.
- */
-const isFloatWithinRange = (value: string, min: string, max: string): boolean => (
-  new BigNumber(value).isGreaterThanOrEqualTo(min)
-  && new BigNumber(value).isLessThanOrEqualTo(max)
 );
 
 export const isConeCountInvalid = (value: string): boolean => {

--- a/frontend/src/components/SeedlotReviewSteps/AreaOfUse/utils.ts
+++ b/frontend/src/components/SeedlotReviewSteps/AreaOfUse/utils.ts
@@ -129,7 +129,7 @@ const isDegreeOutOfRange = (value: string, isLat: boolean) => (
   )
 );
 
-const validateDegreeRange = (inputObj: StringInputType, isLat: boolean): StringInputType => {
+export const validateDegreeRange = (inputObj: StringInputType, isLat: boolean): StringInputType => {
   const validatedObj = inputObj;
   validatedObj.isInvalid = isDegreeOutOfRange(inputObj.value, isLat);
 
@@ -146,7 +146,7 @@ const isMinuteOrSecondOutOfRange = (value: string) => (
   !validator.isInt(value, { min: MIN_MINUTE_AND_SECOND_LIMIT, max: MAX_MINUTE_AND_SECOND_LIMIT })
 );
 
-const validateMinuteOrSecondRange = (inputObj: StringInputType): StringInputType => {
+export const validateMinuteOrSecondRange = (inputObj: StringInputType): StringInputType => {
   const validatedObj = inputObj;
   validatedObj.isInvalid = isMinuteOrSecondOutOfRange(inputObj.value);
 

--- a/frontend/src/components/SeedlotReviewSteps/Collection/Read/index.tsx
+++ b/frontend/src/components/SeedlotReviewSteps/Collection/Read/index.tsx
@@ -126,7 +126,7 @@ const CollectionReviewRead = () => {
             value={
               formatCollectionMethods(
                 allStepData.collectionStep.selectedCollectionCodes.value,
-                coneCollectionMethodsQuery.data!
+                coneCollectionMethodsQuery.data
               )
             }
             showSkeleton={isFetchingData || coneCollectionMethodsQuery.isFetching}

--- a/frontend/src/components/SeedlotReviewSteps/Collection/constants.ts
+++ b/frontend/src/components/SeedlotReviewSteps/Collection/constants.ts
@@ -1,0 +1,9 @@
+export const MIN_NE = '0.1';
+
+export const MAX_NE = '999.9';
+
+export const MAX_NE_DECIMAL = 1;
+
+export const INVALID_NE_RANGE_MSG = `Must be between ${MIN_NE} and ${MAX_NE}`;
+
+export const INVALID_NE_DECIMAL_MSG = `Cannot have more than ${MAX_NE_DECIMAL} decimal place`;

--- a/frontend/src/components/SeedlotReviewSteps/Collection/utils.ts
+++ b/frontend/src/components/SeedlotReviewSteps/Collection/utils.ts
@@ -1,5 +1,13 @@
+import validator from 'validator';
+
 import { PLACE_HOLDER } from '../../../shared-constants/shared-constants';
 import { CodeDescResType } from '../../../types/CodeDescResType';
+import { StringInputType } from '../../../types/FormInputType';
+import { isFloatWithinRange } from '../../../utils/NumberUtils';
+
+import {
+  INVALID_NE_DECIMAL_MSG, INVALID_NE_RANGE_MSG, MAX_NE, MAX_NE_DECIMAL, MIN_NE
+} from './constants';
 
 /**
  * Format collection codes into human friendly words, e.g. [4, 5] -> "raking, picking".
@@ -33,4 +41,32 @@ export const formatEmptyStr = (val: string, isRead: boolean) => {
     return PLACE_HOLDER;
   }
   return val;
+};
+
+/**
+ * Validate whether the NE value has the correct number of decimal place and is within range.
+ */
+export const validateEffectivePopSize = (inputObj: StringInputType): StringInputType => {
+  const validatedObj = inputObj;
+
+  const isOverDecimal = !validator.isDecimal(validatedObj.value, { decimal_digits: `0,${MAX_NE_DECIMAL}` });
+  validatedObj.isInvalid = isOverDecimal;
+
+  if (isOverDecimal) {
+    validatedObj.errMsg = INVALID_NE_DECIMAL_MSG;
+    return validatedObj;
+  }
+
+  const isOutOfRange = !isFloatWithinRange(validatedObj.value, MIN_NE, MAX_NE);
+
+  validatedObj.isInvalid = isOutOfRange;
+
+  if (isOutOfRange) {
+    validatedObj.errMsg = INVALID_NE_RANGE_MSG;
+    return validatedObj;
+  }
+
+  validatedObj.errMsg = undefined;
+
+  return validatedObj;
 };

--- a/frontend/src/components/SeedlotReviewSteps/Collection/utils.ts
+++ b/frontend/src/components/SeedlotReviewSteps/Collection/utils.ts
@@ -4,8 +4,15 @@ import { CodeDescResType } from '../../../types/CodeDescResType';
 /**
  * Format collection codes into human friendly words, e.g. [4, 5] -> "raking, picking".
  */
-export const formatCollectionMethods = (codes: string[], methods: CodeDescResType[]): string => {
+export const formatCollectionMethods = (
+  codes: string[],
+  methods: CodeDescResType[] | undefined
+): string => {
   let formated = '';
+
+  if (!methods) {
+    return formated;
+  }
 
   codes.forEach((code) => {
     const found = methods.find((method) => method.code === code);

--- a/frontend/src/utils/NumberUtils.ts
+++ b/frontend/src/utils/NumberUtils.ts
@@ -1,0 +1,9 @@
+import BigNumber from 'bignumber.js';
+
+/**
+ * A float validator, the validator.isFloat() cannot handle high precision comparing.
+ */
+export const isFloatWithinRange = (value: string, min: string, max: string): boolean => (
+  new BigNumber(value).isGreaterThanOrEqualTo(min)
+  && new BigNumber(value).isLessThanOrEqualTo(max)
+);

--- a/frontend/src/views/Seedlot/ContextContainerClassA/context.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/context.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/definitions';
 import InfoDisplayObj from '../../../types/InfoDisplayObj';
 import { SummarySectionConfig } from '../../../components/SeedlotRegistrationSteps/ParentTreeStep/constants';
+import { StringInputType } from '../../../types/FormInputType';
 
 export type ClassAContextType = {
   seedlotData: SeedlotType | undefined,
@@ -26,7 +27,7 @@ export type ClassAContextType = {
   geoInfoVals: GeoInfoValType,
   genWorthVals: GenWorthValType,
   setGenWorthVal: (traitCode: keyof GenWorthValType, newVal: string) => void,
-  setGeoInfoVal: (infoName: keyof GeoInfoValType, newVal: string) => void,
+  setGeoInfoInputObj: (infoName: keyof GeoInfoValType, inputObj: StringInputType) => void,
   seedlotNumber: string | undefined,
   allStepData: AllStepData,
   setStepData: (stepName: keyof AllStepData, stepData: any) => void,
@@ -105,7 +106,7 @@ const ClassAContext = createContext<ClassAContextType>({
   geoInfoVals: {} as GeoInfoValType,
   genWorthVals: {} as GenWorthValType,
   setGenWorthVal: () => { },
-  setGeoInfoVal: () => { },
+  setGeoInfoInputObj: () => { },
   genWorthInfoItems: {} as Record<keyof RowItem, InfoDisplayObj[]>,
   setGenWorthInfoItems: () => { },
   weightedGwInfoItems: {} as Record<keyof RowItem, InfoDisplayObj>,

--- a/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
@@ -52,7 +52,8 @@ import {
   validateExtractionStep, verifyExtractionStepCompleteness, validateParentStep,
   verifyParentStepCompleteness, checkAllStepsCompletion, getSeedlotPayload,
   initEmptySteps, resDataToState,
-  fillAreaOfUseData
+  fillAreaOfUseData,
+  fillGeoVals
 } from './utils';
 import {
   MAX_EDIT_BEFORE_SAVE, initialAreaOfUseData,
@@ -60,6 +61,7 @@ import {
 } from './constants';
 
 import './styles.scss';
+import { StringInputType } from '../../../types/FormInputType';
 
 type props = {
   children: React.ReactNode
@@ -142,12 +144,19 @@ const ContextContainerClassA = ({ children }: props) => {
    * and use it to fill the form
    */
   const [isFormSubmitted, setIsFormSubmitted] = useState<boolean>(false);
+  const [geoInfoVals, setGeoInfoVals] = useState<GeoInfoValType>(() => INITIAL_GEO_INFO_VALS);
 
   useEffect(() => {
-    if (seedlotQuery.data?.seedlot.seedlotStatus.seedlotStatusCode === 'SUB') {
-      setIsFormSubmitted(true);
+    if (seedlotQuery.status === 'success') {
+      if (seedlotQuery.data?.seedlot.seedlotStatus.seedlotStatusCode === 'SUB') {
+        setIsFormSubmitted(true);
+      }
+
+      if (seedlotQuery.data) {
+        fillGeoVals(setGeoInfoVals, seedlotQuery.data);
+      }
     }
-  }, [seedlotQuery.isFetched]);
+  }, [seedlotQuery.status]);
 
   const getAllSeedlotInfoQuery = useQuery({
     queryKey: ['seedlot-full-form', seedlotNumber],
@@ -666,7 +675,6 @@ const ContextContainerClassA = ({ children }: props) => {
     }
   }, [getFormDraftQuery.status, getFormDraftQuery.isFetchedAfterMount, forestClientQuery.status]);
 
-  const [geoInfoVals, setGeoInfoVals] = useState<GeoInfoValType>(() => INITIAL_GEO_INFO_VALS);
   const [genWorthVals, setGenWorthVals] = useState<GenWorthValType>(() => INITIAL_GEN_WORTH_VALS);
 
   const fillGenWorthVals = () => {
@@ -699,13 +707,10 @@ const ContextContainerClassA = ({ children }: props) => {
   /**
    * Set a single geo info val
    */
-  const setGeoInfoVal = (infoName: keyof GeoInfoValType, newVal: string) => {
+  const setGeoInfoInputObj = (infoName: keyof GeoInfoValType, inputObj: StringInputType) => {
     setGeoInfoVals((prevVals) => ({
       ...prevVals,
-      [infoName]: {
-        ...prevVals[infoName],
-        value: newVal
-      }
+      [infoName]: inputObj
     }));
   };
 
@@ -723,7 +728,7 @@ const ContextContainerClassA = ({ children }: props) => {
         calculatedValues,
         geoInfoVals,
         genWorthVals,
-        setGeoInfoVal,
+        setGeoInfoInputObj,
         setGenWorthVal,
         seedlotNumber,
         allStepData,

--- a/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import BigNumber from 'bignumber.js';
 import { AxiosError } from 'axios';
 import { CollectionForm } from '../../../components/SeedlotRegistrationSteps/CollectionStep/definitions';
@@ -27,6 +28,7 @@ import { ErrorDescriptionType } from '../../../types/ErrorDescriptionType';
 import ROUTES from '../../../routes/constants';
 import { addParamToPath } from '../../../utils/PathUtils';
 import { getOptionsInputObj } from '../../../utils/FormInputUtils';
+import { GeoInfoValType } from '../SeedlotReview/definitions';
 
 import {
   emptyCollectionStep, emptyExtractionStep, emptyInterimStep,
@@ -1019,4 +1021,45 @@ export const fillAreaOfUseData = (
   }
 
   return clonedAreaOfUse;
+};
+
+export const fillGeoVals = (
+  setGeoInfoVals: React.Dispatch<React.SetStateAction<GeoInfoValType>>,
+  data: RichSeedlotType
+) => {
+  setGeoInfoVals((prevVals) => ({
+    ...prevVals,
+    meanElevation: {
+      ...prevVals.meanElevation,
+      value: data.seedlot.collectionElevation?.toString() ?? ''
+    },
+    meanLatDeg: {
+      ...prevVals.meanLatDeg,
+      value: data.seedlot.collectionLatitudeDeg?.toString() ?? ''
+    },
+    meanLatMinute: {
+      ...prevVals.meanLatMinute,
+      value: data.seedlot.collectionLatitudeMin?.toString() ?? ''
+    },
+    meanLatSec: {
+      ...prevVals.meanLatSec,
+      value: data.seedlot.collectionLatitudeSec?.toString() ?? ''
+    },
+    meanLongDeg: {
+      ...prevVals.meanLongDeg,
+      value: data.seedlot.collectionLongitudeDeg?.toString() ?? ''
+    },
+    meanLongMinute: {
+      ...prevVals.meanLongMinute,
+      value: data.seedlot.collectionLongitudeMin?.toString() ?? ''
+    },
+    meanLongSec: {
+      ...prevVals.meanLongMinute,
+      value: data.seedlot.collectionLongitudeMin?.toString() ?? ''
+    },
+    effectivePopSize: {
+      ...prevVals.effectivePopSize,
+      value: data.seedlot.effectivePopulationSize?.toString() ?? ''
+    }
+  }));
 };

--- a/frontend/src/views/Seedlot/SeedlotReview/constants.ts
+++ b/frontend/src/views/Seedlot/SeedlotReview/constants.ts
@@ -1,26 +1,6 @@
 import { GenWorthValType, GeoInfoValType } from './definitions';
 
 export const INITIAL_GEO_INFO_VALS: GeoInfoValType = {
-  becZone: {
-    id: 'geo-info-bec-zone',
-    isInvalid: false,
-    value: ''
-  },
-  subZone: {
-    id: 'geo-info-sub-zone',
-    isInvalid: false,
-    value: ''
-  },
-  variant: {
-    id: 'geo-info-variant',
-    isInvalid: false,
-    value: ''
-  },
-  primarySpu: {
-    id: 'geo-info-primary-spu',
-    isInvalid: false,
-    value: ''
-  },
   meanElevation: {
     id: 'geo-info-mean-elevation',
     isInvalid: false,

--- a/frontend/src/views/Seedlot/SeedlotReview/definitions.ts
+++ b/frontend/src/views/Seedlot/SeedlotReview/definitions.ts
@@ -1,10 +1,6 @@
 import { StringInputType } from '../../../types/FormInputType';
 
 export type GeoInfoValType = {
-  becZone: StringInputType,
-  subZone: StringInputType,
-  variant: StringInputType,
-  primarySpu: StringInputType,
   meanElevation: StringInputType,
   meanLatDeg: StringInputType,
   meanLatMinute: StringInputType,

--- a/oracle-api/src/main/java/ca/bc/gov/backendstartapi/service/SeedPlanUnitService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/backendstartapi/service/SeedPlanUnitService.java
@@ -22,7 +22,7 @@ public class SeedPlanUnitService {
   private final SeedPlanZoneRepository seedPlanZoneRepository;
 
   /**
-   * Get the description of a BEC Zone by an ID
+   * Get the description of a Seed Plan Unit by an ID
    *
    * @return a {@link SpuDto} if found
    * @throws {@link SpuNotFoundException} or {@link SpzNotFoundException}


### PR DESCRIPTION
# Description
Closes #1211

Note that the app's UI is outdated, so it won't look the same as Figma, we'll need to have another task for it

BEC Zone and SPU data are read only

![image](https://github.com/bcgov/nr-spar/assets/25162561/9fd8f520-7691-491f-9efa-e419540beb72)
![image](https://github.com/bcgov/nr-spar/assets/25162561/c50878f7-9cf0-4e82-a4d9-109b1fb44b78)


### Changelog
#### New
- Display BEC Values, Collection Geo data
- Validate Inputs

#### Changed
- [backend] Fill in seed_plan_unit upon submitting a seedlot form 

#### Removed
- None

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media2.giphy.com/media/Nx85vtTY70T3W/giphy.gif" width="200"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-39-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1289-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1289-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)