### PR TITLE
fix: enable seedlot review button

### DIFF
--- a/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
@@ -99,7 +99,7 @@ export const initCollectionState = (
   },
   volumeOfCones: {
     id: 'collection-vol-of-cones',
-    value: String(collectionStepData.clctnVolume.toString()),
+    value: String(collectionStepData.clctnVolume),
     isInvalid: false
   },
   selectedCollectionCodes: {

--- a/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
@@ -89,22 +89,22 @@ export const initCollectionState = (
   },
   numberOfContainers: {
     id: 'collection-num-of-container',
-    value: collectionStepData.noOfContainers.toString(),
+    value: String(collectionStepData.noOfContainers),
     isInvalid: false
   },
   volumePerContainers: {
     id: 'collection-vol-per-container',
-    value: collectionStepData.volPerContainer.toString(),
+    value: String(collectionStepData.volPerContainer),
     isInvalid: false
   },
   volumeOfCones: {
     id: 'collection-vol-of-cones',
-    value: collectionStepData.clctnVolume.toString(),
+    value: String(collectionStepData.clctnVolume.toString()),
     isInvalid: false
   },
   selectedCollectionCodes: {
     id: 'collection-selected-collection-code',
-    value: collectionStepData.coneCollectionMethodCodes.map((methodCode) => methodCode.toString()),
+    value: collectionStepData.coneCollectionMethodCodes.map((methodCode) => String(methodCode)),
     isInvalid: false
   },
   comments: {

--- a/frontend/src/views/Seedlot/SeedlotDetails/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotDetails/index.tsx
@@ -199,7 +199,7 @@ const SeedlotDetails = () => {
                   isFetching={forestClientQuery?.isFetching}
                 />
                 {
-                  seedlotData?.seedlotStatus === 'Submitted'
+                  (seedlotData?.seedlotStatus !== 'Pending' && seedlotData?.seedlotStatus !== 'Incomplete')
                     ? <TscReviewSection seedlotNumber={seedlotNumber ?? ''} />
                     : null
                 }


### PR DESCRIPTION
Enable seedlot review button on seedlots with status other than PND or INC, previously only seedlots with submitted status have that button enabled.

Also fixed a problem where null value will trigger .toString() errors

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-42-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1292-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1292-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)