### PR TITLE
feat: show image tag version on actuator health page

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/config/ImageTagVersionConfig.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/config/ImageTagVersionConfig.java
@@ -14,6 +14,6 @@ public class ImageTagVersionConfig implements HealthIndicator {
 
   @Override
   public Health health() {
-    return Health.up().withDetail("ImageTag", nrSparBackendVersion).build();
+    return Health.up().withDetail("imageTag", nrSparBackendVersion).build();
   }
 }

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/config/ImageTagVersionConfig.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/config/ImageTagVersionConfig.java
@@ -1,0 +1,19 @@
+package ca.bc.gov.backendstartapi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/** This class contains a single component config with image tag version. */
+@Component
+public class ImageTagVersionConfig implements HealthIndicator {
+
+  @Value("${nr-spar-backend-version}")
+  private String nrSparBackendVersion;
+
+  @Override
+  public Health health() {
+    return Health.up().withDetail("ImageTag", nrSparBackendVersion).build();
+  }
+}

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/config/ImageTagVersionConfig.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/config/ImageTagVersionConfig.java
@@ -14,6 +14,6 @@ public class ImageTagVersionConfig implements HealthIndicator {
 
   @Override
   public Health health() {
-    return Health.up().withDetail("ImageTag", nrSparOracleApiVersion).build();
+    return Health.up().withDetail("imageTag", nrSparOracleApiVersion).build();
   }
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/config/ImageTagVersionConfig.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/config/ImageTagVersionConfig.java
@@ -1,0 +1,19 @@
+package ca.bc.gov.oracleapi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/** This class contains a single component config with image tag version. */
+@Component
+public class ImageTagVersionConfig implements HealthIndicator {
+  
+  @Value("${nr-spar-oracle-api.version}")
+  private String nrSparOracleApiVersion;
+
+  @Override
+  public Health health() {
+    return Health.up().withDetail("ImageTag", nrSparOracleApiVersion).build();
+  }
+}


### PR DESCRIPTION
# Description
Closes no issue;

### Changelog
#### New
- Image Tag version configs on both Postgres and Oracle;

#### Changed
- None;

#### Removed
- None;

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media1.giphy.com/media/oUS6u2rbjg4JD4Z9Lp/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-19-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1319-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1319-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)