### PR TITLE
fix(ci): handle ORACLE_SERVICE with GH secrets

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -68,8 +68,9 @@ jobs:
           parameters:
             -p ZONE=${{ inputs.target || github.event.number }}
             -p DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
-            -p ORACLE_DB_USER=${{ vars.ORACLE_DB_USER }}
+            -p ORACLE_DB_USER='${{ vars.ORACLE_DB_USER }}'
             -p ORACLE_DB_PASSWORD='${{ secrets.ORACLE_DB_PASSWORD }}'
+            -p ORACLE_SERVICE='${{ vars.ORACLE_SERVICE }}'
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
             -p AWS_KINESIS_STREAM='${{ secrets.AWS_KINESIS_STREAM }}'
             -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
@@ -117,7 +118,6 @@ jobs:
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
               -p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.log_env_target }}
-              ${{ inputs.target == 'prod' && '-p SERVICE_NAME=dbq01.nrs.bcgov' || '' }}
             verification_path: "actuator/health"
           - name: sync
             file: sync/openshift.deploy.yml


### PR DESCRIPTION
# Description

Required to fix PROD deployments of oracle-api.  Handle ORACLE_SERVICE (or SERVICE_NAME) with GitHub Secrets instead of juggling the config in .deploy.yml.

### Changelog

#### New
- vars.ORACLE_SERVICE for repo
- vars.ORACLE_SERVICE override for prod

#### Removed
- SERVICE_NAME and logic removed from .deploy.yml

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/hj8eOHrXqoLntsCyWz/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-22-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1322-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1322-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)