### PR TITLE
chore(ci): Run FluentBit in TEST and PROD only

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -73,10 +73,6 @@ jobs:
             -p ORACLE_PASSWORD='${{ secrets.ORACLE_PASSWORD }}'
             -p ORACLE_SERVICE='${{ vars.ORACLE_SERVICE }}'
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
-            -p AWS_KINESIS_STREAM='${{ secrets.AWS_KINESIS_STREAM }}'
-            -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
-            -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-            -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}'
 
       - name: FluentBit
         if: fluentbit_target != ''
@@ -87,6 +83,11 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           file: common/openshift.fluentbit.yml
           overwrite: true
+          parameters:
+            -p AWS_KINESIS_STREAM='${{ secrets.AWS_KINESIS_STREAM }}'
+            -p AWS_KINESIS_ROLE_ARN='${{ secrets.AWS_KINESIS_ROLE_ARN }}'
+            -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -111,7 +111,7 @@ jobs:
             overwrite: true
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
+              -p OPENSEARCH_ENV=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
             verification_path: "actuator/health"
           - name: frontend
             file: frontend/openshift.deploy.yml
@@ -126,7 +126,7 @@ jobs:
             overwrite: true
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
+              -p OPENSEARCH_ENV=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
             verification_path: "actuator/health"
           - name: sync
             file: sync/openshift.deploy.yml

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -126,7 +126,7 @@ jobs:
             overwrite: true
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-              -p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.log_env_target }}
+              ${{ github.event_name == 'pull_request' && '' || '-p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.log_env_target }}' }}
             verification_path: "actuator/health"
           - name: sync
             file: sync/openshift.deploy.yml

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -75,7 +75,7 @@ jobs:
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
 
       - name: FluentBit
-        if: fluentbit_target != ''
+        if: inputs.fluentbit_target != ''
         uses: bcgov-nr/action-deployer-openshift@v2.3.0
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -11,10 +11,11 @@ on:
         required: false
         type: boolean
         default: false
-      log_env_target:
+      fluentbit_target:
+        description: FluentBit target; usually development, test or production
+        default: ''
         required: false
         type: string
-        default: development
       tag:
         description: Container tag; usually PR number
         required: false
@@ -77,6 +78,16 @@ jobs:
             -p AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             -p AWS_ACCESS_KEY_SECRET='${{ secrets.AWS_ACCESS_KEY_SECRET }}'
 
+      - name: FluentBit
+        if: fluentbit_target != ''
+        uses: bcgov-nr/action-deployer-openshift@v2.3.0
+        with:
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
+          oc_token: ${{ secrets.OC_TOKEN }}
+          file: common/openshift.fluentbit.yml
+          overwrite: true
+
   deploy:
     name: Deploy
     environment: ${{ inputs.target }}
@@ -87,7 +98,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     strategy:
       matrix:
-        name: [database, backend, fluentbit, frontend, oracle-api, sync]
+        name: [database, backend, frontend, oracle-api, sync]
         include:
           - name: database
             file: database/openshift.deploy.yml
@@ -98,12 +109,9 @@ jobs:
             file: backend/openshift.deploy.yml
             overwrite: true
             parameters:
-              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.log_env_target }}
+              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
             verification_path: "actuator/health"
-          - name: fluentbit
-            file: common/openshift.fluentbit.yml
-            overwrite: true
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -13,7 +13,7 @@ on:
         default: false
       fluentbit_target:
         description: FluentBit target; usually development, test or production
-        default: ''
+        default: development
         required: false
         type: string
       tag:
@@ -75,7 +75,7 @@ jobs:
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
 
       - name: FluentBit
-        if: inputs.fluentbit_target != ''
+        if: inputs.fluentbit_target != 'development'
         uses: bcgov-nr/action-deployer-openshift@v2.3.0
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
@@ -110,8 +110,8 @@ jobs:
             file: backend/openshift.deploy.yml
             overwrite: true
             parameters:
-              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
+              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
             verification_path: "actuator/health"
           - name: frontend
             file: frontend/openshift.deploy.yml
@@ -126,7 +126,7 @@ jobs:
             overwrite: true
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-              ${{ github.event_name == 'pull_request' && '' || '-p NR_SPAR_ORACLE_API_ENV_OPENSEARCH=${{ inputs.log_env_target }}' }}
+              -p NR_SPAR_BACKEND_ENV_OPENSEARCH=${{ inputs.fluentbit_target == 'prod' && 'production' || inputs.fluentbit_target }}
             verification_path: "actuator/health"
           - name: sync
             file: sync/openshift.deploy.yml

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       tag: ${{ inputs.tag }} # Uses PR number if blank
       target: test
-      log_env_target: test
+      fluentbit_target: test
 
   deploy-prod:
     name: PROD
@@ -38,4 +38,4 @@ jobs:
     with:
       tag: ${{ inputs.tag }} # Uses PR number if blank
       target: prod
-      log_env_target: production
+      fluentbit_target: production

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -48,7 +48,7 @@ parameters:
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
     value: "5"
-  - name: NR_SPAR_BACKEND_ENV_OPENSEARCH
+  - name: OPENSEARCH_ENV
     description: Backend environment for OpenSearch. # One of: development, test, production
     required: true
     value: development
@@ -94,8 +94,8 @@ objects:
               env:
                 - name: NR_SPAR_BACKEND_VERSION
                   value: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
-                - name: NR_SPAR_BACKEND_ENV_OPENSEARCH
-                  value: ${NR_SPAR_BACKEND_ENV_OPENSEARCH}
+                - name: OPENSEARCH_ENV
+                  value: ${OPENSEARCH_ENV}
                 - name: ALLOWED_ORIGINS
                   value: ${ALLOWED_ORIGINS}
                 - name: FORESTCLIENTAPI_ADDRESS

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,7 +17,7 @@ server.allowed.cors.origins = ${ALLOWED_ORIGINS:#{'http://127.*, http://localhos
 
 # OpenSearch settings
 nr-spar-ecs-version = 8.11
-nr-spar-backend-env-opensearch = ${NR_SPAR_BACKEND_ENV_OPENSEARCH:development}
+nr-spar-backend-env-opensearch = ${OPENSEARCH_ENV:development}
 nr-spar-team-email-address = FSA.Delivery.Team2@gov.bc.ca
 
 # Database, datasource and JPA

--- a/common/openshift.fluentbit.yml
+++ b/common/openshift.fluentbit.yml
@@ -10,8 +10,6 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: TAG
-    description: Dummy image tag, actually used in other templates
   - name: AWS_KINESIS_STREAM
     description: AWS Kinesis Stream identifier
   - name: AWS_KINESIS_ROLE_ARN
@@ -38,10 +36,18 @@ parameters:
     description: Requested Memory per pod (in gigabytes Gi or megabytes Mi ex. 500Mi)
     displayName: Memory Request
     value: 16Mi
-  - name: MIN_REPLICAS
-    description: Dummy value for workflow convenience
-  - name: MAX_REPLICAS
-    description: Dummy value for workflow convenience
+  - name: AWS_ACCESS_KEY_ID
+    description: AWS Access Key ID
+    required: true
+  - name: AWS_ACCESS_KEY_SECRET
+    description: AWS Access Key Secret
+    required: true
+  - name: AWS_KINESIS_STREAM
+    description: AWS Kinesis stream name
+    required: true
+  - name: AWS_KINESIS_ROLE_ARN
+    description: AWS Kinesis Role ARN
+    required: true
 objects:
   - kind: Deployment
     apiVersion: apps/v1
@@ -82,25 +88,13 @@ objects:
                   memory: "${LOGGING_MEMORY_LIMIT}"
               env:
                 - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${NAME}-${ZONE}-fluentbit
-                      key: aws-access-key-id
+                  value: ${AWS_ACCESS_KEY_ID}
                 - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${NAME}-${ZONE}-fluentbit
-                      key: aws-access-key-secret
+                  value: ${AWS_ACCESS_KEY_SECRET}
                 - name: STREAM_NAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${NAME}-${ZONE}-fluentbit
-                      key: aws-kinesis-stream
+                  value: ${AWS_KINESIS_STREAM}
                 - name: ROLE_ARN
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${NAME}-${ZONE}-fluentbit
-                      key: aws-kinesis-role-arn
+                  value: ${AWS_KINESIS_ROLE_ARN}
                 - name: FLUENT_CONF_HOME
                   value: ${FLUENT_CONF_HOME}
                 - name: FLUENT_VERSION

--- a/common/openshift.fluentbit.yml
+++ b/common/openshift.fluentbit.yml
@@ -144,19 +144,6 @@ objects:
                   - key: timestamp.lua
                     path: timestamp.lua
                 defaultMode: 0644
-  - kind: PersistentVolumeClaim
-    apiVersion: v1
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}-logs
-    spec:
-      accessModes:
-        - ReadWriteMany
-      resources:
-        requests:
-          storage: "75Mi"
-      storageClassName: netapp-file-standard
   - kind: ConfigMap
     apiVersion: v1
     metadata:

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -18,18 +18,6 @@ parameters:
     value: "5432"
   - name: FORESTCLIENTAPI_KEY
     required: true
-  - name: AWS_ACCESS_KEY_ID
-    description: AWS Access Key ID
-    required: true
-  - name: AWS_ACCESS_KEY_SECRET
-    description: AWS Access Key Secret
-    required: true
-  - name: AWS_KINESIS_STREAM
-    description: AWS Kinesis stream name
-    required: true
-  - name: AWS_KINESIS_ROLE_ARN
-    description: AWS Kinesis Role ARN
-    required: true
   - name: ORACLE_HOST
     description: Oracle database host
     value: nrcdb03.bcgov
@@ -77,17 +65,6 @@ objects:
         app: ${NAME}-${ZONE}
     stringData:
       forest-client-api-key: ${FORESTCLIENTAPI_KEY}
-  - apiVersion: v1
-    kind: Secret
-    metadata:
-      name: ${NAME}-${ZONE}-fluentbit
-      labels:
-        app: ${NAME}-${ZONE}
-    stringData:
-      aws-access-key-id: ${AWS_ACCESS_KEY_ID}
-      aws-access-key-secret: ${AWS_ACCESS_KEY_SECRET}
-      aws-kinesis-stream: ${AWS_KINESIS_STREAM}
-      aws-kinesis-role-arn: ${AWS_KINESIS_ROLE_ARN}
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -88,3 +88,16 @@ objects:
     spec:
       policyTypes:
         - Ingress
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-fluentbit-logs
+    spec:
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: "75Mi"
+      storageClassName: netapp-file-standard

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -42,7 +42,7 @@ parameters:
     value: "2"
   - name: NR_SPAR_ORACLE_API_ENV_OPENSEARCH
     description: Oracle API environment for OpenSearch. # One of: development, test, production
-    required: true
+    required: false
     value: development
   - name: ORACLEDB_KEYSTORE
     description: Keystore location path

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -40,7 +40,7 @@ parameters:
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
     value: "2"
-  - name: NR_SPAR_ORACLE_API_ENV_OPENSEARCH
+  - name: OPENSEARCH_ENV
     description: Oracle API environment for OpenSearch. # One of: development, test, production
     required: false
     value: development
@@ -80,8 +80,8 @@ objects:
               env:
                 - name: NR_SPAR_ORACLE_API_VERSION
                   value: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
-                - name: NR_SPAR_ORACLE_API_ENV_OPENSEARCH
-                  value: ${NR_SPAR_ORACLE_API_ENV_OPENSEARCH}
+                - name: OPENSEARCH_ENV
+                  value: ${OPENSEARCH_ENV}
                 - name: ALLOWED_ORIGINS
                   value: ${ALLOWED_ORIGINS}
                 - name: DATABASE_HOST

--- a/oracle-api/src/main/resources/application.properties
+++ b/oracle-api/src/main/resources/application.properties
@@ -7,7 +7,7 @@ app.version = @project.version@
 
 # OpenSearch settings
 nr-spar-ecs-version = 8.8
-nr-spar-oracle-api-env-opensearch = ${NR_SPAR_ORACLE_API_ENV_OPENSEARCH:development}
+nr-spar-oracle-api-env-opensearch = ${OPENSEARCH_ENV:development}
 nr-spar-team-email-address = FSA.Delivery.Team2@gov.bc.ca
 
 # Certificate for the Database
@@ -17,7 +17,7 @@ ca.bc.gov.nrs.oracle.host = ${DATABASE_HOST}
 
 # OpenSearch settings
 nr-spar-ecs-version = 8.11
-nr-spar-oracle-api-env-opensearch = ${NR_SPAR_ORACLE_API_ENV_OPENSEARCH:development}
+nr-spar-oracle-api-env-opensearch = ${OPENSEARCH_ENV:development}
 nr-spar-team-email-address = FSA.Delivery.Team2@gov.bc.ca
 
 # Certificate for the Database


### PR DESCRIPTION
# Description

### Changelog

#### Changed
- Only run FluentBit when `fluentbit_target` is provided
- Only provide `fluentbit_target` for TEST and PROD
- Move fluentbit config from init into fluentbit deploy
- Drop fluentbit secret object, pass into deployment

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/iApBSyCtIukJQzcRLr/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-30-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1330-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1330-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)