### PR TITLE
fix: remove mean geospatial columns

### DIFF
--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -365,31 +365,6 @@ export const rowTemplate: RowItem = {
     isInvalid: false,
     value: ''
   },
-  meanDegLat: {
-    id: '',
-    isInvalid: false,
-    value: ''
-  },
-  meanMinLat: {
-    id: '',
-    isInvalid: false,
-    value: ''
-  },
-  meanDegLong: {
-    id: '',
-    isInvalid: false,
-    value: ''
-  },
-  meanMinLong: {
-    id: '',
-    isInvalid: false,
-    value: ''
-  },
-  meanElevation: {
-    id: '',
-    isInvalid: false,
-    value: ''
-  },
   isMixTab: false
 };
 
@@ -654,51 +629,6 @@ export const headerTemplate: Array<HeaderObj> = [
     editable: false,
     isAnOption: false,
     availableInTabs: [undefined, undefined, 'mixTab']
-  },
-  {
-    id: 'meanDegLat',
-    name: 'Mean degrees latitude',
-    description: 'Mean degrees latitude',
-    enabled: false,
-    editable: false,
-    isAnOption: true,
-    availableInTabs: [undefined, 'successTab']
-  },
-  {
-    id: 'meanMinLat',
-    name: 'Mean minutes latitude',
-    description: 'Mean minutes latitude',
-    enabled: false,
-    editable: false,
-    isAnOption: true,
-    availableInTabs: [undefined, 'successTab']
-  },
-  {
-    id: 'meanDegLong',
-    name: 'Mean degrees longitude',
-    description: 'Mean degrees longitude',
-    enabled: false,
-    editable: false,
-    isAnOption: true,
-    availableInTabs: [undefined, 'successTab']
-  },
-  {
-    id: 'meanMinLong',
-    name: 'Mean minutes longitude',
-    description: 'Mean minutes longitude',
-    enabled: false,
-    editable: false,
-    isAnOption: true,
-    availableInTabs: [undefined, 'successTab']
-  },
-  {
-    id: 'meanElevation',
-    name: 'Mean elevation',
-    description: 'Mean elevation',
-    enabled: false,
-    editable: false,
-    isAnOption: true,
-    availableInTabs: [undefined, 'successTab']
   },
   {
     id: 'actions',

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
@@ -36,12 +36,7 @@ export type StrTypeRowItem = {
   w_wdu: StringInputType,
   w_wwd: StringInputType,
   w_dsg: StringInputType,
-  w_iws: StringInputType,
-  meanDegLat: StringInputType,
-  meanMinLat: StringInputType,
-  meanDegLong: StringInputType,
-  meanMinLong: StringInputType,
-  meanElevation: StringInputType,
+  w_iws: StringInputType
 }
 
 export type PrimitiveRowItem = {


### PR DESCRIPTION
# Description
Closes #1252

Removed unused columns on the table as described in the issue

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-34-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1334-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1334-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)