### PR TITLE
fix: return all stages of orchards

### DIFF
--- a/frontend/src/api-service/orchardAPI.ts
+++ b/frontend/src/api-service/orchardAPI.ts
@@ -1,4 +1,3 @@
-import MultiOptionsObj from '../types/MultiOptionsObject';
 import OrchardDataType from '../types/OrchardDataType';
 import ApiConfig from './ApiConfig';
 import api from './api';
@@ -20,16 +19,5 @@ export const getAllParentTrees = (vegCode: string) => {
 
 export const getOrchardByVegCode = (vegCode: string) => {
   const url = `${ApiConfig.orchardsVegCode}/${vegCode}`;
-  return api.get(url).then((res) => {
-    const unSortedList: Array<MultiOptionsObj> = [];
-    res.data
-      .forEach((orchard: OrchardDataType) => (
-        unSortedList.push({
-          code: orchard.id,
-          description: orchard.name,
-          label: `${orchard.id} - ${orchard.name} - ${orchard.lotTypeCode} - ${orchard.stageCode}`
-        })
-      ));
-    return unSortedList.sort((a, b) => Number(a.code) - Number(b.code));
-  });
+  return api.get(url).then((res): OrchardDataType[] => res.data);
 };

--- a/frontend/src/components/SeedlotRegistrationSteps/OrchardStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OrchardStep/index.tsx
@@ -99,7 +99,17 @@ const OrchardStep = ({
   const orchardQuery = useQuery({
     queryKey: ['orchards', seedlotSpecies.code],
     queryFn: () => getOrchardByVegCode(seedlotSpecies.code),
-    enabled: !isFormSubmitted
+    enabled: !isFormSubmitted,
+    select: (orchards) => orchards
+      .filter((orchard) => (orchard.stageCode !== 'RET'))
+      .map((orchard) => (
+        ({
+          code: orchard.id,
+          description: orchard.name,
+          label: `${orchard.id} - ${orchard.name} - ${orchard.lotTypeCode} - ${orchard.stageCode}`
+        })
+      ))
+      .sort((a, b) => Number(a.code) - Number(b.code))
   });
 
   const setGametic = (event: ComboBoxEvent, isFemale: boolean) => {

--- a/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
@@ -384,7 +384,16 @@ const ContextContainerClassA = ({ children }: props) => {
   const orchardQuery = useQuery({
     queryKey: ['orchards', seedlotSpecies.code],
     queryFn: () => getOrchardByVegCode(seedlotSpecies.code),
-    enabled: seedlotQuery.status === 'success'
+    enabled: seedlotQuery.status === 'success',
+    select: (orchards) => orchards
+      .map((orchard) => (
+        ({
+          code: orchard.id,
+          description: orchard.name,
+          label: `${orchard.id} - ${orchard.name} - ${orchard.lotTypeCode} - ${orchard.stageCode}`
+        })
+      ))
+      .sort((a, b) => Number(a.code) - Number(b.code))
   });
 
   useEffect(() => {

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/OrchardRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/OrchardRepository.java
@@ -12,6 +12,6 @@ public interface OrchardRepository extends JpaRepository<OrchardEntity, String> 
   @Query("from OrchardEntity o where o.stageCode <> 'RET' and o.id = ?1")
   Optional<OrchardEntity> findNotRetiredById(String id);
 
-  // Find all orchards that are not retired with a given vegCode
+  // Find all orchards with a given vegCode
   List<OrchardEntity> findAllByVegetationCode(String vegCode);
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/OrchardRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/OrchardRepository.java
@@ -13,5 +13,5 @@ public interface OrchardRepository extends JpaRepository<OrchardEntity, String> 
   Optional<OrchardEntity> findNotRetiredById(String id);
 
   // Find all orchards that are not retired with a given vegCode
-  List<OrchardEntity> findAllByVegetationCodeAndStageCodeNot(String vegCode, String stageCode);
+  List<OrchardEntity> findAllByVegetationCode(String vegCode);
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/ParentTreeRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/ParentTreeRepository.java
@@ -25,7 +25,7 @@ public interface ParentTreeRepository extends JpaRepository<ParentTreeEntity, Lo
               ON O.ORCHARD_ID = PTO.ORCHARD_ID
             JOIN PARENT_TREE_GENETIC_QUALITY Q
               ON PT.PARENT_TREE_ID = Q.PARENT_TREE_ID
-            WHERE O.ORCHARD_STAGE_CODE != 'RET' AND PT.VEGETATION_CODE = ?1
+            WHERE PT.VEGETATION_CODE = ?1
           """,
       nativeQuery = true)
   List<ParentTreeProj> findAllParentTreeWithVegCode(String vegCode);

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/OrchardService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/OrchardService.java
@@ -134,12 +134,12 @@ public class OrchardService {
    * @return {@link Optional} of a {@link List} of {@link OrchardParentTreeDto}
    */
   public Optional<List<OrchardDto>> findNotRetOrchardsByVegCode(String vegCode) {
-    SparLog.info("Finding not retired Orchard by VegCode: {}", vegCode);
+    SparLog.info("Finding all Orchards by VegCode: {}", vegCode);
 
     List<OrchardDto> resultList = new ArrayList<>();
 
     List<OrchardEntity> orchardList =
-        orchardRepository.findAllByVegetationCodeAndStageCodeNot(vegCode.toUpperCase(), "RET");
+        orchardRepository.findAllByVegetationCode(vegCode.toUpperCase());
 
     orchardList.forEach(
         orchard -> {

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/repository/OrchardRepositoryTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/repository/OrchardRepositoryTest.java
@@ -62,23 +62,21 @@ class OrchardRepositoryTest {
   @DisplayName("findOrchardByVegCodeRepoSuccessTest")
   void findOrchardByVegCodeRepoSuccessTest() {
     String vegCode = "PLI";
-    String stageCode = "RET";
-    List<OrchardEntity> orchardRet =
-        orchardRepository.findAllByVegetationCodeAndStageCodeNot(vegCode, stageCode);
+    List<OrchardEntity> orchardRet = orchardRepository.findAllByVegetationCode(vegCode);
 
     Assertions.assertFalse(orchardRet.isEmpty());
     Assertions.assertEquals(2, orchardRet.size());
     Assertions.assertEquals(vegCode, orchardRet.get(0).getVegetationCode());
     Assertions.assertEquals(vegCode, orchardRet.get(1).getVegetationCode());
-    Assertions.assertNotEquals(stageCode, orchardRet.get(0).getStageCode());
-    Assertions.assertNotEquals(stageCode, orchardRet.get(1).getStageCode());
   }
 
   @Test
-  @DisplayName("findOrchardByVegCodeRepoErrorTest")
+  @DisplayName("Find orchard by veg code should include retired orchard")
   void findOrchardByVegCodeRepoErrorTest() {
     List<OrchardEntity> orchardRet =
-        orchardRepository.findAllByVegetationCodeAndStageCodeNot("SX", "RET");
+        orchardRepository.findAllByVegetationCode("FDC").stream()
+            .filter(orchard -> orchard.getStageCode() == "RET")
+            .toList();
 
     Assertions.assertTrue(orchardRet.isEmpty());
   }

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/OrchardServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/OrchardServiceTest.java
@@ -312,7 +312,7 @@ class OrchardServiceTest {
 
     List<OrchardEntity> repoResult = List.of(firstOrchard, secondOrchard, expiredOrchard);
 
-    when(orchardRepository.findAllByVegetationCodeAndStageCodeNot(vegCode, "RET"))
+    when(orchardRepository.findAllByVegetationCode(vegCode))
         .thenReturn(repoResult);
 
     List<OrchardDto> listToTest = orchardService.findNotRetOrchardsByVegCode(vegCode).get();


### PR DESCRIPTION
 The purpose of this PR is to allow data with retired orchard and parent trees under retired orchard to appear correctly   

- allow Oracle orchard endpoint to return all stages of Orchards by removing the filter for retired orchards
 - filter retired orchards on orchard step of the reg form instead
 - return all parent trees under a veg code regardless of orchard's stage code


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-46-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1346-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1346-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)