### PR TITLE
chore(ci): split out sync envars

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   init:
     name: Deploy (init)
-    environment: ${{ inputs.target }}
+    environment: ${{ inputs.environment }}
     outputs:
       mod-tag: ${{ steps.mod-tag.outputs.mod-tag }}
     runs-on: ubuntu-22.04
@@ -92,7 +92,7 @@ jobs:
 
   database:
     name: Deploy (database)
-    environment: ${{ inputs.target }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-22.04
     steps:
       - name: Database
@@ -111,7 +111,7 @@ jobs:
 
   deploy:
     name: Deploy
-    environment: ${{ inputs.target }}
+    environment: ${{ inputs.environment }}
     needs: [database, init]
     outputs:
       triggered: ${{ steps.trigger.outputs.triggered }}
@@ -177,7 +177,7 @@ jobs:
   verify:
     name: Verify ETL
     if: inputs.etl == 'true'
-    environment: ${{ inputs.target }}
+    environment: ${{ inputs.environment }}
     needs: [deploy]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -67,10 +67,12 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ inputs.target }}
-            -p ORACLE_USER='${{ vars.ORACLE_USER }}'
+            -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
             -p ORACLE_PASSWORD='${{ secrets.ORACLE_PASSWORD }}'
             -p ORACLE_SERVICE='${{ vars.ORACLE_SERVICE }}'
-            -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
+            -p ORACLE_USER='${{ vars.ORACLE_USER }}'
+            -p ORACLE_SYNC_USER='${{ vars.ORACLE_SYNC_USER }}'
+            -p ORACLE_SYNC_PASSWORD='${{ secrets.ORACLE_SYNC_PASSWORD }}'
 
       - name: FluentBit
         if: inputs.fluentbit_target != 'development'

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -29,7 +29,7 @@ parameters:
     required: true
   - name: ORACLE_SYNC_USER
     description: Oracle database username for Sync
-    value: proxy_fsa_spar_sync_user
+    value: proxy_fsa_spar_read_only_user
 objects:
   - apiVersion: v1
     kind: Secret

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -23,13 +23,13 @@ parameters:
     required: true
   - name: ORACLE_USER
     description: Oracle database username for API
-    value: proxy_fsa_spar_sync_user
+    value: proxy_fsa_spar_read_only_user
   - name: ORACLE_SYNC_PASSWORD
     description: Oracle database password for Sync
     required: true
   - name: ORACLE_SYNC_USER
     description: Oracle database username for Sync
-    value: proxy_fsa_spar_read_only_user
+    value: proxy_fsa_spar_sync_user
 objects:
   - apiVersion: v1
     kind: Secret

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -18,12 +18,18 @@ parameters:
   - name: ORACLE_SERVICE
     description: Oracle service name
     value: dbq01.nrs.bcgov
-  - name: ORACLE_USER
-    description: Oracle database username for API
-    value: proxy_fsa_spar_sync_user
   - name: ORACLE_PASSWORD
     description: Oracle database password for API
     required: true
+  - name: ORACLE_USER
+    description: Oracle database username for API
+    value: proxy_fsa_spar_sync_user
+  - name: ORACLE_SYNC_PASSWORD
+    description: Oracle database password for Sync
+    required: true
+  - name: ORACLE_SYNC_USER
+    description: Oracle database username for Sync
+    value: proxy_fsa_spar_sync_user
 objects:
   - apiVersion: v1
     kind: Secret
@@ -37,6 +43,8 @@ objects:
       oracle-port: ${ORACLE_PORT}
       oracle-service: ${ORACLE_SERVICE}
       oracle-user: ${ORACLE_USER}
+      oracle-sync-password: ${ORACLE_SYNC_PASSWORD}
+      oracle-sync-user: ${ORACLE_SYNC_USER}
   - apiVersion: v1
     kind: Secret
     metadata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,10 +159,10 @@ services:
       EXECUTION_ID: ${EXECUTION_ID:-100}
       DATABASE_HOST: database
       ORACLE_HOST: ${ORACLE_HOST:-nrcdb03.bcgov}
-      ORACLE_PASSWORD: ${ORACLE_PASSWORD}
       ORACLE_PORT: ${ORACLE_PORT:-1543}
       ORACLE_SERVICE: ${ORACLE_SERVICE:-dbq01.nrs.bcgov}
-      ORACLE_USER: ${ORACLE_USER:-proxy_fsa_spar_read_only_user}
+      ORACLE_SYNC_PASSWORD: ${ORACLE_PASSWORD}
+      ORACLE_SYNC_USER: ${ORACLE_USER:-proxy_fsa_spar_read_only_user}
     depends_on:
       database:
         condition: service_started

--- a/sync/src/main.py
+++ b/sync/src/main.py
@@ -19,8 +19,8 @@ def generate_db_config(type_,schema_,settings):
     if type_ == "ORACLE":
         dbconfig = {
             "type": "ORACLE",
-            "username": os.environ.get("ORACLE_USER"),
-            "password": os.environ.get("ORACLE_PASSWORD"),
+            "username": os.environ.get("ORACLE_SYNC_USER"),
+            "password": os.environ.get("ORACLE_SYNC_PASSWORD"),
             "host": os.environ.get("ORACLE_HOST"),
             "port": os.environ.get("ORACLE_PORT"),
             "service_name": os.environ.get("ORACLE_SERVICE"),
@@ -64,8 +64,8 @@ def required_variables_exists():
        not env_var_is_filled("ORACLE_PORT") or \
        not env_var_is_filled("ORACLE_HOST") or \
        not env_var_is_filled("ORACLE_SERVICE") or \
-       not env_var_is_filled("ORACLE_USER") or \
-       not env_var_is_filled("ORACLE_PASSWORD"):
+       not env_var_is_filled("ORACLE_SYNC_USER") or \
+       not env_var_is_filled("ORACLE_SYNC_PASSWORD"):
        ret = False        
         
     if ret:

--- a/sync/src/main.py
+++ b/sync/src/main.py
@@ -109,7 +109,7 @@ def read_settings():
         
 
 def main() -> None:
-    definition_of_yes = ["Y","YES","1","T","TRUE"]
+    definition_of_yes = ["Y","YES","1","T","TRUE","t","true"]
     # print(os.environ.get("TEST_MODE"))
     if os.environ.get("TEST_MODE") is None:
         print("Error: test mode variable is None")


### PR DESCRIPTION
# Description

Splits out envars for sync.

### Changelog
#### New
- Vars/secrets for ORACLE_SYNC_USER and ORACLE_SYNC_PASSWORD

#### Changed
-  Values changed for pick up

### How was this tested?
- [x] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/3xz2BLBOt13X9AgjEA/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-12-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1362-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1362-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)