### PR TITLE
feat: addressnulls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,8 +161,8 @@ services:
       ORACLE_HOST: ${ORACLE_HOST:-nrcdb03.bcgov}
       ORACLE_PORT: ${ORACLE_PORT:-1543}
       ORACLE_SERVICE: ${ORACLE_SERVICE:-dbq01.nrs.bcgov}
-      ORACLE_SYNC_PASSWORD: ${ORACLE_PASSWORD}
-      ORACLE_SYNC_USER: ${ORACLE_USER:-proxy_fsa_spar_read_only_user}
+      ORACLE_SYNC_PASSWORD: ${ORACLE_SYNC_PASSWORD}
+      ORACLE_SYNC_USER: ${ORACLE_SYNC_USER:-proxy_fsa_spar_read_only_user}
     depends_on:
       database:
         condition: service_started

--- a/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_PARENT_TREE_EXTRACT.sql
+++ b/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_PARENT_TREE_EXTRACT.sql
@@ -5,7 +5,7 @@ SELECT
 , spt.pollen_count
 , spt.smp_success_pct
 , spt.non_orchard_pollen_contam_pct
-, spt.total_genetic_worth_contrib
+, COALESCE(spt.total_genetic_worth_contrib,0) total_genetic_worth_contrib
 , spt.revision_count
  FROM spar.seedlot_parent_tree spt
 WHERE spt.seedlot_number = %(p_seedlot_number)s


### PR DESCRIPTION
# Description
Address issue: ORA-01400: cannot insert NULL into ("THE"."SEEDLOT_PARENT_TREE"."TOTAL_GENETIC_WORTH_CONTRIB")

### Changelog
-

#### Changed
-mod POSTGRES_SEEDLOT_PARENT_TREE_EXTRACT.sql to default to 0

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [X] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-19-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1369-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1369-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)