### PR TITLE
fix: network error upon login for tsc admin profile

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpoint.java
@@ -538,7 +538,7 @@ public class SeedlotEndpoint {
     return saveSeedlotFormService.getFormClassA(seedlotNumber);
   }
 
-  /** Retreive only the progress_status column from the form progress table. */
+  /** Retrieve only the progress_status column from the form progress table. */
   @GetMapping("/{seedlotNumber}/a-class-form-progress/status")
   @Operation(
       summary = "Retrieve the progress status of an a-class reg form.",

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/security/LoggedUserService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/security/LoggedUserService.java
@@ -1,6 +1,8 @@
 package ca.bc.gov.backendstartapi.security;
 
+import ca.bc.gov.backendstartapi.config.SparLog;
 import ca.bc.gov.backendstartapi.entity.embeddable.AuditInformation;
+import ca.bc.gov.backendstartapi.exception.ClientIdForbiddenException;
 import ca.bc.gov.backendstartapi.exception.UserNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -99,5 +101,27 @@ public class LoggedUserService {
    */
   public AuditInformation createAuditCurrentUser() {
     return new AuditInformation(getLoggedUserId());
+  }
+
+  /**
+   * Verify if the service initiator has the correct access.
+   *
+   * @param clientId to verify
+   * @throw an {@link ClientIdForbiddenException}
+   */
+  public void verifySeedlotAccessPrivilege(String clientId) {
+    Optional<UserInfo> userInfo = getLoggedUserInfo();
+
+    if (userInfo.get().roles().contains("SPAR_TSC_ADMIN")) {
+      SparLog.info("Request allowed, TSC Admin role found!");
+      return;
+    }
+
+    boolean isForbidden = userInfo.isPresent() && !userInfo.get().clientIds().contains(clientId);
+
+    if (isForbidden) {
+      SparLog.info("Request denied due to user not having client id: {}", clientId);
+      throw new ClientIdForbiddenException();
+    }
   }
 }

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/security/LoggedUserService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/security/LoggedUserService.java
@@ -112,14 +112,16 @@ public class LoggedUserService {
   public void verifySeedlotAccessPrivilege(String clientId) {
     Optional<UserInfo> userInfo = getLoggedUserInfo();
 
+    if (userInfo.isEmpty()) {
+      throw new UserNotFoundException();
+    }
+
     if (userInfo.get().roles().contains("SPAR_TSC_ADMIN")) {
       SparLog.info("Request allowed, TSC Admin role found!");
       return;
     }
 
-    boolean isForbidden = userInfo.isPresent() && !userInfo.get().clientIds().contains(clientId);
-
-    if (isForbidden) {
+    if (!userInfo.get().clientIds().contains(clientId)) {
       SparLog.info("Request denied due to user not having client id: {}", clientId);
       throw new ClientIdForbiddenException();
     }

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -260,8 +260,10 @@ public class SeedlotService {
     Optional<UserInfo> userInfo = loggedUserService.getLoggedUserInfo();
 
     if (userInfo.isPresent() && !userInfo.get().clientIds().contains(clientId)) {
-      SparLog.info("User has no access to seedlot {}, request denied.", seedlotNumber);
-      throw new ClientIdForbiddenException();
+      if (!userInfo.get().roles().contains("SPAR_TSC_ADMIN")) {
+        SparLog.info("User has no access to seedlot {}, request denied.", seedlotNumber);
+        throw new ClientIdForbiddenException();
+      }
     }
 
     SeedlotDto seedlotDto = new SeedlotDto();

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -40,7 +40,6 @@ import ca.bc.gov.backendstartapi.entity.embeddable.AuditInformation;
 import ca.bc.gov.backendstartapi.entity.idclass.SeedlotParentTreeId;
 import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
 import ca.bc.gov.backendstartapi.entity.seedlot.SeedlotOrchard;
-import ca.bc.gov.backendstartapi.exception.ClientIdForbiddenException;
 import ca.bc.gov.backendstartapi.exception.GeneticClassNotFoundException;
 import ca.bc.gov.backendstartapi.exception.InvalidSeedlotRequestException;
 import ca.bc.gov.backendstartapi.exception.NoSpuForOrchardException;
@@ -215,9 +214,7 @@ public class SeedlotService {
       String clientId, int pageNumber, int pageSize) {
     Optional<UserInfo> userInfo = loggedUserService.getLoggedUserInfo();
 
-    if (userInfo.isPresent() && !userInfo.get().clientIds().contains(clientId)) {
-      throw new ClientIdForbiddenException();
-    }
+    loggedUserService.verifySeedlotAccessPrivilege(clientId);
 
     SparLog.info(
         "Retrieving paginated list of seedlots for the user: {} with client id: {}",

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -257,14 +257,8 @@ public class SeedlotService {
     SparLog.info("Seedlot number {} found", seedlotNumber);
 
     String clientId = seedlotEntity.getApplicantClientNumber();
-    Optional<UserInfo> userInfo = loggedUserService.getLoggedUserInfo();
 
-    if (userInfo.isPresent() && !userInfo.get().clientIds().contains(clientId)) {
-      if (!userInfo.get().roles().contains("SPAR_TSC_ADMIN")) {
-        SparLog.info("User has no access to seedlot {}, request denied.", seedlotNumber);
-        throw new ClientIdForbiddenException();
-      }
-    }
+    loggedUserService.verifySeedlotAccessPrivilege(clientId);
 
     SeedlotDto seedlotDto = new SeedlotDto();
 

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/security/LoggedUserServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/security/LoggedUserServiceTest.java
@@ -1,0 +1,103 @@
+package ca.bc.gov.backendstartapi.security;
+
+import static org.mockito.Mockito.when;
+
+import ca.bc.gov.backendstartapi.exception.ClientIdForbiddenException;
+import ca.bc.gov.backendstartapi.exception.UserNotFoundException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class LoggedUserServiceTest {
+
+  @Mock UserAuthenticationHelper userAuthenticationHelper;
+
+  private LoggedUserService loggedUserService;
+
+  @BeforeEach
+  void setup() {
+    loggedUserService = new LoggedUserService(userAuthenticationHelper);
+  }
+
+  private UserInfo mockUserInfo(Set<String> roles, List<String> clients) {
+    return new UserInfo(
+        "123456789@idir",
+        "Bilbo",
+        "Baggings",
+        "bilbo.baggings@gov.bc.ca",
+        "Baggings, Bilbo LWRS:EX",
+        "BAGGINGS",
+        null,
+        IdentityProvider.IDIR,
+        roles != null ? roles : Set.of(),
+        clients != null ? clients : List.of(),
+        "abcdef123456789");
+  }
+
+  @Test
+  @DisplayName("Verify seedlot access privilege happy path should succeed")
+  void verifySeedlotAccessPrivilege_happyPath_shouldSucceed() {
+    String clientId = "00012345";
+
+    when(userAuthenticationHelper.getUserInfo())
+        .thenReturn(
+            Optional.of(mockUserInfo(Set.of("FAKE_ROLE_TEST_00012345"), List.of("00012345"))));
+
+    Assertions.assertDoesNotThrow(
+        () -> {
+          loggedUserService.verifySeedlotAccessPrivilege(clientId);
+        });
+  }
+
+  @Test
+  @DisplayName("Verify seedlot access privilege no user should succeed")
+  void verifySeedlotAccessPrivilege_noUser_shouldSucceed() {
+    String clientId = "00012345";
+
+    when(userAuthenticationHelper.getUserInfo()).thenReturn(Optional.empty());
+
+    Assertions.assertThrows(
+        UserNotFoundException.class,
+        () -> {
+          loggedUserService.verifySeedlotAccessPrivilege(clientId);
+        });
+  }
+
+  @Test
+  @DisplayName("Verify seedlot access privilege tsc admin should succeed")
+  void verifySeedlotAccessPrivilege_tscAdmin_shouldSucceed() {
+    String clientId = "00012345";
+
+    when(userAuthenticationHelper.getUserInfo())
+        .thenReturn(Optional.of(mockUserInfo(Set.of("SPAR_TSC_ADMIN"), null)));
+
+    Assertions.assertDoesNotThrow(
+        () -> {
+          loggedUserService.verifySeedlotAccessPrivilege(clientId);
+        });
+  }
+
+  @Test
+  @DisplayName("Verify seedlot access privilege regular user should fail")
+  void verifySeedlotAccessPrivilege_regularUser_shouldSucceed() {
+    String clientId = "00012345";
+
+    when(userAuthenticationHelper.getUserInfo())
+        .thenReturn(
+            Optional.of(mockUserInfo(Set.of("FAKE_ROLE_TEST_00012345"), List.of("00012346"))));
+
+    Assertions.assertThrows(
+        ClientIdForbiddenException.class,
+        () -> {
+          loggedUserService.verifySeedlotAccessPrivilege(clientId);
+        });
+  }
+}

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -348,6 +349,10 @@ class SeedlotServiceTest {
   @DisplayName("findSeedlotsByUserClientIdForbidden")
   void getUserSeedlots_forbidden_shouldFail() {
     when(loggedUserService.getLoggedUserInfo()).thenReturn(Optional.of(UserInfo.createDevUser()));
+
+    doThrow(ClientIdForbiddenException.class)
+        .when(loggedUserService)
+        .verifySeedlotAccessPrivilege(any());
 
     Assertions.assertThrows(
         ClientIdForbiddenException.class,

--- a/frontend/src/components/SeedlotCards/constants.ts
+++ b/frontend/src/components/SeedlotCards/constants.ts
@@ -12,7 +12,8 @@ export const cards = [
     isEmpty: false,
     emptyTitle: '',
     emptyDescription: '',
-    displayForAdmin: false
+    displayForAdmin: true,
+    displayForNonAdmin: true
   },
   // {
   //   id: '2',
@@ -37,7 +38,8 @@ export const cards = [
     isEmpty: false,
     emptyTitle: '',
     emptyDescription: '',
-    displayForAdmin: false
+    displayForAdmin: false,
+    displayForNonAdmin: true
   },
   {
     id: '4',
@@ -49,6 +51,7 @@ export const cards = [
     isEmpty: false,
     emptyTitle: '',
     emptyDescription: '',
-    displayForAdmin: true
+    displayForAdmin: true,
+    displayForNonAdmin: false
   }
 ];

--- a/frontend/src/components/SeedlotCards/constants.ts
+++ b/frontend/src/components/SeedlotCards/constants.ts
@@ -11,7 +11,8 @@ export const cards = [
     highlighted: false,
     isEmpty: false,
     emptyTitle: '',
-    emptyDescription: ''
+    emptyDescription: '',
+    displayForAdmin: false
   },
   // {
   //   id: '2',
@@ -35,6 +36,19 @@ export const cards = [
     highlighted: false,
     isEmpty: false,
     emptyTitle: '',
-    emptyDescription: ''
+    emptyDescription: '',
+    displayForAdmin: false
+  },
+  {
+    id: '4',
+    image: 'Sprout',
+    header: 'Review seedlots',
+    description: 'Check all seedlots that are waiting for approval',
+    link: ROUTES.TSC_SEEDLOTS_TABLE,
+    highlighted: false,
+    isEmpty: false,
+    emptyTitle: '',
+    emptyDescription: '',
+    displayForAdmin: true
   }
 ];

--- a/frontend/src/components/SeedlotCards/constants.ts
+++ b/frontend/src/components/SeedlotCards/constants.ts
@@ -38,12 +38,12 @@ export const cards = [
     isEmpty: false,
     emptyTitle: '',
     emptyDescription: '',
-    displayForAdmin: false,
+    displayForAdmin: true,
     displayForNonAdmin: true
   },
   {
     id: '4',
-    image: 'Sprout',
+    image: 'Farm_01',
     header: 'Review seedlots',
     description: 'Check all seedlots that are waiting for approval',
     link: ROUTES.TSC_SEEDLOTS_TABLE,

--- a/frontend/src/components/SeedlotCards/index.tsx
+++ b/frontend/src/components/SeedlotCards/index.tsx
@@ -11,7 +11,7 @@ const SeedlotCards = () => {
   return (
     <Row className="seedlot-activities-cards">
       {
-        cards.filter(c => c.displayForAdmin === isTscAdmin).map((card) => (
+        cards.filter((c) => c.displayForAdmin === isTscAdmin).map((card) => (
           <Column sm={4} md={4} lg={8} xlg={8} max={4} key={card.id}>
             <StandardCard
               image={card.image}
@@ -27,6 +27,6 @@ const SeedlotCards = () => {
       }
     </Row>
   );
-}
+};
 
 export default SeedlotCards;

--- a/frontend/src/components/SeedlotCards/index.tsx
+++ b/frontend/src/components/SeedlotCards/index.tsx
@@ -8,10 +8,24 @@ import AuthContext from '../../contexts/AuthContext';
 const SeedlotCards = () => {
   const { isTscAdmin } = useContext(AuthContext);
 
+  const shouldDisplayCard = (card: any) => {
+    let display = card.displayForNonAdmin;
+    if (isTscAdmin && display === true) {
+      display = true;
+    }
+    if (!isTscAdmin) {
+      return card.displayForNonAdmin;
+    }
+    if (!card.displayForAdmin) {
+      return false;
+    }
+    return card.displayForAdmin;
+  };
+
   return (
     <Row className="seedlot-activities-cards">
       {
-        cards.filter((c) => c.displayForAdmin === isTscAdmin).map((card) => (
+        cards.filter((c) => shouldDisplayCard(c)).map((card) => (
           <Column sm={4} md={4} lg={8} xlg={8} max={4} key={card.id}>
             <StandardCard
               image={card.image}

--- a/frontend/src/components/SeedlotCards/index.tsx
+++ b/frontend/src/components/SeedlotCards/index.tsx
@@ -1,30 +1,32 @@
-import React from 'react';
-
+import React, { useContext } from 'react';
 import { Row, Column } from '@carbon/react';
-
 import StandardCard from '../Card/StandardCard';
 import { cards } from './constants';
-
 import './styles.scss';
+import AuthContext from '../../contexts/AuthContext';
 
-const SeedlotCards = () => (
-  <Row className="seedlot-activities-cards">
-    {
-      cards.map((card) => (
-        <Column sm={4} md={4} lg={8} xlg={8} max={4} key={card.id}>
-          <StandardCard
-            image={card.image}
-            header={card.header}
-            description={card.description}
-            url={card.link}
-            isEmpty={card.isEmpty}
-            emptyTitle={card.emptyTitle}
-            emptyDescription={card.emptyDescription}
-          />
-        </Column>
-      ))
-    }
-  </Row>
-);
+const SeedlotCards = () => {
+  const { isTscAdmin } = useContext(AuthContext);
+
+  return (
+    <Row className="seedlot-activities-cards">
+      {
+        cards.filter(c => c.displayForAdmin === isTscAdmin).map((card) => (
+          <Column sm={4} md={4} lg={8} xlg={8} max={4} key={card.id}>
+            <StandardCard
+              image={card.image}
+              header={card.header}
+              description={card.description}
+              url={card.link}
+              isEmpty={card.isEmpty}
+              emptyTitle={card.emptyTitle}
+              emptyDescription={card.emptyDescription}
+            />
+          </Column>
+        ))
+      }
+    </Row>
+  );
+}
 
 export default SeedlotCards;

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -206,6 +206,7 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }: Pro
       if (famUser.clientRoles.length === 1) {
         // If a user has only 1 client role then set it right away.
         setSelectedClientRoles(famUser.clientRoles[0]);
+        setIsTscAdmin(famUser.clientRoles[0].roles.includes(TSC_ADMIN_ROLE));
       } else {
         restoreSelectedClient(famUser);
       }


### PR DESCRIPTION
# Description
Closes #1375

### Changelog

#### Changed
- AuthContext method to get when a user is admin
- Seedlot service to allow admin to get seedlots by number


### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media2.giphy.com/media/y52RntcwZOFz052GMt/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-31-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1381-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1381-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)