### PR TITLE
chore(ci): change backend base

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN ./mvnw -B package -Pnative -DskipTests -Dspring-boot.run.profiles=prod
 
 
 ### Deployer
-FROM debian:bookworm-slim AS deploy
+FROM gcr.io/distroless/java-base:nonroot AS deploy
 ARG PORT=8090
 
 # Copy


### PR DESCRIPTION
# Description

Reduce surface of attack with minimal backend base.

### Changelog
#### New
-

#### Changed
- Backend Docker image is not distroless/java-base:nonroot

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/3NsIJ2narUqaju1HaV/giphy.gif" width="200"/>