### PR TITLE
fix: return of rowcount

### DIFF
--- a/sync/src/module/database_connection.py
+++ b/sync/src/module/database_connection.py
@@ -222,6 +222,7 @@ class database_connection(object):
         logger.debug('Starting UPSERT statement in Oracle Database')
         logger.debug('run_mode is '+run_mode)
         onconflictstatement = ""
+        rows_affected = 0
 
         i = 0
         for row in dataframe.itertuples():
@@ -268,9 +269,10 @@ class database_connection(object):
             logger.debug(f'---Executing statement for row {i}')
             logger.debug(sql_text)
             result = self.conn.execute(text(sql_text), params)
+            rows_affected = result.rowcount
         
         self.commit()  # If everything is ok, a commit will be executed.
-        return result.rowcount  # Number of rows affected
+        return rows_affected
 
 def convertTypesToOracle(dataframe):
     dataframe = dataframe.fillna(numpy.nan).replace([numpy.nan], [None])


### PR DESCRIPTION
# Description
Bug fix for issue getting rowcount when no soq data exists

### Changelog
#### New
-

#### Changed
-

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [X] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-34-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1384-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1384-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)