### PR TITLE
fix: enable the tsc admin to submit the form as a regular user

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -41,7 +41,7 @@ parameters:
   - name: MEMORY_REQUEST
     value: 100Mi
   - name: MEMORY_LIMIT
-    value: 350Mi
+    value: 500Mi
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
     value: "3"

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpoint.java
@@ -456,7 +456,7 @@ public class SeedlotEndpoint {
       @RequestBody SeedlotFormSubmissionDto form) {
     boolean isTscAdmin = loggedUserService.isTscAdminLogged();
     SeedlotStatusResponseDto createDto =
-        seedlotService.updateSeedlotWithForm(seedlotNumber, form, isTscAdmin, "SUB");
+        seedlotService.updateSeedlotWithForm(seedlotNumber, form, isTscAdmin, true, "SUB");
     return ResponseEntity.status(HttpStatus.CREATED).body(createDto);
   }
 

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpoint.java
@@ -12,6 +12,7 @@ import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
 import ca.bc.gov.backendstartapi.exception.CsvTableParsingException;
 import ca.bc.gov.backendstartapi.response.DefaultSpringExceptionResponse;
 import ca.bc.gov.backendstartapi.response.ValidationExceptionResponse;
+import ca.bc.gov.backendstartapi.security.LoggedUserService;
 import ca.bc.gov.backendstartapi.security.RoleAccessConfig;
 import ca.bc.gov.backendstartapi.service.SaveSeedlotFormService;
 import ca.bc.gov.backendstartapi.service.SeedlotService;
@@ -71,6 +72,8 @@ public class SeedlotEndpoint {
   private final SeedlotService seedlotService;
 
   private final SaveSeedlotFormService saveSeedlotFormService;
+
+  private final LoggedUserService loggedUserService;
 
   /**
    * Parse the CSV table in {@code file} and return the data stored in it.
@@ -451,8 +454,9 @@ public class SeedlotEndpoint {
           @PathVariable
           String seedlotNumber,
       @RequestBody SeedlotFormSubmissionDto form) {
+    boolean isTscAdmin = loggedUserService.isTscAdminLogged();
     SeedlotStatusResponseDto createDto =
-        seedlotService.updateSeedlotWithForm(seedlotNumber, form, false, "SUB");
+        seedlotService.updateSeedlotWithForm(seedlotNumber, form, isTscAdmin, "SUB");
     return ResponseEntity.status(HttpStatus.CREATED).body(createDto);
   }
 

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpoint.java
@@ -190,7 +190,7 @@ public class TscAdminEndpoint {
     }
 
     SeedlotStatusResponseDto updatedDto =
-        seedlotService.updateSeedlotWithForm(seedlotNumber, form, true, formattedStatus);
+        seedlotService.updateSeedlotWithForm(seedlotNumber, form, true, false, formattedStatus);
     return ResponseEntity.status(HttpStatus.OK).body(updatedDto);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/security/LoggedUserService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/security/LoggedUserService.java
@@ -116,7 +116,7 @@ public class LoggedUserService {
       throw new UserNotFoundException();
     }
 
-    if (userInfo.get().roles().contains("SPAR_TSC_ADMIN")) {
+    if (isTscAdminLogged()) {
       SparLog.info("Request allowed, TSC Admin role found!");
       return;
     }
@@ -125,5 +125,20 @@ public class LoggedUserService {
       SparLog.info("Request denied due to user not having client id: {}", clientId);
       throw new ClientIdForbiddenException();
     }
+  }
+
+  /**
+   * Verify if the logged user has TSC_ADMIN role.
+   *
+   * @return true if it has, false otherwise.
+   */
+  public boolean isTscAdminLogged() {
+    Optional<UserInfo> userInfo = getLoggedUserInfo();
+
+    if (userInfo.isEmpty()) {
+      throw new UserNotFoundException();
+    }
+
+    return userInfo.get().roles().contains("SPAR_TSC_ADMIN");
   }
 }

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -698,6 +698,9 @@ public class SeedlotService {
       boolean isTscAdmin,
       String statusOnSuccess) {
 
+    // Detects if it's actually TSC. It might be.
+    isTscAdmin = loggedUserService.isTscAdminLogged();
+
     if (isTscAdmin) {
       SparLog.info("Received request by TSC admin to update seedlot {}", seedlotNumber);
     } else {

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -688,6 +688,8 @@ public class SeedlotService {
    * @param seedlotNumber The Seedlot identification
    * @param form The {@link SeedlotFormSubmissionDto} containing all form fields
    * @param isTscAdmin determines whether this operation is initiated by a tsc admin
+   * @param isFromRegularForm determines where the request originated from. If it's from the regular
+   *     form, with 6 steps, it also could be sent by someone from the TSC Admin.
    * @param statusOnSuccess the status to set if the operation is successful
    * @return A {@link SeedlotStatusResponseDto} with the seedlot number and status
    */
@@ -696,13 +698,22 @@ public class SeedlotService {
       String seedlotNumber,
       SeedlotFormSubmissionDto form,
       boolean isTscAdmin,
+      boolean isFromRegularForm,
       String statusOnSuccess) {
 
+    StringBuilder sb = new StringBuilder();
+    sb.append("Received request ");
     if (isTscAdmin) {
-      SparLog.info("Received request by TSC admin to update seedlot {}", seedlotNumber);
-    } else {
-      SparLog.info("Received request to update seedlot {}", seedlotNumber);
+      sb.append("by TSC Admin ");
     }
+    if (isFromRegularForm) {
+      sb.append("from regular form ");
+    } else {
+      sb.append("from review form ");
+    }
+    sb.append("to update seedlot {}");
+
+    SparLog.info(sb.toString(), seedlotNumber);
 
     Optional<Seedlot> seedlotEntity = seedlotRepository.findById(seedlotNumber);
     Seedlot seedlot = seedlotEntity.orElseThrow(SeedlotNotFoundException::new);
@@ -766,7 +777,7 @@ public class SeedlotService {
     // Fetch data from Oracle to get the primary Seed Plan Unit id
     setBecValues(seedlot, form.seedlotFormOrchardDto().primaryOrchardId());
 
-    if (!isTscAdmin) {
+    if (isFromRegularForm) {
       // Update the Seedlot instance only
       // Calculate Ne value (effective population size)
       // Calculate Mean GeoSpatial (for SMP Mix, mean latitude, mean longitude, mean elevation)

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -698,9 +698,6 @@ public class SeedlotService {
       boolean isTscAdmin,
       String statusOnSuccess) {
 
-    // Detects if it's actually TSC. It might be.
-    isTscAdmin = loggedUserService.isTscAdminLogged();
-
     if (isTscAdmin) {
       SparLog.info("Received request by TSC admin to update seedlot {}", seedlotNumber);
     } else {

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
@@ -29,6 +29,7 @@ import ca.bc.gov.backendstartapi.exception.InvalidSeedlotRequestException;
 import ca.bc.gov.backendstartapi.exception.SeedlotFormProgressNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SeedlotNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SeedlotSourceNotFoundException;
+import ca.bc.gov.backendstartapi.security.LoggedUserService;
 import ca.bc.gov.backendstartapi.service.SaveSeedlotFormService;
 import ca.bc.gov.backendstartapi.service.SeedlotService;
 import ca.bc.gov.backendstartapi.service.parser.ConeAndPollenCountCsvTableParser;
@@ -68,6 +69,8 @@ class SeedlotEndpointTest {
   @MockBean SeedlotService seedlotService;
 
   @MockBean SaveSeedlotFormService saveSeedlotFormService;
+
+  @MockBean LoggedUserService loggedUserService;
 
   private final WebApplicationContext webApplicationContext;
 
@@ -538,8 +541,7 @@ class SeedlotEndpointTest {
   @Test
   @DisplayName("patchSeedlotApplicationBadIdTest")
   void patchSeedlotApplicationBadIdTest() throws Exception {
-    when(seedlotService.patchApplicantInfo(any(), any()))
-        .thenThrow(new SeedlotNotFoundException());
+    when(seedlotService.patchApplicantInfo(any(), any())).thenThrow(new SeedlotNotFoundException());
 
     mockMvc
         .perform(
@@ -581,6 +583,8 @@ class SeedlotEndpointTest {
     when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), any()))
         .thenThrow(new SeedlotNotFoundException());
 
+    when(loggedUserService.isTscAdminLogged()).thenReturn(false);
+
     mockMvc
         .perform(
             put("/api/seedlots/{seedlotNumber}/a-class-submission", 123)
@@ -593,13 +597,15 @@ class SeedlotEndpointTest {
   }
 
   @Test
-  @DisplayName("Seedlot Form subbmited with success")
+  @DisplayName("Seedlot Form submitted with success")
   @WithMockUser(username = "SPARTest", roles = "SPAR_TSC_ADMIN")
   void submitSeedlotForm_happyPath_shouldSucceed() throws Exception {
     SeedlotStatusResponseDto createResponseDto = new SeedlotStatusResponseDto("123", "PND");
 
     when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), any()))
         .thenReturn(createResponseDto);
+
+    when(loggedUserService.isTscAdminLogged()).thenReturn(false);
 
     mockMvc
         .perform(

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
@@ -580,7 +580,7 @@ class SeedlotEndpointTest {
   @DisplayName("Seedlot Form submitted with not found seedlot")
   @WithMockUser(username = "SPARTest", roles = "SPAR_TSC_ADMIN")
   void submitSeedlotForm_notFoundSeedlot_shouldThrowException() throws Exception {
-    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), any()))
+    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), anyBoolean(), any()))
         .thenThrow(new SeedlotNotFoundException());
 
     when(loggedUserService.isTscAdminLogged()).thenReturn(false);
@@ -602,7 +602,7 @@ class SeedlotEndpointTest {
   void submitSeedlotForm_happyPath_shouldSucceed() throws Exception {
     SeedlotStatusResponseDto createResponseDto = new SeedlotStatusResponseDto("123", "PND");
 
-    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), any()))
+    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), anyBoolean(), any()))
         .thenReturn(createResponseDto);
 
     when(loggedUserService.isTscAdminLogged()).thenReturn(false);

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpointTest.java
@@ -208,7 +208,8 @@ class TscAdminEndpointTest {
   void editSeedlot_shouldSucceed() throws Exception {
     String seedlotNumber = "63012";
     SeedlotStatusResponseDto res = new SeedlotStatusResponseDto(seedlotNumber, "SUB");
-    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), any())).thenReturn(res);
+    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), anyBoolean(), any()))
+        .thenReturn(res);
     mockMvc
         .perform(
             put(
@@ -227,7 +228,7 @@ class TscAdminEndpointTest {
   @DisplayName("Edit seedlot should fail upon seedlot not found.")
   void editSeedlot_shouldFail() throws Exception {
     String seedlotNumber = "63999";
-    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), any()))
+    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), anyBoolean(), any()))
         .thenThrow(new SeedlotNotFoundException());
 
     mockMvc
@@ -248,7 +249,7 @@ class TscAdminEndpointTest {
   @DisplayName("Edit seedlot should fail with invalid seedlot status.")
   void editSeedlot_invalidStatus_shouldFail() throws Exception {
     String seedlotNumber = "63999";
-    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), any()))
+    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), anyBoolean(), any()))
         .thenThrow(new SeedlotNotFoundException());
 
     mockMvc

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
@@ -229,7 +229,7 @@ class SeedlotFormPutTest {
         SeedlotNotFoundException.class,
         () -> {
           seedlotService.updateSeedlotWithForm(
-              "5432", mockSeedlotFormDto(null, null), false, "SUB");
+              "5432", mockSeedlotFormDto(null, null), false, true, "SUB");
         });
   }
 
@@ -251,7 +251,7 @@ class SeedlotFormPutTest {
         ConeCollectionMethodNotFoundException.class,
         () -> {
           seedlotService.updateSeedlotWithForm(
-              "5432", mockSeedlotFormDto(null, null), false, "SUB");
+              "5432", mockSeedlotFormDto(null, null), false, true, "SUB");
         });
   }
 
@@ -276,7 +276,7 @@ class SeedlotFormPutTest {
         MethodOfPaymentNotFoundException.class,
         () -> {
           seedlotService.updateSeedlotWithForm(
-              "5432", mockSeedlotFormDto(null, null), false, "SUB");
+              "5432", mockSeedlotFormDto(null, null), false, true, "SUB");
         });
   }
 
@@ -306,7 +306,7 @@ class SeedlotFormPutTest {
         SeedlotParentTreeNotFoundException.class,
         () -> {
           seedlotService.updateSeedlotWithForm(
-              "5432", mockSeedlotFormDto(null, null), false, "SUB");
+              "5432", mockSeedlotFormDto(null, null), false, true, "SUB");
         });
   }
 
@@ -340,7 +340,7 @@ class SeedlotFormPutTest {
         SmpMixNotFoundException.class,
         () -> {
           seedlotService.updateSeedlotWithForm(
-              "5432", mockSeedlotFormDto(null, null), false, "SUB");
+              "5432", mockSeedlotFormDto(null, null), false, true, "SUB");
         });
   }
 
@@ -378,13 +378,14 @@ class SeedlotFormPutTest {
         SeedlotFormValidationException.class,
         () -> {
           seedlotService.updateSeedlotWithForm(
-              "5432", mockSeedlotFormDto(null, "OTH"), false, "SUB");
+              "5432", mockSeedlotFormDto(null, "OTH"), false, true, "SUB");
         });
 
     Assertions.assertThrows(
         SeedlotFormValidationException.class,
         () -> {
-          seedlotService.updateSeedlotWithForm("5432", mockSeedlotFormDto("", "OTH"), false, "SUB");
+          seedlotService.updateSeedlotWithForm(
+              "5432", mockSeedlotFormDto("", "OTH"), false, true, "SUB");
         });
   }
 
@@ -479,7 +480,7 @@ class SeedlotFormPutTest {
     when(seedlotSeedPlanZoneRepository.saveAll(any())).thenReturn(List.of());
 
     SeedlotStatusResponseDto scDto =
-        seedlotService.updateSeedlotWithForm("5432", mockedForm, false, "SUB");
+        seedlotService.updateSeedlotWithForm("5432", mockedForm, false, true, "SUB");
 
     Assertions.assertNotNull(scDto);
     Assertions.assertEquals("5432", scDto.seedlotNumber());

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -828,7 +828,8 @@ class SeedlotServiceTest {
     boolean isTscAdmin = true;
 
     SeedlotStatusResponseDto responseDto =
-        seedlotService.updateSeedlotWithForm(seedlotNumber, form, isTscAdmin, statusOnSuccess);
+        seedlotService.updateSeedlotWithForm(
+            seedlotNumber, form, isTscAdmin, false, statusOnSuccess);
 
     Assertions.assertEquals(seedlotNumber, responseDto.seedlotNumber());
     Assertions.assertEquals(statusOnSuccess, responseDto.seedlotStatusCode());

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -827,6 +827,8 @@ class SeedlotServiceTest {
 
     boolean isTscAdmin = true;
 
+    when(loggedUserService.isTscAdminLogged()).thenReturn(isTscAdmin);
+
     SeedlotStatusResponseDto responseDto =
         seedlotService.updateSeedlotWithForm(seedlotNumber, form, isTscAdmin, statusOnSuccess);
 

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -827,8 +827,6 @@ class SeedlotServiceTest {
 
     boolean isTscAdmin = true;
 
-    when(loggedUserService.isTscAdminLogged()).thenReturn(isTscAdmin);
-
     SeedlotStatusResponseDto responseDto =
         seedlotService.updateSeedlotWithForm(seedlotNumber, form, isTscAdmin, statusOnSuccess);
 


### PR DESCRIPTION
# Description
Closes no issue;

- Fix the form submission when it's subbmited by someone with Admin powers.

### Changelog

#### Changed
- Seedlot service;
- Maximum memory for the backend;

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->


###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media0.giphy.com/media/3o7abAHdYvZdBNnGZq/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-39-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1389-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1389-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)