### PR TITLE
feat: remove postgress from orchard vegcodes request

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/OrchardEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/OrchardEndpoint.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.backendstartapi.endpoint;
 
-import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.OrchardSpuDto;
 import ca.bc.gov.backendstartapi.dto.ParentTreeDto;
 import ca.bc.gov.backendstartapi.dto.SameSpeciesTreeDto;
@@ -64,39 +63,6 @@ public class OrchardEndpoint {
               description = "Identifier of the Orchard.")
           String orchardId) {
     return orchardService.findParentTreeGeneticQualityData(orchardId);
-  }
-
-  /**
-   * Gets all orchards with vegCode.
-   *
-   * @param vegCode {@link Orchard}'s identification
-   * @return a {@link List} of {@link OrchardDto}
-   * @throws ResponseStatusException if no data is found
-   */
-  @GetMapping(path = "/vegetation-code/{vegCode}")
-  @Operation(
-      summary = "Fetch a list of orchard based on the provided vegCode",
-      description =
-          "Returns all non-retired orchards under the provided vegCode, this is a proxy that calls"
-              + " oracle-api.",
-      responses = {
-        @ApiResponse(responseCode = "200"),
-        @ApiResponse(
-            responseCode = "401",
-            description = "Access token is missing or invalid",
-            content = @Content(schema = @Schema(implementation = Void.class))),
-        @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
-      })
-  @RoleAccessConfig({"SPAR_TSC_ADMIN", "SPAR_MINISTRY_ORCHARD", "SPAR_NONMINISTRY_ORCHARD"})
-  public List<OrchardDto> getOrchardsByVegCode(
-      @PathVariable("vegCode")
-          @Pattern(regexp = "^[a-zA-Z]{1,8}$")
-          @Parameter(
-              name = "vegCode",
-              in = ParameterIn.PATH,
-              description = "Identifier of the Orchard.")
-          String vegCode) {
-    return orchardService.findOrchardsByVegCode(vegCode);
   }
 
   /**

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/provider/OracleApiProvider.java
@@ -90,36 +90,6 @@ public class OracleApiProvider implements Provider {
    * Finds all orchards with the provided vegCode from oracle-api.
    *
    * @param vegCode The vegetation code of a seedlot.
-   * @return An {@link List} of {@link OrchardDto}
-   */
-  @Override
-  public List<OrchardDto> findOrchardsByVegCode(String vegCode) {
-    String oracleApiUrl = String.format("%s/api/orchards/vegetation-code/{vegCode}", rootUri);
-
-    SparLog.info("Starting {} - {} request to {}", PROVIDER, "findOrchardsByVegCode", oracleApiUrl);
-
-    try {
-      ResponseEntity<List<OrchardDto>> orchardsResult =
-          restTemplate.exchange(
-              oracleApiUrl,
-              HttpMethod.GET,
-              new HttpEntity<>(addHttpHeaders()),
-              new ParameterizedTypeReference<List<OrchardDto>>() {},
-              createParamsMap("vegCode", vegCode));
-      SparLog.info("GET orchards by vegCode from oracle - Success response!");
-      return orchardsResult.getBody();
-    } catch (HttpClientErrorException httpExc) {
-      SparLog.error(
-          "GET orchards by vegCode from oracle - Response code error: {}", httpExc.getStatusCode());
-    }
-
-    return List.of();
-  }
-
-  /**
-   * Finds all orchards with the provided vegCode from oracle-api.
-   *
-   * @param vegCode The vegetation code of a seedlot.
    * @return An {@link List} of {@link ParentTreeDto}
    */
   @Override

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/provider/Provider.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/provider/Provider.java
@@ -41,10 +41,6 @@ public interface Provider {
     return Optional.empty();
   }
 
-  default List<OrchardDto> findOrchardsByVegCode(String vegCode) {
-    return List.of();
-  }
-
   default List<SameSpeciesTreeDto> findParentTreesByVegCode(
       String vegCode, Map<String, String> orchardSpuMap) {
     return List.of();

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/OrchardService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/OrchardService.java
@@ -1,7 +1,6 @@
 package ca.bc.gov.backendstartapi.service;
 
 import ca.bc.gov.backendstartapi.config.SparLog;
-import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.OrchardSpuDto;
 import ca.bc.gov.backendstartapi.dto.SameSpeciesTreeDto;
 import ca.bc.gov.backendstartapi.entity.ActiveOrchardSpuEntity;
@@ -107,20 +106,6 @@ public class OrchardService {
     SparLog.info("Finished fetching Parent Tree data for Orchard ID: {}", orchardId);
 
     return parentTreeDto.orElseThrow(NoParentTreeDataException::new);
-  }
-
-  /**
-   * Finds all orchards with the provided vegCode.
-   *
-   * @param vegCode Orchard's identification.
-   * @return An {@link List} of {@link OrchardDto} from oracle-api
-   */
-  public List<OrchardDto> findOrchardsByVegCode(String vegCode) {
-    SparLog.info("Finding all orchards by veg code for code {}", vegCode);
-
-    List<OrchardDto> list = oracleApiProvider.findOrchardsByVegCode(vegCode.toUpperCase());
-    SparLog.info("{} orchards found for veg code {}", list.size(), vegCode);
-    return list;
   }
 
   /**

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/OrchardEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/OrchardEndpointTest.java
@@ -6,13 +6,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.OrchardSpuDto;
 import ca.bc.gov.backendstartapi.dto.SameSpeciesTreeDto;
 import ca.bc.gov.backendstartapi.exception.NoParentTreeDataException;
 import ca.bc.gov.backendstartapi.exception.NoSpuForOrchardException;
 import ca.bc.gov.backendstartapi.service.OrchardService;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -90,91 +88,6 @@ class OrchardEndpointTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound())
         .andExpect(status().reason("No active SPU for the given Orchard ID!"))
-        .andReturn();
-  }
-
-  @Test
-  @DisplayName("findOrchardsWithVegCodeSuccessTest")
-  void findOrchardsWithVegCodeTest() throws Exception {
-    String vegCode = "PLI";
-
-    OrchardDto firstOrchard =
-        new OrchardDto(
-            "123",
-            "smOrchard",
-            vegCode,
-            'S',
-            "Seed lot",
-            "PRD",
-            "ICH",
-            "Interior Cedar -- Hemlock",
-            "dw",
-            '4',
-            5);
-    OrchardDto secondOrchard =
-        new OrchardDto(
-            "456",
-            "xlOrchard",
-            vegCode,
-            'S',
-            "Seed lot",
-            "TEST",
-            "IDF",
-            "Interior Douglas-fir",
-            "mk",
-            '1',
-            5);
-
-    List<OrchardDto> testList =
-        new ArrayList<>() {
-          {
-            add(firstOrchard);
-            add(secondOrchard);
-          }
-        };
-
-    when(orchardService.findOrchardsByVegCode(vegCode)).thenReturn(testList);
-
-    mockMvc
-        .perform(
-            get("/api/orchards/vegetation-code/{vegCode}", vegCode)
-                .with(csrf().asHeader())
-                .header("Content-Type", "application/json")
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].id").value("123"))
-        .andExpect(jsonPath("$[0].vegetationCode").value(vegCode))
-        .andExpect(jsonPath("$[0].name").value("smOrchard"))
-        .andExpect(jsonPath("$[0].becZoneCode").value("ICH"))
-        .andExpect(jsonPath("$[0].becZoneDescription").value("Interior Cedar -- Hemlock"))
-        .andExpect(jsonPath("$[0].becSubzoneCode").value("dw"))
-        .andExpect(jsonPath("$[0].variant").value("4"))
-        .andExpect(jsonPath("$[0].becVersionId").value(5))
-        .andExpect(jsonPath("$[1].id").value("456"))
-        .andExpect(jsonPath("$[1].vegetationCode").value(vegCode))
-        .andExpect(jsonPath("$[1].name").value("xlOrchard"))
-        .andExpect(jsonPath("$[1].becZoneCode").value("IDF"))
-        .andExpect(jsonPath("$[1].becZoneDescription").value("Interior Douglas-fir"))
-        .andExpect(jsonPath("$[1].becSubzoneCode").value("mk"))
-        .andExpect(jsonPath("$[1].variant").value("1"))
-        .andExpect(jsonPath("$[1].becVersionId").value(5))
-        .andReturn();
-  }
-
-  @Test
-  @DisplayName("findOrchardsWithVegCodeNotFoundTest")
-  void findOrchardsWithVegCodeNotFoundTest() throws Exception {
-    String vegCode = "BEEF";
-
-    when(orchardService.findOrchardsByVegCode(vegCode)).thenReturn(List.of());
-    mockMvc
-        .perform(
-            get("/api/orchards/vegetation-code/{vegCode}", vegCode)
-                .with(csrf().asHeader())
-                .header("Content-Type", "application/json")
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(0))
         .andReturn();
   }
 

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/provider/OracleApiProviderTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/provider/OracleApiProviderTest.java
@@ -84,53 +84,6 @@ class OracleApiProviderTest {
   }
 
   @Test
-  @DisplayName("findOrchardWithVegCodeProviderTest")
-  void findOrchardWithVegCodeProviderTest() {
-    when(loggedUserService.getLoggedUserToken()).thenReturn("1f7a4k5e8t9o5k6e9n8h5e2r6e");
-
-    String vegCode = "FDC";
-    String url = "/null/api/orchards/vegetation-code/" + vegCode;
-
-    String json =
-        """
-        [
-          {
-            "id": "339",
-            "name": "EAGLEROCK",
-            "vegetationCode": "PLI",
-            "lotTypeCode": "S",
-            "lotTypeDescription": "Seed Lot",
-            "stageCode": "PRD"
-          }
-        ]
-        """;
-
-    mockRestServiceServer
-        .expect(requestTo(url))
-        .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
-
-    List<OrchardDto> orchardDtoList = oracleApiProvider.findOrchardsByVegCode(vegCode);
-
-    Assertions.assertEquals("339", orchardDtoList.get(0).id());
-    Assertions.assertFalse(orchardDtoList.isEmpty());
-  }
-
-  @Test
-  @DisplayName("findOrchardWithVegCodeProviderErrorTest")
-  void findOrchardWithVegCodeProviderErrorTest() {
-    when(loggedUserService.getLoggedUserToken()).thenReturn("");
-
-    String vegCode = "FDC";
-    String url = "/null/api/orchards/vegetation-code/" + vegCode;
-
-    mockRestServiceServer.expect(requestTo(url)).andRespond(withStatus(HttpStatus.NOT_FOUND));
-
-    List<OrchardDto> orchardDtoList = oracleApiProvider.findOrchardsByVegCode(vegCode);
-
-    Assertions.assertTrue(orchardDtoList.isEmpty());
-  }
-
-  @Test
   @DisplayName("findParentTreesByVegCodeTest")
   void findParentTreesByVegCodeTest() {
     when(loggedUserService.getLoggedUserToken()).thenReturn("1f7a4k5e8t9o5k6e9n8h5e2r6e");

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/OrchardServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/OrchardServiceTest.java
@@ -2,7 +2,6 @@ package ca.bc.gov.backendstartapi.service;
 
 import static org.mockito.Mockito.when;
 
-import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.OrchardSpuDto;
 import ca.bc.gov.backendstartapi.dto.ParentTreeGeneticInfoDto;
 import ca.bc.gov.backendstartapi.dto.ParentTreeGeneticQualityDto;
@@ -12,7 +11,6 @@ import ca.bc.gov.backendstartapi.exception.NoSpuForOrchardException;
 import ca.bc.gov.backendstartapi.provider.OracleApiProvider;
 import ca.bc.gov.backendstartapi.repository.ActiveOrchardSeedPlanningUnitRepository;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -151,68 +149,6 @@ class OrchardServiceTest {
 
     Assertions.assertEquals(
         "404 NOT_FOUND \"No active SPU for the given Orchard ID!\"", exc.getMessage());
-  }
-
-  @Test
-  @DisplayName("findOrchardByVegCodeSuccessServiceTest")
-  void findOrchardByVegCodeSuccessServiceTest() {
-    String vegCode = "FDI";
-
-    OrchardDto firstOrchard =
-        new OrchardDto(
-            "123",
-            "smOrchard",
-            vegCode,
-            'S',
-            "Seed lot",
-            "PRD",
-            "ICH",
-            "Interior Cedar -- Hemlock",
-            "dw",
-            '4',
-            5);
-    OrchardDto secondOrchard =
-        new OrchardDto(
-            "456",
-            "xlOrchard",
-            vegCode,
-            'S',
-            "Seed lot",
-            "TEST",
-            "IDF",
-            "Interior Douglas-fir",
-            "mk",
-            '1',
-            5);
-
-    List<OrchardDto> testList =
-        new ArrayList<>() {
-          {
-            add(firstOrchard);
-            add(secondOrchard);
-          }
-        };
-
-    when(oracleApiProvider.findOrchardsByVegCode(vegCode)).thenReturn(testList);
-
-    List<OrchardDto> responseFromService = orchardService.findOrchardsByVegCode(vegCode);
-
-    Assertions.assertNotNull(responseFromService);
-    Assertions.assertEquals(testList.size(), responseFromService.size());
-    Assertions.assertEquals(testList, responseFromService);
-  }
-
-  @Test
-  @DisplayName("findOrchardByVegCodeEmptyServiceTest")
-  void findOrchardByVegCodeEmptyServiceTest() {
-    String vegCode = "FDI";
-
-    when(oracleApiProvider.findOrchardsByVegCode(vegCode)).thenReturn(List.of());
-
-    List<OrchardDto> responseFromService = orchardService.findOrchardsByVegCode(vegCode);
-
-    Assertions.assertNotNull(responseFromService);
-    Assertions.assertEquals(0, responseFromService.size());
   }
 
   @Test

--- a/frontend/src/api-service/ApiConfig.ts
+++ b/frontend/src/api-service/ApiConfig.ts
@@ -16,8 +16,6 @@ const ApiConfig = {
 
   orchards: `${serverHost}/api/orchards`,
 
-  orchardsVegCode: `${serverHost}/api/orchards/vegetation-code`,
-
   coneCollectionMethod: `${serverHost}/api/cone-collection-methods`,
 
   uploadConeAndPollen: `${serverHost}/api/seedlots/parent-trees-contribution/cone-pollen-count-table/upload`,
@@ -50,6 +48,8 @@ const ApiConfig = {
   facilityTypes: `${oracleServerHost}/api/facility-types`,
 
   oracleOrchards: `${oracleServerHost}/api/orchards`,
+
+  orchardsVegCode: `${oracleServerHost}/api/orchards/vegetation-code`,
 
   areaOfUseSpzList: `${oracleServerHost}/api/area-of-use/spz-list/vegetation-code`
 };

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/UnrelatedGenWorth.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/UnrelatedGenWorth.tsx
@@ -15,7 +15,6 @@ import {
   MAX_VALUE_GEN_WORTH, MIN_VALUE_GEN_WORTH
 } from './constants';
 
-
 type UnrelatedGenWorthProps = {
   validGenWorth: Array<string> | undefined;
   isRead?: boolean;


### PR DESCRIPTION
# Description
Closes #1396 

### Changelog

#### Changed
- Postgres API removing proxy request. (no reason to have that in the first place)

#### Removed
- Orchard API request from Postgres.

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [x] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media3.giphy.com/media/1QjxtwZ9LoPD2Jlcuq/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-48-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1398-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1398-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)