### PR TITLE
chore(ci): improve deploy triggers and longer-running validations

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -27,6 +27,10 @@ on:
         default: ${{ github.event.number }}
         required: false
         type: string
+      triggers:
+        description: Deployment trigger; omit = build; e.g. ('backend/' 'frontend/')
+        required: false
+        type: string
       ### Usually a bad idea / not recommended
       timeout-minutes:
         description: 'Timeout minutes'
@@ -45,14 +49,27 @@ jobs:
     environment: ${{ inputs.environment }}
     outputs:
       mod-tag: ${{ steps.mod-tag.outputs.mod-tag }}
+      triggered: ${{ steps.triggers.outputs.triggered }}
     runs-on: ubuntu-22.04
     steps:
+      # Check triggers (omitted or matched), exiting successfully if not fired/required
+      - uses: bcgov-nr/action-diff-triggers@v0.2.0
+        id: triggers
+        with:
+          triggers: ${{ inputs.triggers }}
+
+      - if: steps.triggers.outputs.triggered == 'false'
+        run: |
+          echo "No deployment required/triggered!"
+          exit 0
+
       - name: Get PR Number Mod 50
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.triggers.outputs.triggered == 'true'
         id: mod-tag
         run: echo "mod-tag=$(( ${{ inputs.target }} % 50 ))" >> $GITHUB_OUTPUT
 
       - name: OpenShift Init
+        if: github.event_name != 'pull_request' || steps.triggers.outputs.triggered == 'true'
         uses: bcgov-nr/action-deployer-openshift@v3.0.0
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
@@ -72,6 +89,8 @@ jobs:
   database:
     name: Deploy (database)
     environment: ${{ inputs.environment }}
+    if: github.event_name != 'pull_request' || needs.init.outputs.triggered == 'true'
+    needs: [init]
     runs-on: ubuntu-22.04
     steps:
       - name: Database
@@ -91,6 +110,7 @@ jobs:
   deploy:
     name: Deploy
     environment: ${{ inputs.environment }}
+    if: github.event_name != 'pull_request' || needs.init.outputs.triggered == 'true'
     needs: [database, init]
     outputs:
       triggered: ${{ steps.trigger.outputs.triggered }}
@@ -144,7 +164,7 @@ jobs:
             ${{ github.event_name == 'pull_request' && '-p MAX_REPLICAS=2' || '' }}
             ${{ matrix.parameters }}
           post_rollout: ${{ matrix.post_rollout }}
-          triggers: ${{ matrix.triggers }}
+          triggers: ${{ inputs.triggers }}
           verification_path: ${{ matrix.verification_path }}
           verification_retry_attempts: "5"
           verification_retry_seconds: "20"
@@ -153,9 +173,9 @@ jobs:
 
   verify:
     name: Verify ETL
-    if: inputs.etl == 'true'
+    if: inputs.etl == 'true' && needs.init.outputs.triggered == 'true'
     environment: ${{ inputs.environment }}
-    needs: [deploy]
+    needs: [deploy, init]
     runs-on: ubuntu-latest
     steps:
       - name: Override OpenShift version

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -52,16 +52,14 @@ jobs:
       triggered: ${{ steps.triggers.outputs.triggered }}
     runs-on: ubuntu-22.04
     steps:
-      # Check triggers (omitted or matched), exiting successfully if not fired/required
+      # Check triggers (omitted or matched)
       - uses: bcgov-nr/action-diff-triggers@v0.2.0
         id: triggers
         with:
           triggers: ${{ inputs.triggers }}
 
       - if: steps.triggers.outputs.triggered == 'false'
-        run: |
-          echo "No deployment required/triggered!"
-          exit 0
+        run: echo "No deployment required/triggered!"
 
       - name: Get PR Number Mod 50
         if: github.event_name == 'pull_request' && steps.triggers.outputs.triggered == 'true'

--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -11,6 +11,10 @@ on:
         description: PR number, test or prod; defaults to PR number
         default: ${{ github.event.number }}
         type: string
+      triggers:
+        description: Deployment trigger; omit = build; e.g. ('backend/' 'frontend/')
+        required: false
+        type: string
 
 jobs:
   cypress:
@@ -26,8 +30,20 @@ jobs:
       VITE_ZONE: TEST
     runs-on: ubuntu-22.04
     steps:
+      # Check triggers (omitted or matched)
+      - uses: bcgov-nr/action-diff-triggers@v0.2.0
+        id: triggers
+        with:
+          triggers: ${{ inputs.triggers }}
+
+      - if: steps.triggers.outputs.triggered == 'false'
+        run: echo "No tests required/triggered!"
+
       - uses: actions/checkout@v4
+        if: steps.triggers.outputs.triggered == 'true'
+
       - name: Run Cypress CI
+        if: steps.triggers.outputs.triggered == 'true'
         uses: bcgov-nr/action-test-and-analyse@v1.2.1
         with:
           node_version: "18"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -28,28 +28,14 @@ jobs:
           tag_fallback: latest
           triggers: ('${{ matrix.package }}/')
 
-      - if: steps.build.outputs.triggered == 'true'
-        run: |
-          # Trigger deploys
-          echo "deploy=true" >> $GITHUB_OUTPUT
-
-  check:
-    name: Build Outputs
-    runs-on: ubuntu-22.04
-    needs: [builds]
-    steps:
-      - run: |
-          # View outputs
-          echo "needs.builds: ${{ toJson(needs.builds) }}"
-
   deploys:
     name: Deploys
     needs: [builds]
     if: needs.builds.outputs.triggered == 'true'
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
-    # with:
-    #   etl: true
+    with:
+      triggers: ('backend/' 'common/' 'database/' 'frontend/' 'oracle-api/' 'sync/')
 
   tests:
     name: Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -31,7 +31,6 @@ jobs:
   deploys:
     name: Deploys
     needs: [builds]
-    if: needs.builds.outputs.triggered == 'true'
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:
@@ -39,10 +38,11 @@ jobs:
 
   tests:
     name: Tests
-    if: needs.deploys.outputs.triggered == 'true'
     needs: [deploys]
     secrets: inherit
     uses: ./.github/workflows/.tests.yml
+    with:
+      triggers: ('backend/' 'common/' 'database/' 'frontend/' 'oracle-api/')
 
   results:
     name: PR Results

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache ca-certificates curl
 # Copy files and run formatting
 COPY --from=build /app/build/ /app/dist
 COPY Caddyfile /etc/caddy/Caddyfile
-RUN caddy fmt /etc/caddy/Caddyfile
+RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 
 # User, port and healthcheck
 EXPOSE 3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache ca-certificates curl
 # Copy files and run formatting
 COPY --from=build /app/build/ /app/dist
 COPY Caddyfile /etc/caddy/Caddyfile
-RUN caddy fmt --overwrite /etc/caddy/Caddyfile
+RUN caddy fmt /etc/caddy/Caddyfile
 
 # User, port and healthcheck
 EXPOSE 3000


### PR DESCRIPTION
# Description
Deployment triggers haven't been working as intended.  There's a race condition where if an omitted/skipped build runs last, previous build triggers are ignored.

Also, there were significant changes made to the deployer to accommodate the frequent validation failures for backend and oracle-api. 

### Changelog
#### New
- Improved support for watching deployments
- Triggers and logic added to .deploy.yml

#### Changed
- Lots of logic, but little is genuinely different

#### Removed
- Build outputs and deployment triggers removed from pr-open.yml

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [x] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/ZdrUuSEC0LygaFXtNT/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-6-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1406-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1406-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)