### PR TITLE
fix(ci): schduled job illegal characters

### DIFF
--- a/.github/workflows/sync-job.yml
+++ b/.github/workflows/sync-job.yml
@@ -32,7 +32,7 @@ jobs:
 
           # Create job
           CRONJOB=${{ github.event.repository.name }}-test-sync
-          RUN_JOB=${CRONJOB}-$(nr-spar: date +"%Y-%m-%d_%H:%M:%S")
+          RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
           oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 
           # Follow

--- a/.github/workflows/sync-job.yml
+++ b/.github/workflows/sync-job.yml
@@ -1,4 +1,4 @@
-name: Scheduled ETL Sync
+name: ETL Sync
 
 on:
   schedule: [cron: "0 */2 * * *"] # Every other hour on the hour


### PR DESCRIPTION
# Description
Closes #1137 .  This is the bug-squashing follow-up to #1408.  The job had to be renamed to avoid colons (`:`).

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->
<img src="https://media0.giphy.com/media/WUUt2ujWlssvUenOuf/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-9-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1409-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1409-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)