### PR TITLE
feat(ci): follow progress of ETL job

### DIFF
--- a/.github/workflows/sync-job.yml
+++ b/.github/workflows/sync-job.yml
@@ -30,22 +30,18 @@ jobs:
           oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
           oc project ${{ secrets.oc_namespace }} #Safeguard!
 
+          # Exit on errors or unset variables
+          set -eu
+
           # Create job
-          CRONJOB=${{ github.event.repository.name }}-test-sync
+          CRONJOB=nr-spar-test-sync
           RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
           oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 
           # Follow
-          oc wait --for=jsonpath='{.status.failed}'=4 job/${RUN_JOB} --timeout=10m || true
+          oc wait --for=condition=ready pod --selector=job-name=${RUN_JOB} --timeout=1m
           oc logs -l job-name=${RUN_JOB} --tail=50 --follow
 
-          # Results
-          oc get job ${RUN_JOB}
-
-          # Handle exit code
-          if [ $(oc get job ${RUN_JOB} -o jsonpath='{.status.ready}') -eq 0 ]; then
-            echo "Job successful!"
-          else
-            echo "Job failed!"
-            exit 1
-          fi
+          # Verify successful completion
+          oc wait --for jsonpath='{.status.phase}'=Succeeded pod --selector=job-name=${RUN_JOB} --timeout=1m
+          echo "Job successful!"


### PR DESCRIPTION
# Description

Follows the progress of the ETL sync job.  Test added to ensure success.

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [x] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/czOM9AjyWfi8w/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-12-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1412-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1412-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)