### PR TITLE
fix(ci): cypress nightly

### DIFF
--- a/.github/workflows/cypress-nightly.yml
+++ b/.github/workflows/cypress-nightly.yml
@@ -2,99 +2,15 @@ name: Cypress Nightly
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   # runs e2e tests every day at 4am
-  #   - cron: '0 4 * * *'
-
-env:
-  REGISTRY: ghcr.io
-  NAME: nrsparwebapp
+  schedule:
+    # runs e2e tests every day at 4am
+    - cron: '0 4 * * *'
 
 jobs:
-  e2e-chrome:
-    runs-on: ubuntu-22.04
-    name: E2E on Chrome
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          browser: chrome
-        env:
-          CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
-          CYPRESS_USERNAME: ${{ vars.CYPRESS_USERNAME }}
-      
-      - name: Upload screenshots on failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: cypress-screenshots-chrome
-          path: cypress/screenshots
-      
-      - name: Upload videos
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: cypress-videos-chrome
-          path: cypress/videos
-  
-  e2e-firefox:
-    runs-on: ubuntu-22.04
-    container:
-      image: cypress/included:11.2.0
-      options: --user 1001
-    name: E2E on Firefox
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Cypress run
-        run: cypress run --browser firefox
-        env:
-          CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
-          CYPRESS_USERNAME: ${{ vars.CYPRESS_USERNAME }}
-      
-      - name: Upload screenshots on failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: cypress-screenshots-firefox
-          path: cypress/screenshots
-      
-      - name: Upload videos
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: cypress-videos-firefox
-          path: cypress/videos
-
-  e2e-edge:
-    runs-on: windows-latest
-    name: E2E on Edge
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          browser: edge
-        env:
-          CYPRESS_USERNAME: ${{ secrets.BCEID_USERNAME }}
-          CYPRESS_PASSWORD: ${{ secrets.BCEID_PASSWORD }}
-      
-      - name: Upload screenshots on failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: cypress-screenshots-edge
-          path: cypress/screenshots
-      
-      - name: Upload videos
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: cypress-videos-edge
-          path: cypress/videos
+  tests:
+    name: Tests
+    needs: [deploys]
+    secrets: inherit
+    uses: ./.github/workflows/.tests.yml
+    with:
+      target: test


### PR DESCRIPTION
# Description

The Cypress Nightly job has been failing and was disabled.  This PR points it to the same shared workflows as pr-open.yml, but using test as the target.

### Changelog
#### Changed
- Reenabled Cypress Nightly
- Pointed to shared workflows (.tests.yml)

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-14-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1414-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1414-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)