### PR TITLE
fix(ci): scheduled cleanup deployements only, keep 4 days

### DIFF
--- a/.github/workflows/job-nightly.yml
+++ b/.github/workflows/job-nightly.yml
@@ -29,27 +29,27 @@ jobs:
             awk '$2 <= "'$(date -d '${{ env.DATE }}' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | \
             xargs --no-run-if-empty oc delete ${{ env.TYPE }}
 
-  # tests:
-  #   name: Tests
-  #   secrets: inherit
-  #   uses: ./.github/workflows/.tests.yml
-  #   with:
-  #     target: test
+  tests:
+    name: Tests
+    secrets: inherit
+    uses: ./.github/workflows/.tests.yml
+    with:
+      target: test
 
-  # zap_scan:
-  #   runs-on: ubuntu-latest
-  #   name: Penetration Tests
-  #   # Run after other tests to avoid rate limiting
-  #   needs: [tests]
-  #   env:
-  #     DOMAIN: apps.silver.devops.gov.bc.ca
-  #     PREFIX: ${{ github.event.repository.name }}-test
-  #   steps:
-  #     - name: ZAP Scan
-  #       uses: zaproxy/action-full-scan@v0.10.0
-  #       with:
-  #         allow_issue_writing: true
-  #         artifact_name: "zap_frontend"
-  #         cmd_options: "-a"
-  #         issue_title: "ZAP: frontend"
-  #         target: https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }}
+  zap_scan:
+    runs-on: ubuntu-latest
+    name: Penetration Tests
+    # Run after other tests to avoid rate limiting
+    needs: [tests]
+    env:
+      DOMAIN: apps.silver.devops.gov.bc.ca
+      PREFIX: ${{ github.event.repository.name }}-test
+    steps:
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.10.0
+        with:
+          allow_issue_writing: true
+          artifact_name: "zap_frontend"
+          cmd_options: "-a"
+          issue_title: "ZAP: frontend"
+          target: https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }}

--- a/.github/workflows/job-nightly.yml
+++ b/.github/workflows/job-nightly.yml
@@ -3,6 +3,7 @@ name: Nightly
 on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,27 +29,27 @@ jobs:
             awk '$2 <= "'$(date -d '${{ env.DATE }}' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | \
             xargs --no-run-if-empty oc delete ${{ env.TYPE }}
 
-  tests:
-    name: Tests
-    secrets: inherit
-    uses: ./.github/workflows/.tests.yml
-    with:
-      target: test
+  # tests:
+  #   name: Tests
+  #   secrets: inherit
+  #   uses: ./.github/workflows/.tests.yml
+  #   with:
+  #     target: test
 
-  zap_scan:
-    runs-on: ubuntu-latest
-    name: Penetration Tests
-    # Run after other tests to avoid rate limiting
-    needs: [tests]
-    env:
-      DOMAIN: apps.silver.devops.gov.bc.ca
-      PREFIX: ${{ github.event.repository.name }}-test
-    steps:
-      - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.10.0
-        with:
-          allow_issue_writing: true
-          artifact_name: "zap_frontend"
-          cmd_options: "-a"
-          issue_title: "ZAP: frontend"
-          target: https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }}
+  # zap_scan:
+  #   runs-on: ubuntu-latest
+  #   name: Penetration Tests
+  #   # Run after other tests to avoid rate limiting
+  #   needs: [tests]
+  #   env:
+  #     DOMAIN: apps.silver.devops.gov.bc.ca
+  #     PREFIX: ${{ github.event.repository.name }}-test
+  #   steps:
+  #     - name: ZAP Scan
+  #       uses: zaproxy/action-full-scan@v0.10.0
+  #       with:
+  #         allow_issue_writing: true
+  #         artifact_name: "zap_frontend"
+  #         cmd_options: "-a"
+  #         issue_title: "ZAP: frontend"
+  #         target: https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }}

--- a/.github/workflows/job-nightly.yml
+++ b/.github/workflows/job-nightly.yml
@@ -13,8 +13,8 @@ jobs:
     name: PR Env Purge
     env:
       # https://tecadmin.net/getting-yesterdays-date-in-bash/
-      DATE: "1 week ago"
-      TYPE: "all,secret,pvc,cm"
+      DATE: "4 days ago"
+      TYPE: "deployments"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -24,6 +24,7 @@ jobs:
           oc project ${{ vars.OC_NAMESPACE }} # Safeguard!
 
           oc get ${{ env.TYPE }} -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | \
+            grep -v workspace | \
             awk '$2 <= "'$(date -d '${{ env.DATE }}' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | \
             xargs --no-run-if-empty oc delete ${{ env.TYPE }}
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Analysis](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)
 [![ETL Sync](https://github.com/bcgov/nr-spar/actions/workflows/job-sync.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/job-sync.yml)
 [![Merge](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)
-[![Nightly](https://github.com/bcgov/nr-spar/actions/workflows/nightly.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/nightly.yml)
+[![Nightly](https://github.com/bcgov/nr-spar/actions/workflows/job-nightly.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/job-nightly.yml)
 
 #### Frontend
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=nr-spar_frontend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=nr-spar_frontend)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 #### Workflows
 [![Analysis](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)
-[![ETL Sync](https://github.com/bcgov/nr-spar/actions/workflows/sync-job.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/sync-job.yml)
+[![ETL Sync](https://github.com/bcgov/nr-spar/actions/workflows/job-sync.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/job-sync.yml)
 [![Merge](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)
 [![Nightly](https://github.com/bcgov/nr-spar/actions/workflows/nightly.yml/badge.svg)](https://github.com/bcgov/nr-spar/actions/workflows/nightly.yml)
 


### PR DESCRIPTION
# Description
Still working on failures in the Nightly (formerly Scheduled) job.  OpenShift cleanup is being limited to just deployments, which still cleans up pods.  Cleanup window shortened from 7 to 4 days.

### Changelog
#### Changed
- Now only deleting deployments and their dependents (e.g. pods, replica controllers, horizondal pod autoscalers)
- Shorted cleanup windows from 7 to 4 days

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/2oUfvvUgQHnLsQWFMW/giphy.gif" width="200"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-30-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1430-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1430-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)