### PR TITLE
chore(ci): switch to GH default CodeQL

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -40,42 +40,6 @@ jobs:
             -Dsonar.exclusions=**/config/**,*/dto/**,**/entity/**,**/exception/**,**/filter/**,**/interceptor/**,**/response/**,**/**Builder*,**/RestExceptionEndpoint.*,**/BackendStartApiApplication.*
           sonar_token: ${{ secrets[matrix.token] }}
 
-  codeql:
-    name: Semantic Code Analysis
-    if: ${{ ! github.event.pull_request.draft }}
-    runs-on: ubuntu-22.04
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Initialize
-        uses: github/codeql-action/init@v3
-        with:
-          debug: true
-          languages: java,javascript
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "temurin"
-
-        # Build Java apps, JavaScript doesn't require
-      - name: Backend Build
-        working-directory: backend
-        run: mvn --update-snapshots -P prod clean package -Dmaven.test.skip
-
-        # Build Java apps, JavaScript doesn't require
-      - name: Oracle API Build
-        working-directory: oracle-api
-        run: mvn --update-snapshots package -Dmaven.test.skip
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:
     name: Security Scan

--- a/.github/workflows/job-nightly.yml
+++ b/.github/workflows/job-nightly.yml
@@ -3,7 +3,6 @@ name: Nightly
 on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Description

### Changelog
#### Changed
- Switched to GitHub's new default CodeQL setup

#### Removed
- Our code, which is no longer required!

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/l46CimW38a7TFxLVe/giphy.gif" width="200"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-31-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1431-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1431-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)