### PR TITLE
fix: disable seedlot gen worth saving at the wrong place and time

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotGeneticWorthService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotGeneticWorthService.java
@@ -3,13 +3,10 @@ package ca.bc.gov.backendstartapi.service;
 import ca.bc.gov.backendstartapi.config.SparLog;
 import ca.bc.gov.backendstartapi.dao.GeneticWorthEntityDao;
 import ca.bc.gov.backendstartapi.dto.GeneticWorthTraitsDto;
-import ca.bc.gov.backendstartapi.dto.ParentTreeGeneticQualityDto;
-import ca.bc.gov.backendstartapi.dto.SeedlotFormParentTreeSmpDto;
 import ca.bc.gov.backendstartapi.entity.GeneticWorthEntity;
 import ca.bc.gov.backendstartapi.entity.SeedlotGeneticWorth;
 import ca.bc.gov.backendstartapi.entity.idclass.SeedlotGeneticWorthId;
 import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
-import ca.bc.gov.backendstartapi.exception.SeedlotConflictDataException;
 import ca.bc.gov.backendstartapi.repository.SeedlotGeneticWorthRepository;
 import ca.bc.gov.backendstartapi.security.LoggedUserService;
 import java.util.ArrayList;
@@ -28,49 +25,6 @@ public class SeedlotGeneticWorthService {
   private final LoggedUserService loggedUserService;
 
   private final GeneticWorthEntityDao geneticWorthEntityDao;
-
-  /**
-   * Saves a SeedlotParentTree from the Seedlot Form Registration step 5.
-   *
-   * @param seedlot The {@link Seedlot} related
-   * @param seedlotFormParentTreeDtoList A List of {@link SeedlotFormParentTreeSmpDto}
-   */
-  public List<SeedlotGeneticWorth> saveSeedlotFormStep5(
-      Seedlot seedlot,
-      List<SeedlotFormParentTreeSmpDto> seedlotFormParentTreeDtoList,
-      boolean canDelete) {
-    SparLog.info("Saving SeedlotGeneticWorth for seedlot number {}", seedlot.getId());
-
-    List<SeedlotGeneticWorth> sgwList =
-        seedlotGeneticWorthRepository.findAllBySeedlot_id(seedlot.getId());
-
-    List<ParentTreeGeneticQualityDto> sgwInsertList = new ArrayList<>();
-
-    if (!sgwList.isEmpty()) {
-      SparLog.info(
-          "Deleting {} previous records on the SeedlotGeneticWorth table for seedlot number {}",
-          sgwList.size(),
-          seedlot.getId());
-
-      List<String> sgwExistingList =
-          new ArrayList<>(sgwList.stream().map(SeedlotGeneticWorth::getGeneticWorthCode).toList());
-
-      List<SeedlotGeneticWorthId> sgwiList = new ArrayList<>();
-      for (String genWorthCode : sgwExistingList) {
-        sgwiList.add(new SeedlotGeneticWorthId(seedlot.getId(), genWorthCode));
-      }
-
-      seedlotGeneticWorthRepository.deleteAllById(sgwiList);
-    } else if (!sgwList.isEmpty() && !canDelete) {
-      throw new SeedlotConflictDataException(seedlot.getId());
-    }
-
-    for (SeedlotFormParentTreeSmpDto seedlotPtFormDto : seedlotFormParentTreeDtoList) {
-      sgwInsertList.addAll(seedlotPtFormDto.parentTreeGeneticQualities());
-    }
-
-    return addSeedlotGeneticWorth(seedlot, sgwInsertList);
-  }
 
   /**
    * Override the seedlot genetic worth data.
@@ -138,35 +92,6 @@ public class SeedlotGeneticWorthService {
     }
 
     return seedlotGeneticWorthRepository.saveAll(seedlotGenWorthList);
-  }
-
-  private List<SeedlotGeneticWorth> addSeedlotGeneticWorth(
-      Seedlot seedlot, List<ParentTreeGeneticQualityDto> genWorthCodeToInsert) {
-    if (genWorthCodeToInsert.isEmpty()) {
-      SparLog.info(
-          "No new records to be inserted on the SeedlotGeneticWorth table for seedlot number {}",
-          seedlot.getId());
-      return List.of();
-    }
-
-    SparLog.info(
-        "{} record(s) to be inserted on the SeedlotGeneticWorth table for seedlot number {}",
-        genWorthCodeToInsert.size(),
-        seedlot.getId());
-
-    List<SeedlotGeneticWorth> seedlotGeneticWorths = new ArrayList<>();
-    for (ParentTreeGeneticQualityDto ptgqDto : genWorthCodeToInsert) {
-
-      GeneticWorthEntity gwEntity =
-          geneticWorthEntityDao.getGeneticWorthEntity(ptgqDto.geneticWorthCode()).orElseThrow();
-
-      SeedlotGeneticWorth sgw =
-          new SeedlotGeneticWorth(seedlot, gwEntity, loggedUserService.createAuditCurrentUser());
-      sgw.setGeneticQualityValue(ptgqDto.geneticQualityValue());
-      seedlotGeneticWorths.add(sgw);
-    }
-
-    return seedlotGeneticWorthRepository.saveAll(seedlotGeneticWorths);
   }
 
   /**

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -782,7 +782,7 @@ public class SeedlotService {
     setBecValues(seedlot, form.seedlotFormOrchardDto().primaryOrchardId(), inMemoryDto);
 
     if (isFromRegularForm) {
-      // Update the Seedlot instance only
+      // Update the Seedlot instance and table seedlot_genetic_worth
       // Calculate Ne value (effective population size)
       // Calculate Mean GeoSpatial (for SMP Mix, mean latitude, mean longitude, mean elevation)
       // Calculate Seedlot GeoSpatial (for Seedlot, mean latitude, mean longitude, mean elevation)
@@ -1126,8 +1126,6 @@ public class SeedlotService {
     seedlotParentTreeService.saveSeedlotFormStep5(seedlot, seedlotFormParentTreeDtoList, canDelete);
     seedlotParentTreeGeneticQualityService.saveSeedlotFormStep5(
         seedlot, seedlotFormParentTreeDtoList);
-    seedlotGeneticWorthService.saveSeedlotFormStep5(
-        seedlot, seedlotFormParentTreeDtoList, canDelete);
 
     // SMP Mix information is optional, so the array may be empty,
     // in this case there is no need to save the list

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
@@ -328,8 +328,6 @@ class SeedlotFormPutTest {
     when(seedlotParentTreeService.saveSeedlotFormStep5(any(), any(), anyBoolean()))
         .thenReturn(List.of());
     doNothing().when(seedlotParentTreeGeneticQualityService).saveSeedlotFormStep5(any(), any());
-    when(seedlotGeneticWorthService.saveSeedlotFormStep5(any(), any(), anyBoolean()))
-        .thenReturn(List.of());
     when(smpMixService.saveSeedlotFormStep5(any(), any())).thenReturn(List.of());
 
     doThrow(new SmpMixNotFoundException())
@@ -362,8 +360,6 @@ class SeedlotFormPutTest {
     when(seedlotParentTreeService.saveSeedlotFormStep5(any(), any(), anyBoolean()))
         .thenReturn(List.of());
     doNothing().when(seedlotParentTreeGeneticQualityService).saveSeedlotFormStep5(any(), any());
-    when(seedlotGeneticWorthService.saveSeedlotFormStep5(any(), any(), anyBoolean()))
-        .thenReturn(List.of());
     when(smpMixService.saveSeedlotFormStep5(any(), any())).thenReturn(List.of());
     doNothing().when(smpMixGeneticQualityService).saveSeedlotFormStep5(any(), any());
     doNothing()
@@ -411,8 +407,6 @@ class SeedlotFormPutTest {
     when(seedlotParentTreeService.saveSeedlotFormStep5(any(), any(), anyBoolean()))
         .thenReturn(List.of());
     doNothing().when(seedlotParentTreeGeneticQualityService).saveSeedlotFormStep5(any(), any());
-    when(seedlotGeneticWorthService.saveSeedlotFormStep5(any(), any(), anyBoolean()))
-        .thenReturn(List.of());
     when(smpMixService.saveSeedlotFormStep5(any(), any())).thenReturn(List.of());
     doNothing().when(smpMixGeneticQualityService).saveSeedlotFormStep5(any(), any());
     doNothing()

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotGeneticWorthServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotGeneticWorthServiceTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.when;
 
 import ca.bc.gov.backendstartapi.dao.GeneticWorthEntityDao;
 import ca.bc.gov.backendstartapi.dto.GeneticWorthTraitsDto;
-import ca.bc.gov.backendstartapi.dto.ParentTreeGeneticQualityDto;
-import ca.bc.gov.backendstartapi.dto.SeedlotFormParentTreeSmpDto;
 import ca.bc.gov.backendstartapi.entity.GeneticWorthEntity;
 import ca.bc.gov.backendstartapi.entity.SeedlotGeneticWorth;
 import ca.bc.gov.backendstartapi.entity.embeddable.AuditInformation;
@@ -37,22 +35,6 @@ class SeedlotGeneticWorthServiceTest {
 
   private SeedlotGeneticWorthService seedlotGeneticWorthService;
 
-  private SeedlotFormParentTreeSmpDto createFormDto(Integer parentTreeId) {
-    ParentTreeGeneticQualityDto parentTreeGenQualityDto =
-        new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("18"));
-    return new SeedlotFormParentTreeSmpDto(
-        "85",
-        parentTreeId,
-        "87",
-        new BigDecimal("1"),
-        new BigDecimal("5"),
-        6,
-        2,
-        50,
-        new BigDecimal("100"),
-        List.of(parentTreeGenQualityDto));
-  }
-
   @BeforeEach
   void setup() {
     seedlotGeneticWorthService =
@@ -72,54 +54,6 @@ class SeedlotGeneticWorthServiceTest {
 
   private SeedlotGeneticWorth mockSeedlotGenWorth(Seedlot seedlot, String traitCode) {
     return new SeedlotGeneticWorth(seedlot, mockGeneticWorthEntity(traitCode), mockAudit());
-  }
-
-  @Test
-  @DisplayName("Save Seedlot Genetic Worth first submit")
-  void saveSeedlotFormStep5_firstSubmit_shouldSucceed() {
-    when(seedlotGeneticWorthRepository.findAllBySeedlot_id("54321")).thenReturn(List.of());
-
-    AuditInformation audit = new AuditInformation("userId");
-    when(loggedUserService.createAuditCurrentUser()).thenReturn(audit);
-
-    Seedlot seedlot = new Seedlot("54321");
-    GeneticWorthEntity gw = new GeneticWorthEntity();
-    gw.setGeneticWorthCode("GVO");
-
-    when(geneticWorthEntityDao.getGeneticWorthEntity("GVO")).thenReturn(Optional.of(gw));
-
-    SeedlotGeneticWorth sgw = new SeedlotGeneticWorth(seedlot, gw, audit);
-    when(seedlotGeneticWorthRepository.saveAll(any())).thenReturn(List.of(sgw));
-
-    SeedlotFormParentTreeSmpDto formStep5 = createFormDto(4023);
-
-    List<SeedlotGeneticWorth> list =
-        seedlotGeneticWorthService.saveSeedlotFormStep5(seedlot, List.of(formStep5), false);
-
-    Assertions.assertFalse(list.isEmpty());
-    Assertions.assertEquals(1, list.size());
-  }
-
-  @Test
-  @DisplayName("Save Seedlot Genetic Worth with one new method")
-  void saveSeedlotFormStep5_updateSeedlotAdd_shouldSucceed() {
-    Seedlot seedlot = new Seedlot("54321");
-    AuditInformation audit = new AuditInformation("userId");
-    GeneticWorthEntity gw = new GeneticWorthEntity();
-    gw.setGeneticWorthCode("GVO");
-
-    when(geneticWorthEntityDao.getGeneticWorthEntity("GVO")).thenReturn(Optional.of(gw));
-    SeedlotGeneticWorth sgw = new SeedlotGeneticWorth(seedlot, gw, audit);
-
-    when(seedlotGeneticWorthRepository.findAllBySeedlot_id("54321")).thenReturn(List.of(sgw));
-    when(loggedUserService.createAuditCurrentUser()).thenReturn(audit);
-    when(seedlotGeneticWorthRepository.saveAllAndFlush(any())).thenReturn(List.of(sgw));
-
-    List<SeedlotGeneticWorth> list =
-        seedlotGeneticWorthService.saveSeedlotFormStep5(
-            seedlot, List.of(createFormDto(4025)), false);
-
-    Assertions.assertTrue(list.isEmpty());
   }
 
   @Test
@@ -189,8 +123,7 @@ class SeedlotGeneticWorthServiceTest {
     wwdGenWorth.setGeneticQualityValue(new BigDecimal("12.1"));
     wwdGenWorth.setTestedParentTreeContributionPercentage(new BigDecimal("96"));
 
-    when(seedlotGeneticWorthRepository.findAllBySeedlot_id(seedlot.getId()))
-        .thenReturn(List.of());
+    when(seedlotGeneticWorthRepository.findAllBySeedlot_id(seedlot.getId())).thenReturn(List.of());
 
     when(geneticWorthEntityDao.getGeneticWorthEntity("GVO"))
         .thenReturn(Optional.of(mockGeneticWorthEntity("GVO")));

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -775,8 +775,6 @@ class SeedlotServiceTest {
         .thenReturn(List.of());
     doNothing().when(seedlotParentTreeGeneticQualityService).saveSeedlotFormStep5(any(), any());
 
-    when(seedlotGeneticWorthService.saveSeedlotFormStep5(seedlot, List.of(parentTreeSmpDto), true))
-        .thenReturn(List.of());
     when(smpMixService.saveSeedlotFormStep5(any(), any())).thenReturn(List.of());
     doNothing().when(smpMixGeneticQualityService).saveSeedlotFormStep5(any(), any());
     doNothing()


### PR DESCRIPTION
# Description
Closes #1426 

### Changelog
#### Removed
- Seedlot Genetic Worth table being saved twice.

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media3.giphy.com/media/VHw2B2seV2HUvAVMlF/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-33-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1433-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1433-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-33-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1433-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1433-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)