### PR TITLE
chore(ci): sync job conversion

### DIFF
--- a/.github/workflows/job-sync.yml
+++ b/.github/workflows/job-sync.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   sync:

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -53,7 +53,8 @@ objects:
         app: ${REPO}-${ZONE}
         cronjob: ${REPO}-${ZONE}
     spec:
-      schedule: "${CRON_MINUTES} 8 * * *" # Run daily at 8:xx AM UTC
+      # 00:00 on day-of-month 1 in every 12000th month from January through December
+      schedule: "0 0 1 1/12000 *" # https://crontab.guru/#0_0_1_1/12000_*
       startingDeadlineSeconds: 60
       concurrencyPolicy: "Replace"
       successfulJobsHistoryLimit: "${{JOB_HISTORY_SUCCESS}}"


### PR DESCRIPTION
# Description

We can't fire up OpenShift jobs without a cronjob, so a schedule is required.  This PR sets the schedule to once every 1000 years, which would be infrequent enough to be ignorable.

### Changelog
#### Changed
- Cronjob schedule is now: `0 0 1 1/12000 *`
- "00:00 on day-of-month 1 in every 12000th month from January through December`


### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/TpsnRzEXYT44qboKW9/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-0-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1450-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1450-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)