### PR TITLE
feat(ci): deploy on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  release:
+    types: [published, updated]
+
+concurrency:
+  # Do not interrupt previous workflows
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  dump:
+    name: Dump Contexts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug GitHub Action
+        uses: raven-actions/debug@v1.1.0
+    
+  # init:
+  #   name: Initialize
+  #   outputs:
+  #     pr: ${{ steps.pr.outputs.pr }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #       # Get PR number for squash merges to main
+  #     - name: PR Number
+  #       id: pr
+  #       uses: bcgov-nr/action-get-pr@v0.0.1
+
+  # deploy-prod:
+  #   name: PROD
+  #   needs: [init]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/.deploy.yml
+  #   with:
+  #     environment: prod
+  #     tag: ${{ needs.init.outputs.pr }}
+  #     target: prod


### PR DESCRIPTION
# Description
Closes #1441 

It'll take a few iterations, but the idea is to deploy to PROD when new releases are published or updated.

### Changelog
#### New
- Release workflow

### How was this tested?
- [x] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/r6k2skexAWdxhfKY74/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-16-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1466-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1466-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)