### PR TITLE
chore(ci): sync secrets object

### DIFF
--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -12,9 +12,6 @@ parameters:
   - name: ORACLE_HOST
     description: Oracle database host
     value: nrcdb03.bcgov
-  - name: ORACLE_PORT
-    description: Oracle database port
-    value: "1543"
   - name: ORACLE_SERVICE
     description: Oracle service name
     value: dbq01.nrs.bcgov
@@ -43,10 +40,18 @@ objects:
     stringData:
       oracle-host: ${ORACLE_HOST}
       oracle-password: ${ORACLE_PASSWORD}
-      oracle-port: ${ORACLE_PORT}
       oracle-service: ${ORACLE_SERVICE}
       oracle-user: ${ORACLE_USER}
       oracle-secret: ${ORACLE_CERT_SECRET}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${NAME}-${ZONE}-sync
+      labels:
+        app: ${NAME}-${ZONE}
+    stringData:
+      oracle-host: ${ORACLE_HOST}
+      oracle-service: ${ORACLE_SERVICE}
       oracle-sync-password: ${ORACLE_SYNC_PASSWORD}
       oracle-sync-user: ${ORACLE_SYNC_USER}
   - apiVersion: v1

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -44,6 +44,9 @@ parameters:
     description: Oracle API environment for OpenSearch. # One of: development, test, production
     required: false
     value: development
+  - name: DATABASE_PORT
+    description: Oracle database port
+    value: "1543"
   - name: ORACLEDB_KEYSTORE
     description: Keystore location path
   - name: AWS_COGNITO_ISSUER_URI
@@ -105,10 +108,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: oracle-secret
                 - name: DATABASE_PORT
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${NAME}-${ZONE}-${COMPONENT}
-                      key: oracle-port
+                  value: ${DATABASE_PORT}
               volumeMounts:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-certs
                   mountPath: /cert
@@ -136,10 +136,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: oracle-host
                 - name: DATABASE_PORT
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${NAME}-${ZONE}-${COMPONENT}
-                      key: oracle-port
+                  value: ${DATABASE_PORT}
                 - name: SERVICE_NAME
                   valueFrom:
                     secretKeyRef:

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -86,24 +86,24 @@ objects:
                     - name: ORACLE_HOST
                       valueFrom:
                         secretKeyRef:
-                          name: ${REPO}-${ZONE}-oracle-api
+                          name: ${REPO}-${ZONE}-sync
                           key: oracle-host
                     - name: ORACLE_SYNC_PASSWORD
                       valueFrom:
                         secretKeyRef:
-                          name: ${REPO}-${ZONE}-oracle-api
+                          name: ${REPO}-${ZONE}-sync
                           key: oracle-sync-password
                     - name: DATABASE_PORT
                       value: ${DATABASE_PORT}
                     - name: ORACLE_SERVICE
                       valueFrom:
                         secretKeyRef:
-                          name: ${REPO}-${ZONE}-oracle-api
+                          name: ${REPO}-${ZONE}-sync
                           key: oracle-service
                     - name: ORACLE_SYNC_USER
                       valueFrom:
                         secretKeyRef:
-                          name: ${REPO}-${ZONE}-oracle-api
+                          name: ${REPO}-${ZONE}-sync
                           key: oracle-sync-user
                     - name: POSTGRES_HOST
                       value: ${REPO}-${ZONE}-database

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -13,7 +13,7 @@ parameters:
   - name: APP
     description: Application/component name
     value: sync
-  - name: DATABASE_PORT
+  - name: ORACLE_PORT
     description: Oracle database port
     value: "1543"
   - name: EXECUTION_ID
@@ -93,8 +93,8 @@ objects:
                         secretKeyRef:
                           name: ${REPO}-${ZONE}-sync
                           key: oracle-sync-password
-                    - name: DATABASE_PORT
-                      value: ${DATABASE_PORT}
+                    - name: ORACLE_PORT
+                      value: ${ORACLE_PORT}
                     - name: ORACLE_SERVICE
                       valueFrom:
                         secretKeyRef:
@@ -117,8 +117,11 @@ objects:
                         secretKeyRef:
                           name: ${REPO}-${ZONE}-database
                           key: database-password
-                    - name: DATABASE_PORT
-                      value: ${DATABASE_PORT}
+                    - name: POSTGRES_PORT
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${REPO}-${ZONE}-database
+                          key: database-port
                     - name: POSTGRES_USER
                       valueFrom:
                         secretKeyRef:

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -13,6 +13,9 @@ parameters:
   - name: APP
     description: Application/component name
     value: sync
+  - name: DATABASE_PORT
+    description: Oracle database port
+    value: "1543"
   - name: EXECUTION_ID
     description: Process execution ID for running ETL Tool
     value: "100"
@@ -90,11 +93,8 @@ objects:
                         secretKeyRef:
                           name: ${REPO}-${ZONE}-oracle-api
                           key: oracle-sync-password
-                    - name: ORACLE_PORT
-                      valueFrom:
-                        secretKeyRef:
-                          name: ${REPO}-${ZONE}-oracle-api
-                          key: oracle-port
+                    - name: DATABASE_PORT
+                      value: ${DATABASE_PORT}
                     - name: ORACLE_SERVICE
                       valueFrom:
                         secretKeyRef:
@@ -117,11 +117,8 @@ objects:
                         secretKeyRef:
                           name: ${REPO}-${ZONE}-database
                           key: database-password
-                    - name: POSTGRES_PORT
-                      valueFrom:
-                        secretKeyRef:
-                          name: ${REPO}-${ZONE}-database
-                          key: database-port
+                    - name: DATABASE_PORT
+                      value: ${DATABASE_PORT}
                     - name: POSTGRES_USER
                       valueFrom:
                         secretKeyRef:


### PR DESCRIPTION
# Description

Sync didn't have its own secrets object, which would have been fine, except it differs from oracle-api enough to create confusion.  This creates a separate set.  The database port has also been removed from secrets.

### Changelog
#### New
- Sync secrets object

#### Changed
- Pointed sync to new object
- Remove port secret, go with visible value instead

### How was this tested?
- [x] 🤖 Covered by existing Tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/hj8eOHrXqoLntsCyWz/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-22-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1472-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1472-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)