### PR TITLE
fix: orchard null bec zone code and draft timestamp

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SaveSeedlotFormService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SaveSeedlotFormService.java
@@ -86,6 +86,10 @@ public class SaveSeedlotFormService {
       entityToSave.setProgressStatus(parsedProgressStatus);
     }
 
+    relatedSeedlot.setAuditInformation(loggedUserService.createAuditCurrentUser());
+
+    seedlotRepository.save(relatedSeedlot);
+
     SaveSeedlotProgressEntityClassA saved = saveSeedlotProgressRepositoryClassA.save(entityToSave);
 
     SparLog.info("A-class seedlot progress for seedlot number {} saved!", seedlotNumber);

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/OrchardService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/OrchardService.java
@@ -62,9 +62,15 @@ public class OrchardService {
       }
 
       List<String> bacZones = new ArrayList<>(1);
-      bacZones.add(orchardEntity.getBecZoneCode());
+      if (orchardEntity.getBecZoneCode() != null) {
+        bacZones.add(orchardEntity.getBecZoneCode());
+      }
+
       Map<String, String> becZoneDescMap =
           sparBecCatalogueService.getBecDescriptionsByCode(bacZones);
+
+      String becZoneDescription =
+          becZoneDescMap.isEmpty() ? null : becZoneDescMap.get(orchardEntity.getBecZoneCode());
 
       OrchardDto orchardDto =
           new OrchardDto(
@@ -75,7 +81,7 @@ public class OrchardService {
               orchardLotTypeCode.getDescription(),
               orchardEntity.getStageCode(),
               orchardEntity.getBecZoneCode(),
-              becZoneDescMap.get(orchardEntity.getBecZoneCode()),
+              becZoneDescription,
               orchardEntity.getBecSubzoneCode(),
               orchardEntity.getVariant(),
               orchardEntity.getBecVersionId());

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/SparBecCatalogueService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/SparBecCatalogueService.java
@@ -21,7 +21,8 @@ public class SparBecCatalogueService {
    * null.
    */
   public Map<String, String> getBecDescriptionsByCode(List<String> becZoneCodes) {
-    SparLog.info("Begin service request to find the description of a given BEC zone code");
+    SparLog.info(
+        "Begin service request to find the description of a given BEC zone code {}", becZoneCodes);
 
     if (becZoneCodes.isEmpty()) {
       SparLog.info("No BEC Zone code param, returning empty values for BEC zone descriptions");


### PR DESCRIPTION
- fixed a problem where bec zone code with null values crashes the oracle' orchard endpoint
- update seedlot table's timestamp when draft table is updated

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-27-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1477-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1477-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)