### PR TITLE
fix: 1479 seedlot dates bugs

### DIFF
--- a/frontend/src/utils/SeedlotUtils.ts
+++ b/frontend/src/utils/SeedlotUtils.ts
@@ -48,8 +48,8 @@ export const covertRawToDisplayObj = (seedlot: SeedlotType, vegCodeData: MultiOp
   createdAt: luxon.fromISO(seedlot.auditInformation.entryTimestamp).toFormat(MONTH_DAY_YEAR),
   lastUpdatedAt: luxon.fromISO(seedlot.auditInformation.updateTimestamp)
     .toFormat(MONTH_DAY_YEAR),
-  approvedAt: seedlot.seedlotStatus.seedlotStatusCode === 'APP'
-    ? luxon.fromISO(seedlot.seedlotStatus.updateTimestamp).toFormat(MONTH_DAY_YEAR)
+  approvedAt: seedlot.seedlotStatus.seedlotStatusCode === 'APP' && seedlot.approvedTimestamp
+    ? luxon.fromISO(seedlot.approvedTimestamp).toFormat(MONTH_DAY_YEAR)
     : '--'
 });
 

--- a/frontend/src/utils/SeedlotUtils.ts
+++ b/frontend/src/utils/SeedlotUtils.ts
@@ -48,9 +48,10 @@ export const covertRawToDisplayObj = (seedlot: SeedlotType, vegCodeData: MultiOp
   createdAt: luxon.fromISO(seedlot.auditInformation.entryTimestamp).toFormat(MONTH_DAY_YEAR),
   lastUpdatedAt: luxon.fromISO(seedlot.auditInformation.updateTimestamp)
     .toFormat(MONTH_DAY_YEAR),
-  approvedAt: seedlot.seedlotStatus.seedlotStatusCode === 'APP' && seedlot.approvedTimestamp
-    ? luxon.fromISO(seedlot.approvedTimestamp).toFormat(MONTH_DAY_YEAR)
-    : '--'
+  approvedAt:
+    (seedlot.seedlotStatus.seedlotStatusCode === 'APP' || seedlot.seedlotStatus.seedlotStatusCode === 'COM') && seedlot.approvedTimestamp
+      ? luxon.fromISO(seedlot.approvedTimestamp).toFormat(MONTH_DAY_YEAR)
+      : '--'
 });
 
 /**


### PR DESCRIPTION
# Description
Closes #1479

### Changelog
#### New
- Nothing :)

#### Changed
- Displayed correct field on util function used to display seedlot data.

#### Removed
- Nothing :)

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img width="250" src="https://media1.giphy.com/media/cXblnKXr2BQOaYnTni/giphy.gif"/>
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-34-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1484-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1484-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)