### PR TITLE
fix: expire F8 gametic option

### DIFF
--- a/backend/src/main/resources/db/migration/V44__expire_f8_gametic_option.sql
+++ b/backend/src/main/resources/db/migration/V44__expire_f8_gametic_option.sql
@@ -1,0 +1,7 @@
+UPDATE
+  spar.gametic_methodology_list
+SET
+  expiry_date = '2024-08-09',
+  update_timestamp = '2024-08-09 17:00:00.000000'
+WHERE
+  gametic_methodology_code = 'F8';


### PR DESCRIPTION
Make F8 gametic option expired as requested by the P.O.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-44-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1494-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1494-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)