### PR TITLE
chore(ci): only PRs use TEST_MODE=true

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -175,7 +175,7 @@ jobs:
           parameters:
             -p TAG=${{ inputs.tag }}
             -p ZONE=${{ inputs.target }}
-            -p TEST_MODE=true
+            ${{ github.event_name == 'pull_request' && '-p TEST_MODE=true' || '' }}
 
       - name: Override OpenShift version
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Description
Closes nothing, but still useful!

### Changelog
#### Changed
- TEST_MODE=true for PRs, else false

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media4.giphy.com/media/gw3IWyGkC0rsazTi/giphy.gif" width="200"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-1-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1501-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1501-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)