### PR TITLE
chore(ci): build_number var in sync

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -189,25 +189,4 @@ jobs:
 
       - name: Run sync ETL
         if: github.event_name == 'pull_request'
-        run: |
-          # Run and verify job
-
-          # Login
-          oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
-          oc project ${{ vars.oc_namespace }} #Safeguard!
-
-          # Exit on errors or unset variables
-          set -eu
-
-          # Create job
-          CRONJOB=nr-spar-${{ inputs.target }}-sync
-          RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
-          oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
-
-          # Follow
-          oc wait --for=condition=ready pod --selector=job-name=${RUN_JOB} --timeout=1m
-          oc logs -l job-name=${RUN_JOB} --tail=50 --follow
-
-          # Verify successful completion
-          oc wait --for jsonpath='{.status.phase}'=Succeeded pod --selector=job-name=${RUN_JOB} --timeout=1m
-          echo "Job successful!"
+        run: ./sync/oc_run.sh ${{ secrets.oc_token }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -194,7 +194,7 @@ jobs:
 
           # Login
           oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
-          oc project ${{ secrets.oc_namespace }} #Safeguard!
+          oc project ${{ vars.oc_namespace }} #Safeguard!
 
           # Exit on errors or unset variables
           set -eu

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -30,7 +30,7 @@ jobs:
 
           # Login
           oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
-          oc project ${{ secrets.oc_namespace }} #Safeguard!
+          oc project ${{ vars.oc_namespace }} #Safeguard!
 
           # Delete and replace route
           oc delete route/${{ env.REPO }}-${{ env.DEST }} --ignore-not-found=true

--- a/.github/workflows/job-sync.yml
+++ b/.github/workflows/job-sync.yml
@@ -29,7 +29,7 @@ jobs:
 
           # Login
           oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
-          oc project ${{ secrets.oc_namespace }} #Safeguard!
+          oc project ${{ vars.oc_namespace }} #Safeguard!
 
           # Exit on errors or unset variables
           set -eu

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -24,8 +24,8 @@ jobs:
         id: build
         with:
           build_args: |
-            BUILD_NUMBER="${{ github.event.number }}"
-            BUILDKIT_INLINE_CACHE="1"
+            BUILD_NUMBER=${{ github.event.number }}
+            BUILDKIT_INLINE_CACHE=1
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}
           tag_fallback: latest

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: bcgov-nr/action-builder-ghcr@v2.2.0
         id: build
         with:
-          build_args:
+          build_args: |
             BUILD_NUMBER="${{ github.event.number }}"
-            "BUILDKIT_INLINE_CACHE=1"
+            BUILDKIT_INLINE_CACHE="1"
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}
           tag_fallback: latest

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -24,8 +24,8 @@ jobs:
         id: build
         with:
           build_args: |
-            "BUILDKIT_INLINE_CACHE=1"
             --build-arg BUILD_NUMBER=${{ github.event.number }}
+            "BUILDKIT_INLINE_CACHE=1"
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}
           tag_fallback: latest

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -24,7 +24,7 @@ jobs:
         id: build
         with:
           build_args:
-            --build-arg BUILD_NUMBER=${{ github.event.number }}
+            --build-arg=BUILD_NUMBER="${{ github.event.number }}"
             "BUILDKIT_INLINE_CACHE=1"
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -24,7 +24,7 @@ jobs:
         id: build
         with:
           build_args:
-            --build-arg=BUILD_NUMBER="${{ github.event.number }}"
+            BUILD_NUMBER="${{ github.event.number }}"
             "BUILDKIT_INLINE_CACHE=1"
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: bcgov-nr/action-builder-ghcr@v2.2.0
         id: build
         with:
-          build_args: |
+          build_args:
             --build-arg BUILD_NUMBER=${{ github.event.number }}
             "BUILDKIT_INLINE_CACHE=1"
           package: ${{ matrix.package }}

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 # Receive build number as argument, retain as environment variable
-ARG BUILD_NUMBER=0
+ARG BUILD_NUMBER
 ENV BUILD_NUMBER=${BUILD_NUMBER}
 
 # Packages and nonroot user

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.12-slim
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER=${BUILD_NUMBER}
 
+RUN echo "Build number: ${BUILD_NUMBER}" && blorf
+
 # Packages and nonroot user
 RUN apt update && \
     apt install -y --no-install-recommends gcc libpq-dev python3-dev && \

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -4,8 +4,6 @@ FROM python:3.12-slim
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER=${BUILD_NUMBER}
 
-RUN echo "Build number: ${BUILD_NUMBER}" && blorf
-
 # Packages and nonroot user
 RUN apt update && \
     apt install -y --no-install-recommends gcc libpq-dev python3-dev && \

--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -6,12 +6,10 @@ set -eux
 # Run and verify job
 
 # Login
-if [ ! -z "${1}" ]; then
-  echo "Missing oc_token secret"
-  exit 1
+if [ ! -z "${1:-}" ]; then
+  oc login --token=${1} --server=https://api.silver.devops.gov.bc.ca:6443
+  oc project  #Safeguard!
 fi
-oc login --token=${{ secrets.oc_token }} --server=https://api.silver.devops.gov.bc.ca:6443
-oc project  #Safeguard!
 
 # Create job
 CRONJOB=nr-spar-1502-sync

--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Exit on errors or unset variables
+set -eux
+
+# Run and verify job
+
+# Login
+if [ ! -z "${1}" ]; then
+  echo "Missing oc_token secret"
+  exit 1
+fi
+oc login --token=${{ secrets.oc_token }} --server=https://api.silver.devops.gov.bc.ca:6443
+oc project  #Safeguard!
+
+# Create job
+CRONJOB=nr-spar-1502-sync
+RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
+oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
+
+# Follow
+oc wait --for=condition=ready pod --selector=job-name=${RUN_JOB} --timeout=1m
+oc logs -l job-name=${RUN_JOB} --tail=50 --follow
+
+# Verify successful completion
+oc wait --for jsonpath='{.status.phase}'=Succeeded pod --selector=job-name=${RUN_JOB} --timeout=1m
+echo "Job successful!"

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -30,10 +30,6 @@ parameters:
     value: "false"
 
   ### Usually a bad idea - not recommended
-  - name: CRON_MINUTES
-    description: Random number, 0-60, for scheduling cronjobs
-    from: "[0-5]{1}[0-9]{1}"
-    generate: expression
   - name: JOB_BACKOFF_LIMIT
     description: "The number of attempts to try for a successful job outcome"
     value: "3"


### PR DESCRIPTION
# Description
Build numbers still aren't showing up in the ETL sync job.  I'm trying to fix that!

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/3o6Mb7m2Gr4xmZnjxu/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-2-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1502-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1502-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)