### PR TITLE
fix(ci): move vite_user_pools_web_client_id to init

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -87,6 +87,7 @@ jobs:
             -p ORACLE_SYNC_PASSWORD='${{ secrets.ORACLE_SYNC_PASSWORD }}'
             -p ORACLE_CERT_SECRET='${{ secrets.ORACLE_CERT_SECRET }}'
             -p ORACLE_HOST='${{ vars.ORACLE_HOST }}'
+            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ secrets.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
       - name: Database
         if: steps.triggers.outputs.core == 'true' || steps.triggers.outputs.sync == 'true'
@@ -127,7 +128,6 @@ jobs:
               -p FAM_MODDED_ZONE=${{ needs.init.outputs.fam-modded-zone }}
               -p VITE_SPAR_BUILD_VERSION=snapshot-${{ inputs.target || github.event.number }}
               -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
-              -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ secrets.VITE_USER_POOLS_WEB_CLIENT_ID }}
           - name: oracle-api
             file: oracle-api/openshift.deploy.yml
             overwrite: true

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -31,6 +31,9 @@ parameters:
   - name: ORACLE_SYNC_USER
     description: Oracle database username for Sync
     value: proxy_fsa_spar_sync_user
+  - name: VITE_USER_POOLS_WEB_CLIENT_ID
+    description: Cognito user pools web client ID
+    required: true
 objects:
   - apiVersion: v1
     kind: Secret
@@ -63,6 +66,14 @@ objects:
         app: ${NAME}-${ZONE}
     stringData:
       forest-client-api-key: ${FORESTCLIENTAPI_KEY}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${NAME}-${ZONE}-frontend
+      labels:
+        app: ${NAME}-${ZONE}
+    stringData:
+      vite-user-pools-web-client-id: ${VITE_USER_POOLS_WEB_CLIENT_ID}
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -52,9 +52,6 @@ parameters:
   - name: VITE_USER_POOLS_ID
     description: AWS Cognito Pools ID
     required: true
-  - name: VITE_USER_POOLS_WEB_CLIENT_ID
-    description: AWS Cognito Web Client ID
-    required: true
 objects:
   - apiVersion: apps/v1
     kind: Deployment
@@ -98,7 +95,10 @@ objects:
                 - name: VITE_USER_POOLS_ID
                   value: ${VITE_USER_POOLS_ID}
                 - name: VITE_USER_POOLS_WEB_CLIENT_ID
-                  value: ${VITE_USER_POOLS_WEB_CLIENT_ID}
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NAME}-${ZONE}-frontend
+                      key: vite-user-pools-web-client-id
                 - name: VITE_ZONE
                   value: ${FAM_MODDED_ZONE}
               resources:


### PR DESCRIPTION
# Description
Handling around a var->secret change

### Changelog
#### Changed
- Use init to handle secret that was a var

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/otYYkRFODhvrCEQfRa/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-4-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1504-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1504-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)