### PR TITLE
feat: fix empty string for json dates

### DIFF
--- a/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_EXTRACT.sql
+++ b/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_EXTRACT.sql
@@ -32,11 +32,11 @@ WITH seedlot_coll_methods
             else null 
        end as secondary_orchard_id
      , CAST(case when all_step_data->'collectionStep'->'startDate'->>'isInvalid' = 'false'
-                 then all_step_data->'collectionStep'->'startDate'->>'value'
+                 then NULLIF(all_step_data->'collectionStep'->'startDate'->>'value','')
                  else null 
                   end AS DATE)  as collection_start_date
      , CAST(case when all_step_data->'collectionStep'->'endDate'->>'isInvalid' = 'false'
-                 then all_step_data->'collectionStep'->'endDate'->>'value'
+                 then NULLIF(all_step_data->'collectionStep'->'endDate'->>'value','')
                  else null
                   end AS DATE) as collection_end_date
      , case when all_step_data->'collectionStep'->'collectorAgency'->>'isInvalid' = 'false'


### PR DESCRIPTION
# Description
When collection start or end date return empty string from json query, pg will not cast to date. 

### Changelog
#### New
-

#### Changed
-

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-8-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1508-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1508-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)