### PR TITLE
chore(ci): set minimum replicas and loosen liveness probes

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -103,6 +103,8 @@ jobs:
             -p ZONE=${{ inputs.target }}
             -p DB_PASSWORD='${{ secrets.DB_PASSWORD }}'
             ${{ github.event_name == 'pull_request' && '-p DB_PVC_SIZE=192Mi' || '' }}
+            ${{ github.event_name == 'pull_request' && '-p MEMORY_REQUEST=100Mi' || '' }}
+            ${{ github.event_name == 'pull_request' && '-p MEMORY_LIMIT=200Mi' || '' }}
 
   deploy:
     name: Deploy

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -72,7 +72,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
+      replicas: ${MIN_REPLICAS}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -72,7 +72,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: ${MIN_REPLICAS}
+      replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -118,6 +118,8 @@ objects:
                     - bash
                     - '-ce'
                     - exec pg_isready -U $POSTGRES_USER -d "dbname=$POSTGRES_DB" -h 127.0.0.1 -p 5432
+                periodSeconds: 30
+                timeoutSeconds: 10
               env:
                 - name: POSTGRES_DB
                   valueFrom:

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -29,9 +29,9 @@ parameters:
   - name: CPU_LIMIT
     value: 75m
   - name: MEMORY_REQUEST
-    value: 100Mi
+    value: 2Gi
   - name: MEMORY_LIMIT
-    value: 200Mi
+    value: 4Gi
   - name: DB_PVC_SIZE
     description: Volume space available for data, e.g. 512Mi, 2Gi.
     displayName: Database Volume Capacity

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Build static files
 # Node Bullseye has npm
 FROM node:18.20.4-bullseye-slim AS build
-ENV NODE_OPTIONS "--max-old-space-size=3072"
+ENV NODE_OPTIONS="--max-old-space-size=3072"
 
 # Build
 WORKDIR /app

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -60,7 +60,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: ${MIN_REPLICAS}
+      replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -60,7 +60,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
+      replicas: ${MIN_REPLICAS}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -76,7 +76,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
+      replicas: ${MIN_REPLICAS}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -76,7 +76,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: ${MIN_REPLICAS}
+      replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}


### PR DESCRIPTION
# Description
Set TEST and PROD replicas to 3 min and 5 max for backend, frontend and oracle-api.  Loosen liveness probes for the database, because it reboots too easily when busy.

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/ctWSqhTv0LXd6/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-10-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1510-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1510-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)