### PR TITLE
chore(ci): disable etl retries, script revisions

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -191,4 +191,4 @@ jobs:
 
       - name: Run sync ETL
         if: github.event_name == 'pull_request'
-        run: ./sync/oc_run.sh ${{ secrets.oc_token }}
+        run: ./sync/oc_run.sh ${{ inputs.tag }} ${{ secrets.oc_token }}

--- a/.github/workflows/job-sync.yml
+++ b/.github/workflows/job-sync.yml
@@ -24,25 +24,4 @@ jobs:
         working-directory: /usr/local/bin/
 
       - name: ETL Sync
-        run: |
-          # Run and verify job
-
-          # Login
-          oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
-          oc project ${{ vars.oc_namespace }} #Safeguard!
-
-          # Exit on errors or unset variables
-          set -eu
-
-          # Create job
-          CRONJOB=nr-spar-test-sync
-          RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
-          oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
-
-          # Follow
-          oc wait --for=condition=ready pod --selector=job-name=${RUN_JOB} --timeout=1m
-          oc logs -l job-name=${RUN_JOB} --tail=50 --follow
-
-          # Verify successful completion
-          oc wait --for jsonpath='{.status.phase}'=Succeeded pod --selector=job-name=${RUN_JOB} --timeout=1m
-          echo "Job successful!"
+        run: ./sync/oc_run.sh test ${{ secrets.oc_token }}

--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -12,7 +12,7 @@ if [ ! -z "${1:-}" ]; then
 fi
 
 # Create job
-CRONJOB=nr-spar-1502-sync
+CRONJOB=nr-spar-test-sync
 RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
 oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 

--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -6,13 +6,13 @@ set -eux
 # Run and verify job
 
 # Login
-if [ ! -z "${1:-}" ]; then
-  oc login --token=${1} --server=https://api.silver.devops.gov.bc.ca:6443
+if [ ! -z "${2:-}" ]; then
+  oc login --token=${2} --server=https://api.silver.devops.gov.bc.ca:6443
   oc project  #Safeguard!
 fi
 
 # Create job
-CRONJOB=nr-spar-test-sync
+CRONJOB=nr-spar-${1:-test}-sync
 RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
 oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -32,10 +32,10 @@ parameters:
   ### Usually a bad idea - not recommended
   - name: JOB_BACKOFF_LIMIT
     description: "The number of attempts to try for a successful job outcome"
-    value: "3"
+    value: "0"
   - name: JOB_HISTORY_FAIL
     description: "The number of failed jobs that will be retained"
-    value: "2"
+    value: "1"
   - name: JOB_HISTORY_SUCCESS
     description: "The number of successful jobs that will be retained"
     value: "5"


### PR DESCRIPTION
# Description

Disable ETL retries.  Kicking up an error is good enough.

### How was this tested?
- [x] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/jR7zwqBJ3PzMv7q6oc/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-15-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1515-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1515-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)