### PR TITLE
chore(ci): increase TEST and PROD DB PVCs

### DIFF
--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -35,7 +35,7 @@ parameters:
   - name: DB_PVC_SIZE
     description: Volume space available for data, e.g. 512Mi, 2Gi.
     displayName: Database Volume Capacity
-    value: 1Gi
+    value: 1.8Gi
   - name: DB_PASSWORD
     description: Password for the PostgreSQL connection user
     required: true


### PR DESCRIPTION
# Description
Increases the site of TEST and PROD's DB PVCs to 1.8 GB.  Total for namespace is 2 GB.  Note TEST PVC will have to be deleted to size-up.

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/IV4wBde5Ou0XC/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-18-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1518-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1518-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)