### PR TITLE
chore(ci): PROD ETL

### DIFF
--- a/.github/workflows/job-sync.yml
+++ b/.github/workflows/job-sync.yml
@@ -12,7 +12,6 @@ jobs:
   sync:
     name: Sync
     runs-on: ubuntu-latest
-    environment: test
     steps:
       - name: Override OpenShift version
         env:
@@ -24,5 +23,10 @@ jobs:
         working-directory: /usr/local/bin/
 
       - uses: actions/checkout@v4
-      - name: ETL Sync
+      - name: ETL (TEST)
+        environment: test
         run: ./sync/oc_run.sh test ${{ secrets.oc_token }}
+
+      - name: ETL (PROD)
+        environment: prod
+        run: ./sync/oc_run.sh prod ${{ secrets.oc_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       tag:
         description: 'The tag set to deploy; e.g. latest or PR number'
-        required: true
+        required: false
 
 concurrency:
   # Do not interrupt previous workflows

--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 #
 # Exit on errors or unset variables
-set -eux
+set -eu
 
 # Run and verify job
 
 # Login
 if [ ! -z "${2:-}" ]; then
   oc login --token=${2} --server=https://api.silver.devops.gov.bc.ca:6443
-  oc project  #Safeguard!
+  oc project #Safeguard!
 fi
 
 # Create job
-CRONJOB=nr-spar-${1:-test}-sync
+CRONJOB=nr-spar-${1:-}-sync
 RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
 oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 

--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -25,7 +25,7 @@ RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
 oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 
 # Follow
-oc wait --for=condition=ready pod --selector=job-name=${RUN_JOB} --timeout=1m
+oc wait --for=condition=ready pod --selector=job-name=${RUN_JOB} --timeout=5m
 oc logs -l job-name=${RUN_JOB} --tail=50 --follow
 
 # Verify successful completion

--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -3,16 +3,24 @@
 # Exit on errors or unset variables
 set -eu
 
-# Run and verify job
+# Run and verify ETL jobs in OpenShift
+#
+# Usage: ./oc_run.sh [pr#|test|prod] [optional:token]
 
-# Login
+# Check inputs
+if [ -z "${1:-}" ]; then
+  echo -e "\nAn environment input is required.  Exiting.\n"
+  exit 1
+fi
+
+# Login (optional)
 if [ ! -z "${2:-}" ]; then
   oc login --token=${2} --server=https://api.silver.devops.gov.bc.ca:6443
   oc project #Safeguard!
 fi
 
 # Create job
-CRONJOB=nr-spar-${1:-}-sync
+CRONJOB=nr-spar-${1}-sync
 RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
 oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
 


### PR DESCRIPTION
# Description
Enables ETL for PROD, right after running in TEST.

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->
<img src="https://media1.giphy.com/media/xT9IgAakXAITtXIWje/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-33-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1533-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1533-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)