### PR TITLE
fix(ci): run ETL on TEST and PROD in parallel, not series

### DIFF
--- a/.github/workflows/job-sync.yml
+++ b/.github/workflows/job-sync.yml
@@ -9,8 +9,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  sync:
-    name: Sync
+  sync-test:
+    environment: test
+    name: Sync (TEST)
     runs-on: ubuntu-latest
     steps:
       - name: Override OpenShift version
@@ -24,9 +25,22 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: ETL (TEST)
-        environment: test
         run: ./sync/oc_run.sh test ${{ secrets.oc_token }}
 
+  sync-prod:
+    environment: prod
+    name: Sync (PROD)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Override OpenShift version
+        env:
+          OC: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.13/openshift-client-linux.tar.gz
+        run: |
+          # Download and extract with retry, continuing on error
+          (wget ${{ env.OC }} -qcO - | tar -xzvf - oc)|| !! || true
+          oc version
+        working-directory: /usr/local/bin/
+
+      - uses: actions/checkout@v4
       - name: ETL (PROD)
-        environment: prod
         run: ./sync/oc_run.sh prod ${{ secrets.oc_token }}


### PR DESCRIPTION
# Description
### Changelog
#### Changed
- move environment calls to job, not step level
- run TEST and PROD ETL in parallel, so TEST can't block PROD
- ^ note: we want blocking eventually! ^

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media4.giphy.com/media/xT1XGCzvtlktcwtJTy/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-37-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1537-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1537-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)