### PR TITLE
feat: empty strings returned for json numerics

### DIFF
--- a/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_EXTRACT.sql
+++ b/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_EXTRACT.sql
@@ -11,24 +11,24 @@ WITH seedlot_coll_methods
   (select seedlot_number
      , case when all_step_data->'extractionStorageStep'->'extraction'->'agency'->>'isInvalid' = 'false' 
              and all_step_data->'extractionStorageStep'->'extraction'->'locationCode'->>'isInvalid' = 'false' 
-            then all_step_data->'extractionStorageStep'->'extraction'->'agency'->>'value'
+            then NULLIF(all_step_data->'extractionStorageStep'->'extraction'->'agency'->>'value','')
             else null 
        end as extrct_cli_number 
      , case when all_step_data->'extractionStorageStep'->'extraction'->'agency'->>'isInvalid' = 'false' 
              and all_step_data->'extractionStorageStep'->'extraction'->'locationCode'->>'isInvalid' = 'false' 
-            then all_step_data->'extractionStorageStep'->'extraction'->'locationCode'->>'value'
+            then NULLIF(all_step_data->'extractionStorageStep'->'extraction'->'locationCode'->>'value','')
             else null 
        end as extrct_cli_locn_cd 
      , case when all_step_data->'interimStep'->'facilityType'->>'isInvalid' = 'false' 
-            then all_step_data->'interimStep'->'facilityType'->>'value' 
+            then NULLIF(all_step_data->'interimStep'->'facilityType'->>'value' ,'')
             else null 
        end as interm_facility_code 
      , case when all_step_data->'orchardStep'->'orchards'->'primaryOrchard'->>'isInvalid' = 'false' 
-            then all_step_data->'orchardStep'->'orchards'->'primaryOrchard'->'value'->>'code'
+            then NULLIF(all_step_data->'orchardStep'->'orchards'->'primaryOrchard'->'value'->>'code','')
             else null 
        end as orchard_id
      , case when all_step_data->'orchardStep'->'orchards'->'secondaryOrchard'->>'isInvalid' = 'false' 
-            then all_step_data->'orchardStep'->'orchards'->'secondaryOrchard'->'value'->>'code'
+            then NULLIF(all_step_data->'orchardStep'->'orchards'->'secondaryOrchard'->'value'->>'code','')
             else null 
        end as secondary_orchard_id
      , CAST(case when all_step_data->'collectionStep'->'startDate'->>'isInvalid' = 'false'
@@ -41,36 +41,36 @@ WITH seedlot_coll_methods
                   end AS DATE) as collection_end_date
      , case when all_step_data->'collectionStep'->'collectorAgency'->>'isInvalid' = 'false'
              and all_step_data->'collectionStep'->'locationCode'->>'isInvalid' = 'false'
-            then all_step_data->'collectionStep'->'collectorAgency'->>'value' 
+            then NULLIF(all_step_data->'collectionStep'->'collectorAgency'->>'value' ,'')
             else null
        end as collection_cli_number
      , case when all_step_data->'collectionStep'->'collectorAgency'->>'isInvalid' = 'false'
              and all_step_data->'collectionStep'->'locationCode'->>'isInvalid' = 'false'
-            then all_step_data->'collectionStep'->'locationCode'->>'value'
+            then NULLIF(all_step_data->'collectionStep'->'locationCode'->>'value','')
             else null
        end as collection_cli_locn_cd
      , CAST(case when all_step_data->'collectionStep'->'volumeOfCones'->>'isInvalid' = 'false'
-                 then all_step_data->'collectionStep'->'volumeOfCones'->>'value'
+                 then NULLIF(all_step_data->'collectionStep'->'volumeOfCones'->>'value','')
                  else null
                   end as NUMERIC) as clctn_volume
      , CAST(case when all_step_data->'collectionStep'->'numberOfContainers'->>'isInvalid' = 'false'
-                 then all_step_data->'collectionStep'->'numberOfContainers'->>'value'
+                 then NULLIF(all_step_data->'collectionStep'->'numberOfContainers'->>'value','')
                  else null
                   end as NUMERIC) as no_of_containers
      , CAST(case when all_step_data->'collectionStep'->'volumePerContainers'->>'isInvalid' = 'false'
-                 then all_step_data->'collectionStep'->'volumePerContainers'->>'value'
+                 then NULLIF(all_step_data->'collectionStep'->'volumePerContainers'->>'value','')
                  else null
              end as NUMERIC)      as vol_per_container
      , TO_CHAR(CAST(case when all_step_data->'collectionStep'->'selectedCollectionCodes'->>'isInvalid' = 'false'
-                    then all_step_data->'collectionStep'->'selectedCollectionCodes'->'value'->>0
+                    then NULLIF(all_step_data->'collectionStep'->'selectedCollectionCodes'->'value'->>0,'')
                     else null
                 end AS NUMERIC),'FM00') as cone_collection_method_code
      , TO_CHAR(CAST(case when all_step_data->'collectionStep'->'selectedCollectionCodes'->>'isInvalid' = 'false'
-                    then all_step_data->'collectionStep'->'selectedCollectionCodes'->'value'->>1
+                    then NULLIF(all_step_data->'collectionStep'->'selectedCollectionCodes'->'value'->>1,'')
                     else null
                 end AS NUMERIC),'FM00') as cone_collection_method2_code
      , case when all_step_data->'collectionStep'->'comments'->>'isInvalid' = 'false'
-            then all_step_data->'collectionStep'->'comments'->>'value'
+            then NULLIF(all_step_data->'collectionStep'->'comments'->>'value','')
             else null
        end as seedlot_comment
   from spar.seedlot_registration_a_class_save

--- a/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql
+++ b/sync/config/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql
@@ -23,24 +23,24 @@ UNION ALL
 SELECT drft.seedlot_number
      , CASE WHEN ownerdata->'ownerAgency'->>'isInvalid' = 'false'
              AND ownerdata->'ownerCode'->>'isInvalid' = 'false'
-            THEN ownerdata->'ownerAgency'->>'value'
+            THEN NULLIF(ownerdata->'ownerAgency'->>'value','')
             ELSE NULL
        END AS client_number
      , CASE WHEN ownerdata->'ownerAgency'->>'isInvalid' = 'false'
              AND ownerdata->'ownerCode'->>'isInvalid' = 'false'
-            THEN ownerdata->'ownerCode'->>'value'
+            THEN NULLIF(ownerdata->'ownerCode'->>'value','')
             ELSE NULL
        END AS client_locn_code
      , CAST(CASE WHEN ownerdata->'ownerPortion'->>'isInvalid' = 'false'
-                 THEN ownerdata->'ownerPortion'->>'value'
+                 THEN NULLIF(ownerdata->'ownerPortion'->>'value','')
                  ELSE NULL
              End AS NUMERIC)       as original_pct_owned
      , CAST(CASE WHEN ownerdata->'reservedPerc'->>'isInvalid' = 'false'
-                 THEN ownerdata->'reservedPerc'->>'value'
+                 THEN NULLIF(ownerdata->'reservedPerc'->>'value','')
                  ELSE NULL
                   END AS NUMERIC)  as original_pct_rsrvd
      , CAST(CASE WHEN ownerdata->'surplusPerc'->>'isInvalid' = 'false'
-                 Then ownerdata->'surplusPerc'->>'value'
+                 Then NULLIF(ownerdata->'surplusPerc'->>'value','')
                  ELSE NULL
                   END AS NUMERIC)  as original_pct_srpls
      , 0 qty_reserved


### PR DESCRIPTION
# Description
Some numeric values returned from json such as collection volume as being interpreted as empty string when missing.
Tested locally.
### Changelog
#### New
-

#### Changed
-

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [X] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-40-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1540-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1540-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)