### PR TITLE
chore(ci): set PROD oracle-api replicas to 3-5

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -135,7 +135,7 @@ jobs:
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.ca-central-1.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
               ${{ github.event_name == 'pull_request' && '-p CPU_LIMIT=100m' || '' }}
-              ${{ inputs.target == 'prod' && '-p MIN_REPLICAS=3 ' || '' }}
+              ${{ inputs.target == 'prod' && '-p MIN_REPLICAS=3' || '' }}
               ${{ inputs.target == 'prod' && '-p MAX_REPLICAS=5' || '' }}
             verification_path: "actuator/health"
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -135,6 +135,8 @@ jobs:
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.ca-central-1.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
               ${{ github.event_name == 'pull_request' && '-p CPU_LIMIT=100m' || '' }}
+              ${{ inputs.target == 'prod' && '-p MIN_REPLICAS=3 ' || '' }}
+              ${{ inputs.target == 'prod' && '-p MAX_REPLICAS=5' || '' }}
             verification_path: "actuator/health"
 
     steps:


### PR DESCRIPTION
# Description

### Changelog
#### Changed
- Scales oracle-api instances from 1 to 3/5 min/max in PROD

### How was this tested?
- [x] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/3o84sq21TxDH6PyYms/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-47-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1597-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1597-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)