### PR TITLE
fix: handle long length usernames

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/security/UserAuthenticationHelper.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/security/UserAuthenticationHelper.java
@@ -64,6 +64,12 @@ public class UserAuthenticationHelper {
         // Email will be empty, until next FAM release
         String email = jwtPrincipal.getClaimAsString("email");
 
+        if (userId.length() > 30) {
+          String newUserId = userId.substring(0, 30);
+          SparLog.warn("UserId length bigger than 30. Cutting off. {} to {}", userId, newUserId);
+          userId = newUserId;
+        }
+
         UserInfo userInfo =
             new UserInfo(
                 userId,


### PR DESCRIPTION
# Description
Closes #1600

### Changelog
#### Changed
- UserAuthenticationHelper to handle long usernames.

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [x] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media3.giphy.com/media/dXr0rbo8j6Yhwivo8f/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-4-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1604-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1604-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)