### PR TITLE
feat: 1495 optimize parent tree bigquery

### DIFF
--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/ParentTreeRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/ParentTreeRepository.java
@@ -13,26 +13,57 @@ public interface ParentTreeRepository extends JpaRepository<ParentTreeEntity, Lo
 
   @Query(
       value =
-         """
-          SELECT PT.PARENT_TREE_ID AS \"parentTreeId\",
-            PT.PARENT_TREE_NUMBER AS \"parentTreeNumber\",
-            PTO.ORCHARD_ID AS \"orchardId\",
-            PTSPU.SEED_PLAN_UNIT_ID AS \"spu\",
-            PT.TESTED_IND AS \"tested\",
-            Q.GENETIC_TYPE_CODE AS \"geneticTypeCode\",
-            Q.GENETIC_WORTH_CODE AS \"geneticWorthCode\",
-            Q.GENETIC_QUALITY_VALUE AS \"geneticQualityValue\"
-          FROM parent_tree PT
-          JOIN parent_tree_orchard PTO ON PTO.parent_tree_id = PT.parent_tree_id
-          LEFT JOIN parent_tree_seed_plan_unit PTSPU ON PTSPU.parent_tree_id = PT.parent_tree_id
-          LEFT JOIN parent_tree_genetic_quality Q ON PT.parent_tree_id = Q.parent_tree_id
-            AND Q.seed_plan_unit_id = PTSPU.seed_plan_unit_id
-            AND Q.genetic_worth_calc_ind = 'Y'
-          WHERE PT.VEGETATION_CODE = ?1
-            AND PT.ACTIVE_IND = 'Y'
-            AND PT.parent_tree_reg_status_code = 'APP'
-          ORDER BY PT.parent_tree_id
-        """,
+          """
+            WITH filtered_parent_tree AS (
+              SELECT
+                  PT.PARENT_TREE_ID,
+                  PT.PARENT_TREE_NUMBER,
+                  PT.TESTED_IND
+              FROM parent_tree PT
+              WHERE PT.VEGETATION_CODE = ?1
+                AND PT.ACTIVE_IND = 'Y'
+                AND PT.parent_tree_reg_status_code = 'APP'
+            ),
+            orchard_data AS (
+                SELECT
+                    PTO.parent_tree_id,
+                    PTO.ORCHARD_ID
+                FROM parent_tree_orchard PTO
+                WHERE PTO.parent_tree_id IN (SELECT PARENT_TREE_ID FROM filtered_parent_tree)
+            ),
+            seed_plan_unit_data AS (
+                SELECT
+                    PTSPU.parent_tree_id,
+                    PTSPU.SEED_PLAN_UNIT_ID
+                FROM parent_tree_seed_plan_unit PTSPU
+                WHERE PTSPU.parent_tree_id IN (SELECT PARENT_TREE_ID FROM filtered_parent_tree)
+            ),
+            genetic_quality_data AS (
+                SELECT
+                    Q.parent_tree_id,
+                    Q.seed_plan_unit_id,
+                    Q.GENETIC_TYPE_CODE,
+                    Q.GENETIC_WORTH_CODE,
+                    Q.GENETIC_QUALITY_VALUE
+                FROM parent_tree_genetic_quality Q
+                WHERE Q.genetic_worth_calc_ind = 'Y'
+             )
+            SELECT
+                fpt.PARENT_TREE_ID AS \"parentTreeId\",
+                fpt.PARENT_TREE_NUMBER AS \"parentTreeNumber\",
+                od.ORCHARD_ID AS \"orchardId\",
+                spud.SEED_PLAN_UNIT_ID AS \"spu\",
+                fpt.TESTED_IND AS \"tested\",
+                gqd.GENETIC_TYPE_CODE AS \"geneticTypeCode\",
+                gqd.GENETIC_WORTH_CODE AS \"geneticWorthCode\",
+                gqd.GENETIC_QUALITY_VALUE AS \"geneticQualityValue\"
+            FROM filtered_parent_tree fpt
+            JOIN orchard_data od ON od.parent_tree_id = fpt.PARENT_TREE_ID
+            LEFT JOIN seed_plan_unit_data spud ON spud.parent_tree_id = fpt.PARENT_TREE_ID
+            LEFT JOIN genetic_quality_data gqd ON gqd.parent_tree_id = fpt.PARENT_TREE_ID
+              AND gqd.seed_plan_unit_id = spud.SEED_PLAN_UNIT_ID
+            ORDER BY fpt.PARENT_TREE_ID;
+         """,
       nativeQuery = true)
   List<ParentTreeProj> findAllParentTreeWithVegCode(String vegCode);
 }


### PR DESCRIPTION
# Description
Closes #1459 

### Changelog

#### Changed
- By filtering parent_tree data upfront in filtered_parent_tree, reduced the number of records involved in subsequent joins.
- Ensured a few columns are indexed for faster joins and where clauses


### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media4.giphy.com/media/3o7TKEP6YngkCKFofC/giphy.gif"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-16-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1616-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1616-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)