### PR TITLE
fix: block navigation while in edit mode

### DIFF
--- a/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
+++ b/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
@@ -520,7 +520,7 @@ const SeedlotReviewContent = () => {
     if (
       !isReadMode
       && !tscSeedlotMutation.isLoading
-      && !statusOnlyMutaion.isLoading
+      && !statusOnlyMutation.isLoading
     ) {
       setIsCancelModalOpen(true); // Show modal if there are unsaved changes
       return true; // Block navigation

--- a/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
+++ b/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useBlocker } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import {
@@ -327,10 +327,10 @@ const SeedlotReviewContent = () => {
     onSuccess: async (_data, variables) => {
       await queryClient.invalidateQueries({ queryKey: ['seedlots', seedlotNumber] });
       await queryClient.invalidateQueries({ queryKey: ['seedlot-full-form', seedlotNumber] });
+      setIsReadMode(true);
       if (variables.statusOnSave !== 'SUB') {
         navigate(`/seedlots/details/${seedlotNumber}/?statusOnSave=${variables.statusOnSave}`);
       }
-      setIsReadMode(true);
     }
   });
 
@@ -350,10 +350,10 @@ const SeedlotReviewContent = () => {
     onSuccess: async (_data, variables) => {
       await queryClient.invalidateQueries({ queryKey: ['seedlots', seedlotNumber] });
       await queryClient.invalidateQueries({ queryKey: ['seedlot-full-form', seedlotNumber] });
+      setIsReadMode(true);
       if (variables.statusOnSave !== 'SUB') {
         navigate(`/seedlots/details/${seedlotNumber}/?statusOnSave=${variables.statusOnSave}`);
       }
-      setIsReadMode(true);
     }
   });
 
@@ -501,6 +501,23 @@ const SeedlotReviewContent = () => {
     queryClient.refetchQueries(['seedlot-full-form', seedlotNumber]);
     closeCancelModal();
   };
+
+  /**
+   * Custom blocker function to prevent navigation with unsaved changes.
+   */
+  const blockerFunction = () => {
+    if (
+      !isReadMode
+      && !tscSeedlotMutation.isLoading
+      && !statusOnlyMutaion.isLoading
+    ) {
+      setIsCancelModalOpen(true); // Show modal if there are unsaved changes
+      return true; // Block navigation
+    }
+    return false; // Allow navigation
+  };
+
+  useBlocker(blockerFunction);
 
   return (
     <FlexGrid className="seedlot-review-grid">


### PR DESCRIPTION
# Description
Closes #1635

### Changelog
#### New
- added useBlocker logic to seedlot review screen

#### Changed
- None

#### Removed
- None

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img src="https://media4.giphy.com/media/l378mc4Thco1Be7O8/giphy.gif" width="200"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-36-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1636-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1636-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)