### PR TITLE
chore: bump action-deployer-openshift version

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: OpenShift Init
         if: steps.triggers.outputs.core == 'true' || steps.triggers.outputs.sync == 'true'
-        uses: bcgov-nr/action-deployer-openshift@v3.0.0
+        uses: bcgov-nr/action-deployer-openshift@v3.0.1
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Database
         if: steps.triggers.outputs.core == 'true' || steps.triggers.outputs.sync == 'true'
-        uses: bcgov-nr/action-deployer-openshift@v3.0.0
+        uses: bcgov-nr/action-deployer-openshift@v3.0.1
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
@@ -140,7 +140,7 @@ jobs:
             verification_path: "actuator/health"
 
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v3.0.0
+      - uses: bcgov-nr/action-deployer-openshift@v3.0.1
         id: deploys
         with:
           file: ${{ matrix.file }}
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy (sync)
-        uses: bcgov-nr/action-deployer-openshift@v3.0.0
+        uses: bcgov-nr/action-deployer-openshift@v3.0.1
         with:
           file: sync/openshift.deploy.yml
           oc_namespace: ${{ vars.OC_NAMESPACE }}


### PR DESCRIPTION
# Description
Closes no issue.

This version bump may fix what's happening on this workflow:
Link: https://github.com/bcgov/nr-spar/actions/runs/11077437012

![image](https://github.com/user-attachments/assets/eaf7125a-820a-40ca-b2f2-9e66b64e9244)

```
/home/runner/work/_temp/02c06dd3-dea5-4825-980c-87e60b2586c2.sh: line 5: oc: command not found
Error: Process completed with exit code 127.
```

### Changelog
#### New
- action version

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
<img width="200" src="https://media3.giphy.com/media/urvsFBDfR6N32/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-2-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1652-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1652-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)