### PR TITLE
fix: handle possible null for the contaminantPollenBv recalculate but…

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/dto/PtValsCalReqDto.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/dto/PtValsCalReqDto.java
@@ -13,4 +13,4 @@ public record PtValsCalReqDto(
     @NotNull List<OrchardParentTreeValsDto> orchardPtVals,
     @NotNull List<GeospatialRequestDto> smpMixIdAndProps,
     @NotNull Integer smpParentsOutside,
-    @NotNull BigDecimal contaminantPollenBv) {}
+    BigDecimal contaminantPollenBv) {}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
@@ -203,7 +203,12 @@ public class ParentTreeService {
     Integer totalNonOrchardPollen = 0;
     Integer numNonOrchardPollen = 0;
 
-    SparLog.debug("ptVals.contaminantPollenBv(): {}", ptVals.contaminantPollenBv());
+    double contaminantPollenBvDouble = 0;
+    if (ValueUtil.hasValue(ptVals.contaminantPollenBv())) {
+      contaminantPollenBvDouble = ptVals.contaminantPollenBv().doubleValue();
+    }
+
+    SparLog.debug("contaminantPollenBvDouble: {}", contaminantPollenBvDouble);
 
     // --Third pass to calc values that depend on totals derived above and the remainder
     for (OrchardParentTreeValsDto parentTreeRow : ptVals.orchardPtVals()) {
@@ -257,7 +262,7 @@ public class ParentTreeService {
 
         // --col:AA
         double vmContamContrib =
-            (auxValueAa * ptVals.contaminantPollenBv().doubleValue()) * femaleCropPop.doubleValue();
+            (auxValueAa * contaminantPollenBvDouble) * femaleCropPop.doubleValue();
 
         // --col:AB (depends on SUM(X)=v_sum_m_gw_contrib_orch_poll)
         double auxValueAb =


### PR DESCRIPTION
# Description
Closes no issue;

### Changelog
#### Changed
- Parent Service class adding a null check for the contaminantPollenBv value;


### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-19-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1669-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1669-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)