### PR TITLE
chore(ci): split TEST and PROD ETL jobs

### DIFF
--- a/.github/workflows/etl-prod.yml
+++ b/.github/workflows/etl-prod.yml
@@ -1,0 +1,22 @@
+name: ETL PROD
+
+on:
+  schedule: [cron: "30 */2 * * *"] # Every other hour on the hour
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  etl-prod:
+    environment: prod
+    name: ETL (PROD)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+      - name: Run ./sync/oc_run.sh
+        run: ./sync/oc_run.sh prod ${{ secrets.oc_token }}

--- a/.github/workflows/etl-test.yml
+++ b/.github/workflows/etl-test.yml
@@ -1,4 +1,4 @@
-name: ETL Sync
+name: ETL TEST
 
 on:
   schedule: [cron: "0 */2 * * *"] # Every other hour on the hour
@@ -9,26 +9,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  sync-test:
+  etl-test:
     environment: test
-    name: Sync (TEST)
+    name: ETL (TEST)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4"
-      - name: ETL (TEST)
+      - name: Run ./sync/oc_run.sh
         run: ./sync/oc_run.sh test ${{ secrets.oc_token }}
-
-  sync-prod:
-    environment: prod
-    name: Sync (PROD)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4"
-      - name: ETL (PROD)
-        run: ./sync/oc_run.sh prod ${{ secrets.oc_token }}


### PR DESCRIPTION
# Description

### Changelog
#### New
- Separate TEST and PROD ETL sync jobs
- Two hour intervals, PROD 30 minutes after TEST

#### Removed
- Common TEST and PROD sync job

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/EwE4XIbH8Ug6WCedin/giphy-downsized-medium.gif"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-31-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1681-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1681-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)