### PR TITLE
fix: 1698 changing status when editing seedlot on review page

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpoint.java
@@ -4,7 +4,6 @@ import ca.bc.gov.backendstartapi.config.SparLog;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormSubmissionDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotStatusResponseDto;
 import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
-import ca.bc.gov.backendstartapi.exception.InvalidSeedlotStatusException;
 import ca.bc.gov.backendstartapi.response.DefaultSpringExceptionResponse;
 import ca.bc.gov.backendstartapi.response.ValidationExceptionResponse;
 import ca.bc.gov.backendstartapi.security.RoleAccessConfig;
@@ -193,10 +192,6 @@ public class TscAdminEndpoint {
       @RequestBody SeedlotFormSubmissionDto form) {
     long started = Instant.now().toEpochMilli();
     String formattedStatus = statusOnSave.toUpperCase();
-    if (!List.of("PND", "SUB", "APP").contains(formattedStatus)) {
-      throw new InvalidSeedlotStatusException(formattedStatus);
-    }
-
     SeedlotStatusResponseDto updatedDto =
         seedlotService.updateSeedlotWithForm(seedlotNumber, form, true, false, formattedStatus);
     long finished = Instant.now().toEpochMilli();

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/TscAdminEndpointTest.java
@@ -244,25 +244,4 @@ class TscAdminEndpointTest {
         .andExpect(status().isNotFound())
         .andReturn();
   }
-
-  @Test
-  @DisplayName("Edit seedlot should fail with invalid seedlot status.")
-  void editSeedlot_invalidStatus_shouldFail() throws Exception {
-    String seedlotNumber = "63999";
-    when(seedlotService.updateSeedlotWithForm(any(), any(), anyBoolean(), anyBoolean(), any()))
-        .thenThrow(new SeedlotNotFoundException());
-
-    mockMvc
-        .perform(
-            put(
-                    "/api/tsc-admin/seedlots/{seedlotNumber}/edit?statusOnSave={statusOnSave}",
-                    seedlotNumber,
-                    "EXP")
-                .with(csrf().asHeader())
-                .header("Content-Type", MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .content(WHOLE_SEEDLOT_FORM_JSON))
-        .andExpect(status().isBadRequest())
-        .andReturn();
-  }
 }

--- a/frontend/src/api-service/tscAdminAPI.ts
+++ b/frontend/src/api-service/tscAdminAPI.ts
@@ -1,4 +1,4 @@
-import { SeedlotsReturnType, TscSeedlotEditPayloadType } from '../types/SeedlotType';
+import { SeedlotsReturnType, SeedlotStatusCode, TscSeedlotEditPayloadType } from '../types/SeedlotType';
 import ApiConfig from './ApiConfig';
 import api from './api';
 
@@ -12,17 +12,15 @@ export const getSeedlotToReview = (pageNumber: number, pageSize: number) => {
   ));
 };
 
-export type StatusOnSaveType = 'PND' | 'SUB' | 'APP';
-
 export type PutTscSeedlotMutationObj = {
   seedlotNum: string,
-  statusOnSave: StatusOnSaveType,
+  statusOnSave: SeedlotStatusCode,
   payload: TscSeedlotEditPayloadType
 }
 
 export const putTscSeedlotWithStatus = (
   seedlotNumber: string,
-  statusOnSave: StatusOnSaveType,
+  statusOnSave: SeedlotStatusCode,
   payload: TscSeedlotEditPayloadType
 ) => {
   const url = new URL(ApiConfig.tscSeedlotEdit.replace('{seedlotNumber}', seedlotNumber));
@@ -34,7 +32,7 @@ export const putTscSeedlotWithStatus = (
 
 export const updateSeedlotStatus = (
   seedlotNumber: string,
-  statusOnSave: StatusOnSaveType
+  statusOnSave: SeedlotStatusCode
 ) => {
   const url = ApiConfig.tscSeedlotStatusUpdate.replace('{seedlotNumber}', seedlotNumber).replace('{status}', statusOnSave);
 

--- a/frontend/src/views/Seedlot/SeedlotDetails/index.tsx
+++ b/frontend/src/views/Seedlot/SeedlotDetails/index.tsx
@@ -14,7 +14,9 @@ import {
 
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { SeedlotApplicantType, SeedlotDisplayType, SeedlotType } from '../../../types/SeedlotType';
+import {
+  SeedlotApplicantType, SeedlotDisplayType, SeedlotStatusCode, SeedlotType
+} from '../../../types/SeedlotType';
 
 import PageTitle from '../../../components/PageTitle';
 import ComboButton from '../../../components/ComboButton';
@@ -30,7 +32,6 @@ import { addParamToPath } from '../../../utils/PathUtils';
 import { MEDIUM_SCREEN_WIDTH, MINISTRY_OF_FOREST_ID } from '../../../shared-constants/shared-constants';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import { getMultiOptList } from '../../../utils/MultiOptionsUtils';
-import { StatusOnSaveType } from '../../../api-service/tscAdminAPI';
 import AuthContext from '../../../contexts/AuthContext';
 
 import SeedlotSummary from './SeedlotSummary';
@@ -51,7 +52,7 @@ const SeedlotDetails = () => {
 
   const isSubmitSuccess = searchParams.get('isSubmitSuccess') === 'true';
 
-  const statusOnSave = searchParams.get('statusOnSave') as StatusOnSaveType | null;
+  const statusOnSave = searchParams.get('statusOnSave') as SeedlotStatusCode | null;
 
   const viewOnlySeedlot: boolean = seedlotData?.seedlotStatus === 'Submitted'
     || seedlotData?.seedlotStatus === 'Expired'

--- a/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
+++ b/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
@@ -40,12 +40,12 @@ import ExtractionStorageReviewEdit from '../../../components/SeedlotReviewSteps/
 import AuditInfo from '../../../components/SeedlotReviewSteps/AuditInfo';
 
 import {
-  PutTscSeedlotMutationObj, StatusOnSaveType, putTscSeedlotWithStatus,
+  PutTscSeedlotMutationObj, putTscSeedlotWithStatus,
   updateSeedlotStatus
 } from '../../../api-service/tscAdminAPI';
 import {
   SeedPlanZoneDto, SeedlotReviewElevationLatLongDto,
-  SeedlotReviewGeoInformationDto, TscSeedlotEditPayloadType
+  SeedlotReviewGeoInformationDto, SeedlotStatusCode, TscSeedlotEditPayloadType
 } from '../../../types/SeedlotType';
 import { ErrToastOption } from '../../../config/ToastifyConfig';
 import AuthContext from '../../../contexts/AuthContext';
@@ -85,7 +85,7 @@ const SeedlotReviewContent = () => {
    */
   const [isSaveStatusModalOpen, setIsSaveStatusModalOpen] = useState(false);
 
-  const [statusToUpdateTo, setStatusToUpdateTo] = useState<StatusOnSaveType>('PND');
+  const [statusToUpdateTo, setStatusToUpdateTo] = useState<SeedlotStatusCode>('PND');
 
   const { seedlotNumber } = useParams();
 
@@ -462,7 +462,11 @@ const SeedlotReviewContent = () => {
 
     if (isFormDataValid) {
       const payload = generatePayload();
-      updateDraftMutation.mutate({ seedlotNum: seedlotNumber!, statusOnSave: 'SUB', payload });
+      updateDraftMutation.mutate({
+        seedlotNum: seedlotNumber!,
+        statusOnSave: seedlotData?.seedlotStatus.seedlotStatusCode ?? 'SUB',
+        payload
+      });
       setIsReadMode(!isReadMode);
     }
   };
@@ -470,7 +474,7 @@ const SeedlotReviewContent = () => {
   /**
    * The handler for the send back to pending or approve buttons.
    */
-  const handleSaveAndStatus = (statusOnSave: StatusOnSaveType) => {
+  const handleSaveAndStatus = (statusOnSave: SeedlotStatusCode) => {
     if (isReadMode) {
       statusOnlyMutation.mutate({ seedlotNum: seedlotNumber!, statusOnSave });
     } else {
@@ -498,7 +502,7 @@ const SeedlotReviewContent = () => {
     setIsSaveStatusModalOpen(false);
   };
 
-  const openSaveStatusModal = (status: StatusOnSaveType) => {
+  const openSaveStatusModal = (status: SeedlotStatusCode) => {
     setStatusToUpdateTo(status);
     setIsSaveStatusModalOpen(true);
   };


### PR DESCRIPTION
# Description
Closes #1698

### Changelog
#### New
- Nothing :)

#### Changed
- Nothing :)

#### Removed
- Removed truncated status

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img width="150" src="https://media2.giphy.com/media/ejQyE9Jg7Mhu8OGlV9/giphy.gif"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-49-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1699-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1699-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)