### PR TITLE
feat: 1694 lock ownership to read only

### DIFF
--- a/frontend/src/api-service/ApiConfig.ts
+++ b/frontend/src/api-service/ApiConfig.ts
@@ -57,7 +57,7 @@ const ApiConfig = {
 
   parentTreeByVegCode: `${oracleServerHost}/api/parent-trees/vegetation-codes/{vegCode}`,
 
-  seedlotBySeedlotNumber: `${oracleServerHost}/api/seedlot/{seedlotNumber}`
+  seedlotFromOracleDbBySeedlotNumber: `${oracleServerHost}/api/seedlot/{seedlotNumber}`
 };
 
 export default ApiConfig;

--- a/frontend/src/api-service/ApiConfig.ts
+++ b/frontend/src/api-service/ApiConfig.ts
@@ -55,7 +55,9 @@ const ApiConfig = {
 
   areaOfUseSpzList: `${oracleServerHost}/api/area-of-use/spz-list/vegetation-code`,
 
-  parentTreeByVegCode: `${oracleServerHost}/api/parent-trees/vegetation-codes/{vegCode}`
+  parentTreeByVegCode: `${oracleServerHost}/api/parent-trees/vegetation-codes/{vegCode}`,
+
+  seedlotBySeedlotNumber: `${oracleServerHost}/api/seedlot/{seedlotNumber}`
 };
 
 export default ApiConfig;

--- a/frontend/src/api-service/seedlotAPI.ts
+++ b/frontend/src/api-service/seedlotAPI.ts
@@ -72,3 +72,8 @@ export const getAClassSeedlotFullForm = (seedlotNumber: string) => {
   const url = `${ApiConfig.seedlots}/${seedlotNumber}/a-class-full-form`;
   return api.get(url).then((res) => res.data as SeedlotAClassFullResponseType);
 };
+
+export const getSeedlotBySeedlotNumber = (seedlotNumber: string) => {
+  const url = ApiConfig.seedlotBySeedlotNumber.replace('{seedlotNumber}', seedlotNumber);
+  return api.get(url);
+};

--- a/frontend/src/api-service/seedlotAPI.ts
+++ b/frontend/src/api-service/seedlotAPI.ts
@@ -73,7 +73,7 @@ export const getAClassSeedlotFullForm = (seedlotNumber: string) => {
   return api.get(url).then((res) => res.data as SeedlotAClassFullResponseType);
 };
 
-export const getSeedlotBySeedlotNumber = (seedlotNumber: string) => {
-  const url = ApiConfig.seedlotBySeedlotNumber.replace('{seedlotNumber}', seedlotNumber);
+export const getSeedlotFromOracleDbBySeedlotNumber = (seedlotNumber: string) => {
+  const url = ApiConfig.seedlotFromOracleDbBySeedlotNumber.replace('{seedlotNumber}', seedlotNumber);
   return api.get(url);
 };

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
@@ -18,6 +18,7 @@ import { EmptyMultiOptObj } from '../../../shared-constants/shared-constants';
 import { THREE_HALF_HOURS, THREE_HOURS } from '../../../config/TimeUnits';
 import { getMultiOptList } from '../../../utils/MultiOptionsUtils';
 import getFundingSources from '../../../api-service/fundingSourcesAPI';
+import { getSeedlotBySeedlotNumber } from '../../../api-service/seedlotAPI';
 import TitleAccordion from '../../TitleAccordion';
 import ScrollToTop from '../../ScrollToTop';
 import SingleOwnerInfo from './SingleOwnerInfo';
@@ -53,7 +54,8 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
     setStepData,
     defaultClientNumber: defaultAgency,
     defaultCode,
-    isFormSubmitted
+    isFormSubmitted,
+    seedlotNumber
   } = useContext(ClassAContext);
 
   const [accordionControls, setAccordionControls] = useState<AccordionCtrlObj>({});
@@ -107,6 +109,12 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
     cacheTime: THREE_HALF_HOURS
   });
 
+  const getSeedlotBySeedlotNumberQuery = useQuery(
+    ['get-seedlot-by-seedlotNumber', seedlotNumber],
+    () => getSeedlotBySeedlotNumber(seedlotNumber ?? ''),
+    { enabled: !!seedlotNumber }
+  );
+
   // Set default method of payment for the first owner.
   useEffect(() => {
     if (methodsOfPaymentQuery.status === 'success') {
@@ -142,6 +150,9 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
   });
 
   const getFcQuery = (clientNumber: string): ForestClientType | undefined => qc.getQueryData(['forest-clients', clientNumber]);
+
+  const originalSeedQty = getSeedlotBySeedlotNumberQuery.data?.data?.originalSeedQty ?? 0;
+  const readOnly = originalSeedQty > 0;
 
   return (
     <div>
@@ -209,7 +220,7 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
                   checkPortionSum={
                     (updtEntry: SingleOwnerForm, id: number) => checkPortionSum(updtEntry, id)
                   }
-                  readOnly={isFormSubmitted}
+                  readOnly={isFormSubmitted || readOnly}
                   isReview={isReview}
                 />
               </AccordionItem>

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
@@ -18,7 +18,7 @@ import { EmptyMultiOptObj } from '../../../shared-constants/shared-constants';
 import { THREE_HALF_HOURS, THREE_HOURS } from '../../../config/TimeUnits';
 import { getMultiOptList } from '../../../utils/MultiOptionsUtils';
 import getFundingSources from '../../../api-service/fundingSourcesAPI';
-import { getSeedlotBySeedlotNumber } from '../../../api-service/seedlotAPI';
+import { getSeedlotFromOracleDbBySeedlotNumber } from '../../../api-service/seedlotAPI';
 import TitleAccordion from '../../TitleAccordion';
 import ScrollToTop from '../../ScrollToTop';
 import SingleOwnerInfo from './SingleOwnerInfo';
@@ -111,7 +111,7 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
 
   const getSeedlotBySeedlotNumberQuery = useQuery(
     ['get-seedlot-by-seedlotNumber', seedlotNumber],
-    () => getSeedlotBySeedlotNumber(seedlotNumber ?? ''),
+    () => getSeedlotFromOracleDbBySeedlotNumber(seedlotNumber ?? ''),
     { enabled: !!seedlotNumber }
   );
 

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
@@ -152,7 +152,6 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
   const getFcQuery = (clientNumber: string): ForestClientType | undefined => qc.getQueryData(['forest-clients', clientNumber]);
 
   const originalSeedQty = getSeedlotBySeedlotNumberQuery.data?.data?.originalSeedQty ?? 0;
-  const readOnly = originalSeedQty > 0;
 
   return (
     <div>
@@ -220,7 +219,7 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
                   checkPortionSum={
                     (updtEntry: SingleOwnerForm, id: number) => checkPortionSum(updtEntry, id)
                   }
-                  readOnly={isFormSubmitted || readOnly}
+                  readOnly={isFormSubmitted || originalSeedQty > 0}
                   isReview={isReview}
                 />
               </AccordionItem>

--- a/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
+++ b/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
@@ -13,7 +13,7 @@ import {
 } from '@carbon/icons-react';
 import { Beforeunload } from 'react-beforeunload';
 
-import { getSeedlotById, putAClassSeedlotProgress } from '../../../api-service/seedlotAPI';
+import { getSeedlotById, putAClassSeedlotProgress, getSeedlotBySeedlotNumber } from '../../../api-service/seedlotAPI';
 import { THREE_HALF_HOURS, THREE_HOURS } from '../../../config/TimeUnits';
 import getVegCodes from '../../../api-service/vegetationCodeAPI';
 import Breadcrumbs from '../../../components/Breadcrumbs';
@@ -103,6 +103,12 @@ const SeedlotReviewContent = () => {
     queryFn: () => getSeedlotById(seedlotNumber ?? ''),
     enabled: vegCodeQuery.isFetched,
     refetchOnMount: true
+  });
+
+  const getSeedlotBySeedlotNumberQuery = useQuery({
+    queryKey: ['seedlot-by-seedlotNumber', seedlotNumber],
+    queryFn: () => getSeedlotBySeedlotNumber(seedlotNumber ?? ''),
+    enabled: seedlotQuery.isFetched
   });
 
   useEffect(() => {
@@ -550,6 +556,8 @@ const SeedlotReviewContent = () => {
               className="edit-save-btn"
               renderIcon={isReadMode ? Edit : Save}
               onClick={handleEditSaveBtn}
+              disabled={getSeedlotBySeedlotNumberQuery.isSuccess
+                && getSeedlotBySeedlotNumberQuery.data.data.originalSeedQty > 0}
             >
               {isReadMode ? 'Edit seedlot' : 'Save edit'}
             </Button>

--- a/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
+++ b/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
@@ -13,7 +13,7 @@ import {
 } from '@carbon/icons-react';
 import { Beforeunload } from 'react-beforeunload';
 
-import { getSeedlotById, putAClassSeedlotProgress, getSeedlotBySeedlotNumber } from '../../../api-service/seedlotAPI';
+import { getSeedlotById, putAClassSeedlotProgress, getSeedlotFromOracleDbBySeedlotNumber } from '../../../api-service/seedlotAPI';
 import { THREE_HALF_HOURS, THREE_HOURS } from '../../../config/TimeUnits';
 import getVegCodes from '../../../api-service/vegetationCodeAPI';
 import Breadcrumbs from '../../../components/Breadcrumbs';
@@ -107,7 +107,7 @@ const SeedlotReviewContent = () => {
 
   const getSeedlotBySeedlotNumberQuery = useQuery({
     queryKey: ['seedlot-by-seedlotNumber', seedlotNumber],
-    queryFn: () => getSeedlotBySeedlotNumber(seedlotNumber ?? ''),
+    queryFn: () => getSeedlotFromOracleDbBySeedlotNumber(seedlotNumber ?? ''),
     enabled: seedlotQuery.isFetched
   });
 

--- a/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
+++ b/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
@@ -556,6 +556,8 @@ const SeedlotReviewContent = () => {
         className="edit-save-btn"
         renderIcon={isReadMode ? Edit : Save}
         onClick={handleEditSaveBtn}
+        disabled={getSeedlotBySeedlotNumberQuery.isSuccess
+                && getSeedlotBySeedlotNumberQuery.data.data.originalSeedQty > 0}
       >
         {isReadMode ? 'Edit seedlot' : 'Save edit'}
       </Button>

--- a/oracle-api/config/application-local.yml
+++ b/oracle-api/config/application-local.yml
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    url: jdbc:oracle:thin:@tcp://localhost:1521/dbdock_01
+    username: THE
+    password: default
+
+    

--- a/oracle-api/config/application-local.yml
+++ b/oracle-api/config/application-local.yml
@@ -3,5 +3,3 @@ spring:
     url: jdbc:oracle:thin:@tcp://localhost:1521/dbdock_01
     username: THE
     password: default
-
-    

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/SeedlotEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/SeedlotEndpoint.java
@@ -1,0 +1,61 @@
+package ca.bc.gov.oracleapi.endpoint;
+
+import ca.bc.gov.oracleapi.config.SparLog;
+import ca.bc.gov.oracleapi.entity.Seedlot;
+import ca.bc.gov.oracleapi.repository.SeedlotRepository;
+import ca.bc.gov.oracleapi.security.RoleAccessConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This class exposes seedlot resources API. */
+@RestController
+@RequestMapping("/api/seedlot")
+@Tag(name = "seedlot", description = "Resource to retrieve seedlot")
+public class SeedlotEndpoint {
+
+  private SeedlotRepository seedlotRepository;
+
+  SeedlotEndpoint(SeedlotRepository seedlotRepository) {
+    this.seedlotRepository = seedlotRepository;
+  }
+
+  /**
+   * Retrieve a seedlot by seedlot number.
+   *
+   * @return A record of {@link Seedlot}.
+   */
+  @GetMapping(produces = "application/json")
+  @Operation(
+      summary = "Retrieve a seedlot by seedlot number",
+      description = "Retrieve a seedlot by seedlot number ")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Returns a record of seedlot",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = Seedlot.class))),
+        @ApiResponse(
+            responseCode = "401",
+            description = "Access token is missing or invalid",
+            content = @Content(schema = @Schema(implementation = Void.class)))
+      })
+  @RoleAccessConfig({"SPAR_TSC_ADMIN", "SPAR_MINISTRY_ORCHARD", "SPAR_NONMINISTRY_ORCHARD"})
+  public Seedlot getSeedlotBySeedlotNumber(Long seedlotNumber) {
+    SparLog.info("Fetch a seedlot by seedlot number");
+
+    Seedlot seedlot = seedlotRepository.findSeedlotBySeedlotNumber(seedlotNumber);
+    SparLog.info("{} valid seedlot found.", seedlot);
+
+    return seedlot;
+  }
+}

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/SeedlotEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/SeedlotEndpoint.java
@@ -5,12 +5,15 @@ import ca.bc.gov.oracleapi.entity.Seedlot;
 import ca.bc.gov.oracleapi.repository.SeedlotRepository;
 import ca.bc.gov.oracleapi.security.RoleAccessConfig;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,7 +34,9 @@ public class SeedlotEndpoint {
    *
    * @return A record of {@link Seedlot}.
    */
-  @GetMapping(produces = "application/json")
+  @GetMapping(
+      path = "/{seedlotNumber}",
+      produces = "application/json")
   @Operation(
       summary = "Retrieve a seedlot by seedlot number",
       description = "Retrieve a seedlot by seedlot number ")
@@ -50,9 +55,16 @@ public class SeedlotEndpoint {
             content = @Content(schema = @Schema(implementation = Void.class)))
       })
   @RoleAccessConfig({"SPAR_TSC_ADMIN", "SPAR_MINISTRY_ORCHARD", "SPAR_NONMINISTRY_ORCHARD"})
-  public Seedlot getSeedlotBySeedlotNumber(Long seedlotNumber) {
+  public Seedlot getSeedlotBySeedlotNumber(
+          @PathVariable
+          @Parameter(
+              name = "seedlotNumber",
+              in = ParameterIn.PATH,
+              description = "Identifier of the seedlot.")
+              String seedlotNumber
+  ) {
     SparLog.info("Fetch a seedlot by seedlot number");
-
+    SparLog.info(seedlotNumber);
     Seedlot seedlot = seedlotRepository.findSeedlotBySeedlotNumber(seedlotNumber);
     SparLog.info("{} valid seedlot found.", seedlot);
 

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/entity/Seedlot.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/entity/Seedlot.java
@@ -1,0 +1,29 @@
+package ca.bc.gov.oracleapi.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+/** This class presents a funding source to an agency seedlot owner. */
+@Getter
+@Setter
+@Entity
+@Table(name = "SEEDLOT")
+@Schema(description = "Represents a partial seedlot object in the database")
+public class Seedlot {
+
+  @Id
+  @Column(name = "SEEDLOT_NUMBER")
+  @Schema(description = "The number of a seedlot", example = "16258")
+  private String seedlotNumber;
+
+  @Column(name = "ORIGINAL_SEED_QTY")
+  @Schema(
+      description = "The original quantity of seeds in the seedlot",
+      example = "1")
+  private String originalSeedQty;
+}

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/entity/Seedlot.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/entity/Seedlot.java
@@ -19,11 +19,11 @@ public class Seedlot {
   @Id
   @Column(name = "SEEDLOT_NUMBER")
   @Schema(description = "The number of a seedlot", example = "16258")
-  private String seedlotNumber;
+  private Long seedlotNumber;
 
   @Column(name = "ORIGINAL_SEED_QTY")
   @Schema(
       description = "The original quantity of seeds in the seedlot",
       example = "1")
-  private String originalSeedQty;
+  private Long originalSeedQty;
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/SeedlotRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/SeedlotRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 /** This interface enables the funding source entity to be retrieved from the database. */
 public interface SeedlotRepository extends JpaRepository<Seedlot, String> {
 
-  @Query("SELECT s.ORIGINAL_SEED_QTY FROM SEEDLOT s WHERE s.SEEDLOT_NUMBER = :seedlotNumber")
-  Seedlot findSeedlotBySeedlotNumber(@Param("seedlotNumber") Long seedlotNumber);
+  @Query("SELECT s FROM Seedlot s WHERE s.seedlotNumber = :seedlotNumber")
+  Seedlot findSeedlotBySeedlotNumber(@Param("seedlotNumber") String seedlotNumber);
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/SeedlotRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/SeedlotRepository.java
@@ -1,0 +1,13 @@
+package ca.bc.gov.oracleapi.repository;
+
+import ca.bc.gov.oracleapi.entity.Seedlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** This interface enables the funding source entity to be retrieved from the database. */
+public interface SeedlotRepository extends JpaRepository<Seedlot, String> {
+
+  @Query("SELECT s.ORIGINAL_SEED_QTY FROM SEEDLOT s WHERE s.SEEDLOT_NUMBER = :seedlotNumber")
+  Seedlot findSeedlotBySeedlotNumber(@Param("seedlotNumber") Long seedlotNumber);
+}


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve seedlot information by seedlot number and integrates this functionality into the frontend. The changes include updates to the API configuration, addition of a new endpoint in the backend, and modifications to the frontend components to utilize this new endpoint.

New
- lock ownership to read only when original qty is over 0
- added new endpoint on oracle db to expose original qty from seedlot table

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

<img src="https://media3.giphy.com/media/CmQbcGL2arIyDMADXv/giphy.gif"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-12-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1712-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1712-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)