### PR TITLE
Feat/1693 trigger to prevent over write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,5 @@ schemaspy/output
 
 # local testing
 *.bat
+
+oracle-api/config

--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -328,6 +328,7 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
 
                     original_seed_qty_query = "SELECT ORIGINAL_SEED_QTY FROM the.seedlot WHERE seedlot_number = :seedlot_number"
                     original_seed_qty = target_db_conn.execute(original_seed_qty_query, {"seedlot_number": seedlot.seedlot_number}).fetchone()
+                    logger.debug(f"12344321!!! Original Seed Quantity for {seedlot.seedlot_number} is {original_seed_qty}")
 
                     if original_seed_qty and original_seed_qty[0] == 0:
                         processes.append([{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}])

--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -318,6 +318,8 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
                     ,[{"interface_id":"SMP_MIX_EXTRACT","execution_id":"108","execution_order":"80","source_file":"/SQL/SPAR/POSTGRES_SMP_MIX_EXTRACT.sql","source_table":"spar.smp_mix","source_db_type":"POSTGRES","target_table":"the.smp_mix","target_primary_key":"seedlot_number,parent_tree_id","target_db_type":"ORACLE","run_mode":"UPSERT_WITH_DELETE","ignore_columns_on_update":""}]
                     ,[{"interface_id":"SMP_MIX_GEN_QLTY_EXTRACT","execution_id":"109","execution_order":"90","source_file":"/SQL/SPAR/POSTGRES_SMP_MIX_GEN_QLTY_EXTRACT.sql","source_table":"spar.smp_mix_gen_qlty","source_db_type":"POSTGRES","target_table":"the.smp_mix_gen_qlty","target_primary_key":"seedlot_number,parent_tree_id,genetic_type_code,genetic_worth_code","target_db_type":"ORACLE","run_mode":"UPSERT_WITH_DELETE","ignore_columns_on_update":""}]
                     ]
+        logger.debug(f"23333333 Seedlots to process")
+
         with db_conn.database_connection(oracle_config) as target_db_conn:
             try:
                 seedlotlst = []

--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -1,4 +1,4 @@
- import time
+import time
 import logging
 import numpy as np
 import pandas as pd
@@ -286,8 +286,6 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
         metrics['start_time'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
 
         logger.debug('Source Database connection established')
-        logger.debug('23333333 Seedlots to process')
-
 
         query_sql = """SELECT s.seedlot_number 
                          FROM spar.seedlot s
@@ -330,15 +328,13 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
                     seedlot_metrics['seedlot_number'] = seedlot.seedlot_number
 
                     original_seed_qty_query = "SELECT ORIGINAL_SEED_QTY FROM the.seedlot WHERE seedlot_number = :seedlot_number"
-                    result = target_db_conn.execute(original_seed_qty_query, {"seedlot_number": seedlot.seedlot_number})
-                    if result is None:
-                        logger.warning(f"No result returned for seedlot {seedlot.seedlot_number}. Skipping processing for this seedlot.")
-                        continue 
+                    result = target_db_conn.execute(original_seed_qty_query, params={"seedlot_number": seedlot.seedlot_number})
 
-                    original_seed_qty = result.fetchone()
-                    logger.debug(f"12344321!!! Original Seed Quantity for {seedlot.seedlot_number} is {original_seed_qty}")
-                    if original_seed_qty and original_seed_qty[0] == 0:
-                        processes.append([{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}])
+                    if result is not None:
+                        original_seed_qty = result.fetchone()
+                        if original_seed_qty and original_seed_qty[0] == 0:
+                            processes.append([{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}])
+
                     #delete all tables in RI order (reversing order of processes dataframe)
                     #note - special handling for seedlot_owner_quantity
                     delete_metrics = delete_seedlot_child_tables(seedlot_number=seedlot.seedlot_number,

--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -1,4 +1,4 @@
-import time
+ import time
 import logging
 import numpy as np
 import pandas as pd
@@ -310,7 +310,6 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
         logger.debug('Main driver SEEDLOT data loaded on in-memory dataframe')
         
         processes = [[{"interface_id":"SEEDLOT_EXTRACT","execution_id":"101","execution_order":"10","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_EXTRACT.sql","source_table":"spar.seedlot","source_db_type":"POSTGRES","target_table":"the.seedlot","target_primary_key":"seedlot_number","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"extraction_st_date,extraction_end_date,seed_store_client_number,seed_store_client_locn,temporary_storage_start_date,temporary_storage_end_date,seedlot_status_code"}]
-                    ,[{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}]
                     ,[{"interface_id":"SEEDLOT_SEED_PLAN_ZONE_EXTRACT","execution_id":"103","execution_order":"30","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_SEED_PLAN_ZONE_EXTRACT.sql","source_table":"spar.seedlot_seed_plan_zone","source_db_type":"POSTGRES","target_table":"the.seedlot_plan_zone","target_primary_key":"seedlot_number,seed_plan_zone_code","target_db_type":"ORACLE","run_mode":"UPSERT_WITH_DELETE","ignore_columns_on_update":""}]
                     ,[{"interface_id":"SEEDLOT_GENETIC_WORTH_EXTRACT","execution_id":"104","execution_order":"40","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_GENETIC_WORTH_EXTRACT.sql","source_table":"spar.seedlot_genetic_worth","source_db_type":"POSTGRES","target_table":"the.seedlot_genetic_worth","target_primary_key":"seedlot_number,genetic_worth_code","target_db_type":"ORACLE","run_mode":"UPSERT_WITH_DELETE","ignore_columns_on_update":""}]
                     ,[{"interface_id":"SEEDLOT_PARENT_TREE_EXTRACT","execution_id":"105","execution_order":"50","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_PARENT_TREE_EXTRACT.sql","source_table":"spar.seedlot_parent_tree","source_db_type":"POSTGRES","target_table":"the.seedlot_parent_tree","target_primary_key":"seedlot_number,parent_tree_id","target_db_type":"ORACLE","run_mode":"UPSERT_WITH_DELETE","ignore_columns_on_update":""}]
@@ -327,6 +326,11 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
                     seedlot_metrics['step'] = "Seedlot"
                     seedlot_metrics['seedlot_number'] = seedlot.seedlot_number
 
+                    original_seed_qty_query = "SELECT ORIGINAL_SEED_QTY FROM the.seedlot WHERE seedlot_number = :seedlot_number"
+                    original_seed_qty = target_db_conn.execute(original_seed_qty_query, {"seedlot_number": seedlot.seedlot_number}).fetchone()
+
+                    if original_seed_qty and original_seed_qty[0] == 0:
+                        processes.append([{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}])
                     #delete all tables in RI order (reversing order of processes dataframe)
                     #note - special handling for seedlot_owner_quantity
                     delete_metrics = delete_seedlot_child_tables(seedlot_number=seedlot.seedlot_number,

--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -286,6 +286,8 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
         metrics['start_time'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
 
         logger.debug('Source Database connection established')
+        logger.debug('23333333 Seedlots to process')
+
 
         query_sql = """SELECT s.seedlot_number 
                          FROM spar.seedlot s
@@ -318,7 +320,6 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
                     ,[{"interface_id":"SMP_MIX_EXTRACT","execution_id":"108","execution_order":"80","source_file":"/SQL/SPAR/POSTGRES_SMP_MIX_EXTRACT.sql","source_table":"spar.smp_mix","source_db_type":"POSTGRES","target_table":"the.smp_mix","target_primary_key":"seedlot_number,parent_tree_id","target_db_type":"ORACLE","run_mode":"UPSERT_WITH_DELETE","ignore_columns_on_update":""}]
                     ,[{"interface_id":"SMP_MIX_GEN_QLTY_EXTRACT","execution_id":"109","execution_order":"90","source_file":"/SQL/SPAR/POSTGRES_SMP_MIX_GEN_QLTY_EXTRACT.sql","source_table":"spar.smp_mix_gen_qlty","source_db_type":"POSTGRES","target_table":"the.smp_mix_gen_qlty","target_primary_key":"seedlot_number,parent_tree_id,genetic_type_code,genetic_worth_code","target_db_type":"ORACLE","run_mode":"UPSERT_WITH_DELETE","ignore_columns_on_update":""}]
                     ]
-        logger.debug(f"23333333 Seedlots to process")
 
         with db_conn.database_connection(oracle_config) as target_db_conn:
             try:

--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -330,9 +330,13 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
                     seedlot_metrics['seedlot_number'] = seedlot.seedlot_number
 
                     original_seed_qty_query = "SELECT ORIGINAL_SEED_QTY FROM the.seedlot WHERE seedlot_number = :seedlot_number"
-                    original_seed_qty = target_db_conn.execute(original_seed_qty_query, {"seedlot_number": seedlot.seedlot_number}).fetchone()
-                    logger.debug(f"12344321!!! Original Seed Quantity for {seedlot.seedlot_number} is {original_seed_qty}")
+                    result = target_db_conn.execute(original_seed_qty_query, {"seedlot_number": seedlot.seedlot_number})
+                    if result is None:
+                        logger.warning(f"No result returned for seedlot {seedlot.seedlot_number}. Skipping processing for this seedlot.")
+                        continue 
 
+                    original_seed_qty = result.fetchone()
+                    logger.debug(f"12344321!!! Original Seed Quantity for {seedlot.seedlot_number} is {original_seed_qty}")
                     if original_seed_qty and original_seed_qty[0] == 0:
                         processes.append([{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}])
                     #delete all tables in RI order (reversing order of processes dataframe)


### PR DESCRIPTION
# Description
Closes #1693 

### Changelog

#### Changed
- if the ORIGINAL_SEED_QTY is larger than 0, we won't push SEEDLOT_OWNER_QUANTITY_EXTRACT into the pipeline



### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


