### PR TITLE
fix: return db excuction result

### DIFF
--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -332,7 +332,7 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
 
                     if result is not None:
                         original_seed_qty = result.fetchone()
-                        if original_seed_qty and original_seed_qty[0] in (0, None):
+                        if original_seed_qty and not original_seed_qty[0]:
                             processes.append([{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}])
 
                     #delete all tables in RI order (reversing order of processes dataframe)

--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -332,7 +332,7 @@ def process_seedlots(oracle_config, postgres_config, track_config, track_db_conn
 
                     if result is not None:
                         original_seed_qty = result.fetchone()
-                        if original_seed_qty and original_seed_qty[0] == 0:
+                        if original_seed_qty and original_seed_qty[0] in (0, None):
                             processes.append([{"interface_id":"SEEDLOT_OWNER_QUANTITY_EXTRACT","execution_id":"102","execution_order":"20","source_file":"/SQL/SPAR/POSTGRES_SEEDLOT_OWNER_QUANTITY_EXTRACT.sql","source_table":"spar.seedlot_owner_quantity","source_db_type":"POSTGRES","target_table":"the.seedlot_owner_quantity","target_primary_key":"seedlot_number,client_number,client_locn_code","target_db_type":"ORACLE","run_mode":"UPSERT","ignore_columns_on_update":"qty_reserved,qty_rsrvd_cmtd_pln,qty_rsrvd_cmtd_apr,qty_surplus,qty_srpls_cmtd_pln,qty_srpls_cmtd_apr"}])
 
                     #delete all tables in RI order (reversing order of processes dataframe)

--- a/sync/src/module/database_connection.py
+++ b/sync/src/module/database_connection.py
@@ -35,11 +35,12 @@ class database_connection(object):
     
     def execute(self, query, params):
         """ Runs a SQL statement. """
-        self.conn.execute(text(query), params)
+        result = self.conn.execute(text(query), params or {})
+        return result
         
     def select(self, query, params=None):
         """ Runs a SQL statement. """
-        result = self.conn.execute(text(query), params)
+        result = self.conn.execute(text(query), params or {})
         return result
         
     def health_check(self) -> bool:


### PR DESCRIPTION


### Changelog


#### Changed
- return db excution result
- adjust ownership logic


### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-18-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1718-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1718-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)