### PR TITLE
fix: 1628 adjustments to show hide feature step 5

### DIFF
--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -225,6 +225,7 @@ export const geneticWorthDict: GeneticWorthDictType = {
   PY: ['gvo'],
   SS: ['gvo', 'iws'],
   SX: ['gvo', 'iws'],
+  YC: ['gvo'],
   UNKNOWN: ['gvo']
 };
 

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/constants.tsx
@@ -219,7 +219,7 @@ export const geneticWorthDict: GeneticWorthDictType = {
   PW: ['dsb'],
   DR: ['gvo'],
   EP: ['gvo'],
-  FDI: ['gvo'],
+  FDI: ['gvo', 'wwd'],
   HW: ['gvo'],
   LW: ['gvo'],
   PY: ['gvo'],

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/definitions.ts
@@ -82,7 +82,21 @@ export type NotifCtrlType = {
   }
 }
 
-type SpeciesWithGenWorth = 'CW'| 'PLI' |'FDC' | 'PW' | 'DR' | 'EP' | 'FDI' | 'HW' | 'LW' | 'PY' | 'SS' | 'SX' | 'UNKNOWN';
+type SpeciesWithGenWorth =
+  'CW'
+  |'PLI'
+  |'FDC'
+  |'PW'
+  |'DR'
+  |'EP'
+  |'FDI'
+  |'HW'
+  |'LW'
+  |'PY'
+  |'SS'
+  |'SX'
+  |'YC'
+  |'UNKNOWN';
 
 export type GeneticWorthDictType = {
   [key in SpeciesWithGenWorth]: string[]

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -270,8 +270,7 @@ const ParentTreeStep = ({ isReviewDisplay, isReviewRead }: ParentTreeStepProps) 
     setHeaderConfig,
     weightedGwInfoItems,
     setWeightedGwInfoItems,
-    setApplicableGenWorths,
-    isReviewDisplay ?? false
+    setApplicableGenWorths
   ), [seedlotSpecies]);
 
   const uploadCompostion = useMutation({

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -545,8 +545,7 @@ export const configHeaderOpt = (
   setHeaderConfig: Function,
   weightedGwInfoItems: Record<keyof RowItem, InfoDisplayObj>,
   setWeightedGwInfoItems: Function,
-  setApplicableGenWorths: Function,
-  isReview: boolean
+  setApplicableGenWorths: Function
 ) => {
   const speciesKey = Object.keys(geneticWorthDict).includes(seedlotSpecies.code)
     ? seedlotSpecies.code.toUpperCase()

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/utils.ts
@@ -562,10 +562,8 @@ export const configHeaderOpt = (
     // Enable option in the column customization
     clonedHeaders[optionIndex].isAnOption = true;
 
-    // When on review mode, display all columns
-    if (isReview) {
-      clonedHeaders[optionIndex].enabled = true;
-    }
+    // Display all columns by default
+    clonedHeaders[optionIndex].enabled = true;
 
     // Enable weighted option in mix tab
     const weightedIndex = headerConfig.findIndex((header) => header.id === `w_${opt}`);


### PR DESCRIPTION
# Description
Closes #1628 

### Changelog
#### New
- Added new species to class A seedlots
- Added new GW value to FDI species

#### Changed
- Made all the GW columns appear on the step 5 table

#### Removed
- Nothing :)

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img width="200" src="https://media3.giphy.com/media/toXKzaJP3WIgM/giphy.gif"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-19-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1719-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1719-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)