### PR TITLE
fix: lock ownership section in review page

### DIFF
--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/SingleOwnerInfo/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/SingleOwnerInfo/index.tsx
@@ -35,12 +35,15 @@ interface SingleOwnerInfoProps {
   setState: Function,
   readOnly?: boolean,
   isReview?: boolean
+  isOwnershipStep?: boolean
 }
 
 const SingleOwnerInfo = ({
   ownerInfo, defaultAgency, defaultCode, fundingSourcesQuery,
-  methodsOfPaymentQuery, deleteAnOwner, checkPortionSum, setState, readOnly, isReview
+  methodsOfPaymentQuery, deleteAnOwner, checkPortionSum, setState,
+  readOnly, isReview, isOwnershipStep
 }: SingleOwnerInfoProps) => {
+  const isReadOnly = readOnly && (isOwnershipStep || !isReview);
   const [ownerPortionInvalidText, setOwnerPortionInvalidText] = useState<string>(
     inputText.portion.invalidText
   );
@@ -150,7 +153,7 @@ const SingleOwnerInfo = ({
                   locationCode: StringInputType
                 ) => setClientAndCode(client, locationCode)
               }
-              readOnly={readOnly && !isReview}
+              readOnly={isReadOnly}
             />
           </Column>
           <Column className={`single-owner-info-col ${colsClass}`} xs={4} sm={4} md={4} lg={4}>
@@ -168,7 +171,7 @@ const SingleOwnerInfo = ({
               }}
               invalid={ownerInfo.ownerPortion.isInvalid}
               invalidText={ownerPortionInvalidText}
-              readOnly={readOnly && !isReview}
+              readOnly={isReadOnly}
             />
           </Column>
           <Column className={`single-owner-info-col ${colsClass}`} xs={4} sm={4} md={4} lg={4}>
@@ -188,7 +191,7 @@ const SingleOwnerInfo = ({
                   onWheel={(e: React.ChangeEvent<HTMLInputElement>) => e.target.blur()}
                   invalid={ownerInfo.reservedPerc.isInvalid}
                   invalidText={reservedInvalidText}
-                  readOnly={readOnly && !isReview}
+                  readOnly={isReadOnly}
                 />
               </div>
               <div className="reserved-surplus-input">
@@ -206,7 +209,7 @@ const SingleOwnerInfo = ({
                   onWheel={(e: React.ChangeEvent<HTMLInputElement>) => e.target.blur()}
                   invalid={ownerInfo.surplusPerc.isInvalid}
                   invalidText={surplusInvalidText}
-                  readOnly={readOnly && !isReview}
+                  readOnly={isReadOnly}
                 />
               </div>
             </div>
@@ -233,7 +236,7 @@ const SingleOwnerInfo = ({
                     onChange={(e: ComboBoxEvent) => handleFundingSource(e.selectedItem)}
                     invalid={ownerInfo.fundingSource.isInvalid}
                     invalidText={inputText.funding.invalidText}
-                    readOnly={readOnly && !isReview}
+                    readOnly={isReadOnly}
                   />
                 )
             }
@@ -258,7 +261,7 @@ const SingleOwnerInfo = ({
                     onChange={(e: ComboBoxEvent) => handleMethodOfPayment(e.selectedItem)}
                     invalid={ownerInfo.methodOfPayment.isInvalid}
                     invalidText={inputText.payment.invalidText}
-                    readOnly={readOnly && !isReview}
+                    readOnly={isReadOnly}
                   />
 
                 )
@@ -276,6 +279,7 @@ const SingleOwnerInfo = ({
                     className="owner-mod-btn"
                     renderIcon={TrashCan}
                     onClick={() => deleteAnOwner(ownerInfo.id)}
+                    disabled={isReadOnly}
                   >
                     Delete owner
                   </Button>

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
@@ -221,6 +221,7 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
                   }
                   readOnly={isFormSubmitted || originalSeedQty > 0}
                   isReview={isReview}
+                  isOwnershipStep
                 />
               </AccordionItem>
             ))
@@ -235,6 +236,7 @@ const OwnershipStep = ({ isReview }: OwnershipStepProps) => {
                 className="owner-add-btn"
                 renderIcon={Add}
                 onClick={addAnOwner}
+                disabled={originalSeedQty > 0}
               >
                 Add owner
               </Button>

--- a/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
+++ b/frontend/src/views/Seedlot/SeedlotReview/SeedlotReviewContent.tsx
@@ -13,7 +13,7 @@ import {
 } from '@carbon/icons-react';
 import { Beforeunload } from 'react-beforeunload';
 
-import { getSeedlotById, putAClassSeedlotProgress, getSeedlotFromOracleDbBySeedlotNumber } from '../../../api-service/seedlotAPI';
+import { getSeedlotById, putAClassSeedlotProgress } from '../../../api-service/seedlotAPI';
 import { THREE_HALF_HOURS, THREE_HOURS } from '../../../config/TimeUnits';
 import getVegCodes from '../../../api-service/vegetationCodeAPI';
 import Breadcrumbs from '../../../components/Breadcrumbs';
@@ -103,12 +103,6 @@ const SeedlotReviewContent = () => {
     queryFn: () => getSeedlotById(seedlotNumber ?? ''),
     enabled: vegCodeQuery.isFetched,
     refetchOnMount: true
-  });
-
-  const getSeedlotBySeedlotNumberQuery = useQuery({
-    queryKey: ['seedlot-by-seedlotNumber', seedlotNumber],
-    queryFn: () => getSeedlotFromOracleDbBySeedlotNumber(seedlotNumber ?? ''),
-    enabled: seedlotQuery.isFetched
   });
 
   useEffect(() => {
@@ -556,8 +550,6 @@ const SeedlotReviewContent = () => {
         className="edit-save-btn"
         renderIcon={isReadMode ? Edit : Save}
         onClick={handleEditSaveBtn}
-        disabled={getSeedlotBySeedlotNumberQuery.isSuccess
-                && getSeedlotBySeedlotNumberQuery.data.data.originalSeedQty > 0}
       >
         {isReadMode ? 'Edit seedlot' : 'Save edit'}
       </Button>


### PR DESCRIPTION
# Description
Closes #1694 

### Changelog

#### Changed
- Only lock ownership section in review page


### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-38-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1738-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1738-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)