### PR TITLE
fix: 1781 ownership percentage and client number acronym anomalies in migrated data

### DIFF
--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
@@ -58,6 +58,8 @@ const OwnershipStep = ({ isReview = false }: OwnershipStepProps) => {
     seedlotNumber
   } = useContext(ClassAContext);
 
+  console.log(state);
+
   const [accordionControls, setAccordionControls] = useState<AccordionCtrlObj>({});
   const [originalSeedQty, setOriginalSeedQty] = useState<number>(0);
 

--- a/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OwnershipStep/index.tsx
@@ -58,8 +58,6 @@ const OwnershipStep = ({ isReview = false }: OwnershipStepProps) => {
     seedlotNumber
   } = useContext(ClassAContext);
 
-  console.log(state);
-
   const [accordionControls, setAccordionControls] = useState<AccordionCtrlObj>({});
   const [originalSeedQty, setOriginalSeedQty] = useState<number>(0);
 

--- a/frontend/src/views/Seedlot/ContextContainerClassA/context.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/context.tsx
@@ -59,6 +59,7 @@ export type ClassAContextType = {
   updateProgressStatus: (currentStepNum: number, prevStepNum: number) => void,
   saveProgressStatus: MutationStatusType,
   isFetchingData: boolean,
+  seedlotDataLoaded: boolean,
   genWorthInfoItems: Record<keyof RowItem, InfoDisplayObj[]>,
   setGenWorthInfoItems: React.Dispatch<
     React.SetStateAction<Record<keyof PrimitiveRowItem | keyof StrTypeRowItem, InfoDisplayObj[]>>
@@ -108,6 +109,7 @@ const ClassAContext = createContext<ClassAContextType>({
   updateProgressStatus: (currentStepNum: number, prevStepNum: number) => { },
   saveProgressStatus: 'idle',
   isFetchingData: false,
+  seedlotDataLoaded: false,
   geoInfoVals: {} as GeoInfoValType,
   genWorthVals: {} as GenWorthValType,
   setGenWorthVal: () => { },

--- a/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
@@ -380,6 +380,21 @@ const ContextContainerClassA = ({ children }: props) => {
     getAllSeedlotInfoQuery.fetchStatus
   ]);
 
+  const [seedlotDataLoaded, setSeedlotDataLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const emptySeedlotData = initEmptySteps();
+    if (
+      getAllSeedlotInfoQuery.status === 'success'
+      && allStepData !== emptySeedlotData
+    ) {
+      setSeedlotDataLoaded(true);
+    }
+  }, [
+    getAllSeedlotInfoQuery.status,
+    allStepData
+  ]);
+
   /**
    * Update the progress indicator status
    */
@@ -765,6 +780,7 @@ const ContextContainerClassA = ({ children }: props) => {
           || fundingSourcesQuery.isFetching
           || getFormDraftQuery.isFetching
         ),
+        seedlotDataLoaded,
         genWorthInfoItems,
         setGenWorthInfoItems,
         weightedGwInfoItems,

--- a/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
@@ -119,12 +119,13 @@ export const initOwnershipState = (
   defaultAgencyNumber: string,
   ownersStepData: Array<SingleOwnerFormSubmitType>,
   methodsOfPayment?: Array<MultiOptionsObj>,
-  fundingSource?: Array<MultiOptionsObj>
+  fundingSource?: Array<MultiOptionsObj>,
+  initLoaded?: boolean
 ): Array<SingleOwnerForm> => {
   const seedlotOwners: Array<SingleOwnerForm> = ownersStepData.map((curOwner, index) => {
     const ownerState = createOwnerTemplate(index, curOwner);
 
-    ownerState.ownerAgency.value = defaultAgencyNumber;
+    ownerState.ownerAgency.value = initLoaded ? curOwner.ownerClientNumber : defaultAgencyNumber;
     ownerState.ownerCode.value = curOwner.ownerLocnCode;
 
     if (methodsOfPayment && methodsOfPayment.length > 0) {
@@ -1120,7 +1121,8 @@ export const resDataToState = (
     defaultAgencyNumber,
     fullFormData.seedlotFormOwnershipDtoList,
     methodsOfPaymentData,
-    fundingSourcesData
+    fundingSourcesData,
+    true
   ),
   interimStep: initInterimState(
     fullFormData.seedlotFormInterimDto.intermStrgClientNumber,

--- a/frontend/src/views/Seedlot/SeedlotRegFormClassA/RegPage.tsx
+++ b/frontend/src/views/Seedlot/SeedlotRegFormClassA/RegPage.tsx
@@ -68,9 +68,6 @@ const RegPage = () => {
     || (seedlotData.seedlotStatus.seedlotStatusCode !== 'PND'
     && seedlotData.seedlotStatus.seedlotStatusCode !== 'INC');
 
-  console.log(isFormSubmitted);
-  console.log(seedlotDataLoaded);
-
   return (
     <div className="seedlot-registration-page">
       <FlexGrid fullWidth>

--- a/frontend/src/views/Seedlot/SeedlotRegFormClassA/RegPage.tsx
+++ b/frontend/src/views/Seedlot/SeedlotRegFormClassA/RegPage.tsx
@@ -53,7 +53,9 @@ const RegPage = () => {
     seedlotData,
     getFormDraftQuery,
     seedlotSpecies,
-    popSizeAndDiversityConfig
+    popSizeAndDiversityConfig,
+    isFormSubmitted,
+    seedlotDataLoaded
   } = useContext(ClassAContext);
 
   const reloadFormDraft = () => getFormDraftQuery.refetch();
@@ -65,6 +67,9 @@ const RegPage = () => {
     || !seedlotData
     || (seedlotData.seedlotStatus.seedlotStatusCode !== 'PND'
     && seedlotData.seedlotStatus.seedlotStatusCode !== 'INC');
+
+  console.log(isFormSubmitted);
+  console.log(seedlotDataLoaded);
 
   return (
     <div className="seedlot-registration-page">
@@ -171,7 +176,8 @@ const RegPage = () => {
         <Row>
           <Column className="seedlot-registration-row">
             {
-              isFetchingData || submitSeedlot.status === 'loading'
+              (isFetchingData || submitSeedlot.status === 'loading')
+              || (isFormSubmitted && !seedlotDataLoaded)
                 ? <Loading />
                 : (
                   <RegForm


### PR DESCRIPTION
# Description
Closes #1781 

### Changelog
#### New
- Added new control state to show data only when the form data state is fully loaded, avoiding sync errors

#### Changed
- Fixed ownership step initialization for submitted seedlots

#### Removed
- Nothing :)

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img width="200" src="https://media4.giphy.com/media/DhstvI3zZ598Nb1rFf/giphy-downsized-medium.gif"/>
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-2-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1802-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1802-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)