### PR TITLE
fix: 1739 orchard number disappears in form

### DIFF
--- a/frontend/src/components/SeedlotRegistrationSteps/OrchardStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/OrchardStep/index.tsx
@@ -22,12 +22,13 @@ import validator from 'validator';
 import { getOrchardByVegCode } from '../../../api-service/orchardAPI';
 import getGameticMethodology from '../../../api-service/gameticMethodologyAPI';
 import { filterInput, FilterObj } from '../../../utils/FilterUtils';
+import { getMultiOptList } from '../../../utils/MultiOptionsUtils';
 import ComboBoxEvent from '../../../types/ComboBoxEvent';
 import MultiOptionsObj from '../../../types/MultiOptionsObject';
-import InputErrorText from '../../InputErrorText';
+import { OptionsInputType } from '../../../types/FormInputType';
 import { EmptyMultiOptObj } from '../../../shared-constants/shared-constants';
-import { getMultiOptList } from '../../../utils/MultiOptionsUtils';
 import { THREE_HALF_HOURS, THREE_HOURS } from '../../../config/TimeUnits';
+import InputErrorText from '../../InputErrorText';
 import ScrollToTop from '../../ScrollToTop';
 import Subtitle from '../../Subtitle';
 import ReadOnlyInput from '../../ReadOnlyInput';
@@ -39,7 +40,6 @@ import OrchardWarnModal from './OrchardWarnModal';
 import orchardModalOptions from './OrchardWarnModal/definitions';
 
 import './styles.scss';
-import { OptionsInputType } from '../../../types/FormInputType';
 
 type NumStepperVal = {
   value: number,
@@ -276,9 +276,9 @@ const OrchardStep = ({
   };
 
   const renderOrchardFields = () => {
-    if (isFormSubmitted && isReview) {
+    if (isFormSubmitted || isReview) {
       return (
-        <div className="orchard-fields-review-only">
+        <div className={`${isReview && 'orchard-fields-review-only'}`}>
           <Row>
             <Column sm={4} md={4} lg={4}>
               <ReadOnlyInput


### PR DESCRIPTION
# Description
Closes #1739 

Instead of trying to sync the seedlot data and orchards requests, it was waaaay easier to just change the field displayed to the user.

### Changelog
#### New
- Nothing :)

#### Changed
- Validation for the field to be shown for users after the form is submitted

#### Removed
- Nothing :)

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-15-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1815-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1815-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)