### PR TITLE
fix: revert hibernate version back to 6.6.2

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,7 +39,7 @@
     <sonar.organization>bcgov-sonarcloud</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <oci.revision>${project.version}</oci.revision>
-    <hibernate.version>6.6.5.Final</hibernate.version>
+    <hibernate.version>6.6.2.Final</hibernate.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
# Description
### Changelog

#### Changed
- revert hibernate version back to 6.6.2


### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-43-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1843-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1843-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)