### PR TITLE
chore(ci): deprecate limits

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -103,7 +103,6 @@ jobs:
             -p ZONE=${{ inputs.target }}
             ${{ github.event_name == 'pull_request' && '-p DB_PVC_SIZE=192Mi' || '' }}
             ${{ github.event_name == 'pull_request' && '-p MEMORY_REQUEST=100Mi' || '' }}
-            ${{ github.event_name == 'pull_request' && '-p MEMORY_LIMIT=200Mi' || '' }}
 
   deploy:
     name: Deploy
@@ -134,7 +133,6 @@ jobs:
             overwrite: true
             parameters:
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.ca-central-1.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
-              ${{ github.event_name == 'pull_request' && '-p CPU_LIMIT=100m' || '' }}
               ${{ inputs.target == 'prod' && '-p MIN_REPLICAS=3' || '' }}
               ${{ inputs.target == 'prod' && '-p MAX_REPLICAS=5' || '' }}
             verification_path: "actuator/health"

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -36,12 +36,8 @@ parameters:
     value: "https://nr-forest-client-api-prod.api.gov.bc.ca/api"
   - name: CPU_REQUEST
     value: 25m
-  - name: CPU_LIMIT
-    value: 100m
   - name: MEMORY_REQUEST
     value: 150Mi
-  - name: MEMORY_LIMIT
-    value: 450Mi
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
     value: "3"
@@ -143,9 +139,6 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
               ports:
                 - name: container-port
                   containerPort: 8090

--- a/common/openshift.database.yml
+++ b/common/openshift.database.yml
@@ -14,12 +14,8 @@ parameters:
     required: true
   - name: CPU_REQUEST
     value: 25m
-  - name: CPU_LIMIT
-    value: 75m
   - name: MEMORY_REQUEST
     value: 2Gi
-  - name: MEMORY_LIMIT
-    value: 4Gi
   - name: DB_PVC_SIZE
     description: Volume space available for data, e.g. 512Mi, 2Gi
     value: 1.8Gi
@@ -71,9 +67,6 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
               ports:
                 - containerPort: 5432
                   protocol: TCP

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -28,12 +28,8 @@ parameters:
     value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
     value: 15m
-  - name: CPU_LIMIT
-    value: 30m
   - name: MEMORY_REQUEST
     value: 20Mi
-  - name: MEMORY_LIMIT
-    value: 40Mi
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
     value: "3"
@@ -111,9 +107,6 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
               ports:
                 - name: container-port
                   containerPort: 3000

--- a/oracle-api/openshift.deploy.yml
+++ b/oracle-api/openshift.deploy.yml
@@ -25,12 +25,8 @@ parameters:
     value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
     value: 25m
-  - name: CPU_LIMIT
-    value: 250m
   - name: MEMORY_REQUEST
     value: 150Mi
-  - name: MEMORY_LIMIT
-    value: 225Mi
   - name: ALLOWED_ORIGINS
     description: Sets all the allowed request origins
     value: "http://localhost:300*,https://*.apps.silver.devops.gov.bc.ca,https://*.nrs.gov.bc.ca"
@@ -123,9 +119,6 @@ objects:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-certs
                   mountPath: /cert
               resources:
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
@@ -180,9 +173,6 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
               ports:
                 - name: container-port
                   containerPort: 8090


### PR DESCRIPTION
Remove limits kubernetes resource objects.  This has been disabled with the platform team and should have some kinds of improvements.