### PR TITLE
chore(ci): use BUILDER_TAG from action, drop our BUILD_NUMBER

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -23,9 +23,6 @@ jobs:
       - uses: bcgov/action-builder-ghcr@v2.3.0
         id: build
         with:
-          build_args: |
-            BUILD_NUMBER=${{ github.event.number }}
-            BUILDKIT_INLINE_CACHE=1
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}
           tag_fallback: latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,10 +15,6 @@ RUN ./mvnw -B package -Pnative -DskipTests
 FROM gcr.io/distroless/java-base:nonroot AS deploy
 ARG PORT=8090
 
-# Receive build number as argument, retain as environment variable
-ARG BUILD_NUMBER
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-
 # Copy
 WORKDIR /app
 COPY --from=build /app/target/nr-spar-backend ./nr-spar-backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,10 +17,6 @@ RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
 FROM caddy:2.9.1-alpine
 RUN apk add --no-cache ca-certificates curl
 
-# Receive build number as argument, retain as environment variable
-ARG BUILD_NUMBER
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-
 # Copy files and run formatting
 COPY --from=build /app/build/ /app/dist
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/oracle-api/Dockerfile
+++ b/oracle-api/Dockerfile
@@ -12,10 +12,6 @@ RUN ./mvnw package -Pnative -DskipTests -Dskip.unit.tests=true && \
 ### Deployer
 FROM eclipse-temurin:17.0.14_7-jdk-jammy AS deploy
 
-# Receive build number as argument, retain as environment variable
-ARG BUILD_NUMBER
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-
 # Java vars
 ENV LANG=en_CA.UTF-8
 ENV LANGUAGE=en_CA.UTF-8

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -1,9 +1,5 @@
 FROM python:3.13-slim
 
-# Receive build number as argument, retain as environment variable
-ARG BUILD_NUMBER
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-
 # Packages and nonroot user
 RUN apt update && \
     apt install -y --no-install-recommends gcc libpq-dev python3-dev && \

--- a/sync/src/main.py
+++ b/sync/src/main.py
@@ -47,7 +47,7 @@ def generate_db_config(type_,schema_,settings):
     return dbconfig
 
 def get_build_number():
-    return os.environ.get("BUILD_NUMBER")
+    return os.environ.get("BUILDER_TAG")
 
 def required_variables_exists():
     ret = True


### PR DESCRIPTION
bcgov/action-builder-ghcr already provides BUILDER_TAG and other envars, so let's stop creating our own.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-8-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1858-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1858-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)