### PR TITLE
chore(ci): reign in TEST and PROD memory resources

### DIFF
--- a/common/openshift.database.yml
+++ b/common/openshift.database.yml
@@ -15,7 +15,7 @@ parameters:
   - name: CPU_REQUEST
     value: 25m
   - name: MEMORY_REQUEST
-    value: 2Gi
+    value: 512Mi
   - name: DB_PVC_SIZE
     description: Volume space available for data, e.g. 512Mi, 2Gi
     value: 1.8Gi


### PR DESCRIPTION
TEST and PROD are using 2 Gi of memory, using up all our quota.  It has been dialed down to 512, which is still double the usage being seen.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-10-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1860-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1860-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)