### PR TITLE
fix: adding extra validation for possible null values in pt calculations

### DIFF
--- a/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
@@ -949,8 +949,16 @@ export const convertParentTree = (
       parentTreeNumber: ptNum,
       coneCount: +parentTreeData.tableRowData[ptNum].coneCount.value,
       pollenCount: +parentTreeData.tableRowData[ptNum].pollenCount.value,
-      smpSuccessPct: +parentTreeData.tableRowData[ptNum].smpSuccessPerc.value,
-      nonOrchardPollenContamPct: +parentTreeData.tableRowData[ptNum].nonOrchardPollenContam.value,
+      smpSuccessPct:
+        (parentTreeData.tableRowData[ptNum].smpSuccessPerc.value
+          && parentTreeData.tableRowData[ptNum].smpSuccessPerc.value !== 'null')
+          ? Number(parentTreeData.tableRowData[ptNum].smpSuccessPerc.value)
+          : 0,
+      nonOrchardPollenContamPct:
+        (parentTreeData.tableRowData[ptNum].nonOrchardPollenContam.value
+          && parentTreeData.tableRowData[ptNum].nonOrchardPollenContam.value !== 'null')
+          ? Number(parentTreeData.tableRowData[ptNum].nonOrchardPollenContam.value)
+          : 0,
       amountOfMaterial: +parentTreeData.tableRowData[ptNum].volume.value,
       proportion: +parentTreeData.tableRowData[ptNum].proportion.value,
       parentTreeGeneticQualities: generateParentTreeGenQualPayload(


### PR DESCRIPTION
# Description
Closes #NoIssue

### Changelog
#### New
- Added an extra validation to prevent null values

#### Changed
- Nothing :)

#### Removed
- Nothing :)

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img width="300" src="https://media3.giphy.com/media/lVBtp4SRW6rvDHf1b6/giphy-downsized-medium.gif?cid=bd3ea57ejazvjvwda06ekwvfe5jcw7ipskmui2br7xfsuhnu&ep=v1_gifs_search&rid=giphy-downsized-medium.gif&ct=g"/>


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-42-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1892-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1892-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)