### PR TITLE
chore(ci): adjust db RAM, backend params

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -31,7 +31,7 @@ on:
         type: string
       db-memory-request:
         description: Database memory request; e.g. 2Gi
-        default: "2Gi"
+        default: "512Mi"
         type: string
       max-replicas:
         description: Maximum replicas for backend, frontend and oracle-api

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -36,6 +36,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:
+      db-memory-request: 100Mi
       db-pvc-size: 192Mi
       min-replicas: 1
       max-replicas: 1

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -1,11 +1,5 @@
 apiVersion: template.openshift.io/v1
 kind: Template
-metadata:
-  name: ${NAME}
-  annotations:
-    description: "NR SPAR Backend"
-    tags: "nr-spar-backend,backend"
-    iconClass: icon-java
 labels:
   app: ${NAME}-${ZONE}
 parameters:
@@ -37,7 +31,7 @@ parameters:
   - name: CPU_REQUEST
     value: 25m
   - name: MEMORY_REQUEST
-    value: 150Mi
+    value: 100Mi
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
     value: "3"

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -14,7 +14,6 @@ parameters:
     required: true
   - name: ORACLE_HOST
     description: Oracle database host
-    value: nrcdb03.bcgov
     required: true
   - name: ORACLE_SERVICE
     description: Oracle service name


### PR DESCRIPTION
Tiny change to trigger a backend build and deployment.  Adjust PR memory over-allocations.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-19-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1919-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1919-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)