### PR TITLE
chore(ci): restore sync cronjob script

### DIFF
--- a/sync/oc_run.sh
+++ b/sync/oc_run.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Exit on errors or unset variables
+set -eu
+
+# Run and verify ETL jobs in OpenShift
+#
+# Usage: ./oc_run.sh [pr#|test|prod] [optional:token]
+
+# Check inputs
+if [ -z "${1:-}" ]; then
+  echo -e "\nAn environment input is required.  Exiting.\n"
+  exit 1
+fi
+
+# Login (optional)
+if [ ! -z "${2:-}" ]; then
+  oc login --token=${2} --server=https://api.silver.devops.gov.bc.ca:6443
+  oc project #Safeguard!
+fi
+
+# Create job
+CRONJOB=nr-spar-${1}-sync
+RUN_JOB=${CRONJOB}--$(date +"%Y-%m-%d--%H-%M-%S")
+oc create job ${RUN_JOB} --from=cronjob/${CRONJOB}
+
+# Follow
+oc wait --for=condition=ready pod --selector=job-name=${RUN_JOB} --timeout=5m
+oc logs -l job-name=${RUN_JOB} --tail=50 --follow
+
+# Verify successful completion
+oc wait --for jsonpath='{.status.phase}'=Succeeded pod --selector=job-name=${RUN_JOB} --timeout=1m
+echo "Job successful!"


### PR DESCRIPTION
Restore script.  This caused PROD ETL to fail twice.  Sorry @SLDonnelly !

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-20-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1920-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1920-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)