### PR TITLE
chore: Revert "fix(deps): update dependency vite to v5.4.17 [security]"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24189,9 +24189,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.17",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.17.tgz",
-      "integrity": "sha512-5+VqZryDj4wgCs55o9Lp+p8GE78TLVg0lasCH5xFZ4jacZjtqZa6JUw9/p0WeAojaOfncSM6v77InkFPGnvPvg==",
+      "version": "5.4.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.16.tgz",
+      "integrity": "sha512-Y5gnfp4NemVfgOTDQAunSD4346fal44L9mszGGY/e+qxsRT5y1sMlS/8tiQ8AFAp+MFgYNSINdfEchJiPm41vQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",


### PR DESCRIPTION
Testing
Reverts bcgov/nr-spar#1924

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-31-frontend.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-1931-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-1931-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)