### PR TITLE
feat: 1981 fix ui from user feedback

### DIFF
--- a/frontend/src/components/GenericTable/index.tsx
+++ b/frontend/src/components/GenericTable/index.tsx
@@ -111,7 +111,8 @@ const GenericTable = <T extends Record<string, any>>({
     enableFullScreenToggle,
     enableColumnActions,
     enableEditing,
-    editDisplayMode: 'cell',
+    createDisplayMode: 'row',
+    editDisplayMode: 'table',
     renderRowActions: renderRowActions
       ? ({ row, table }) => renderRowActions({ row, table })
       : undefined,

--- a/frontend/src/types/consep/TestingActivityType.ts
+++ b/frontend/src/types/consep/TestingActivityType.ts
@@ -7,6 +7,7 @@ export type ReplicateType = {
   freshSeed?: number;
   containerAndDryWeight?: number;
   dryWeight?: number;
+  mcValue?: number;
   replicateComment?: string;
   overrideReason?: string;
 };

--- a/frontend/src/views/CONSEP/TestingActivities/ActivityResult/constants.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/ActivityResult/constants.tsx
@@ -21,24 +21,41 @@ const createEditableNumberColumn = (
   accessorKey,
   header,
   size: 120,
-  muiEditTextFieldProps: ({ cell, row }) => ({
-    type: 'number',
-    error: !!validationErrors[cell.id],
-    helperText: validationErrors[cell.id],
-    onChange: (event) => {
-      const value = parseFloat(event.currentTarget.value);
-      const validationError = value < 0 || value > 1000 ? validationMsg : undefined;
+  muiEditTextFieldProps: ({ cell, row }) => {
+    const value = row.original[accessorKey] ?? '';
+    return {
+      type: 'number',
+      value,
+      error: !!validationErrors[cell.id],
+      helperText: validationErrors[cell.id],
+      onChange: (event) => {
+        const newValue = parseFloat(event.currentTarget.value);
+        const validationError = newValue < 0 || newValue > 1000 ? validationMsg : undefined;
 
-      setValidationErrors({ ...validationErrors, [cell.id]: validationError });
+        setValidationErrors({ ...validationErrors, [cell.id]: validationError });
 
-      if (!validationError) {
-        updateRow({
-          ...row.original,
-          [accessorKey]: value
-        } as ReplicateType);
+        if (!validationError) {
+          updateRow({
+            ...row.original,
+            [accessorKey]: newValue
+          } as ReplicateType);
+        }
+      },
+      inputProps: {
+        inputMode: 'numeric',
+        pattern: '[0-9]*'
+      },
+      sx: {
+        '& input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button': {
+          WebkitAppearance: 'none',
+          margin: 0
+        },
+        '& input[type=number]': {
+          MozAppearance: 'textfield'
+        }
       }
-    }
-  }),
+    };
+  },
   ...alignRight
 });
 
@@ -54,24 +71,28 @@ const createEditableTextColumn = (
   accessorKey,
   header,
   size: 80,
-  muiEditTextFieldProps: ({ cell, row }) => ({
-    type: 'text',
-    error: !!validationErrors[cell.id],
-    helperText: validationErrors[cell.id],
-    onChange: (event) => {
-      const { value } = event.currentTarget;
-      const validationError = value.length > maxLength ? validationMsg : undefined;
+  muiEditTextFieldProps: ({ cell, row }) => {
+    const value = row.original[accessorKey] ?? '';
+    return {
+      type: 'text',
+      value,
+      error: !!validationErrors[cell.id],
+      helperText: validationErrors[cell.id],
+      onChange: (event) => {
+        const newValue = event.currentTarget.value;
+        const validationError = newValue.length > maxLength ? validationMsg : undefined;
 
-      setValidationErrors({ ...validationErrors, [cell.id]: validationError });
+        setValidationErrors({ ...validationErrors, [cell.id]: validationError });
 
-      if (!validationError) {
-        updateRow({
-          ...row.original,
-          [accessorKey]: value
-        } as ReplicateType);
+        if (!validationError) {
+          updateRow({
+            ...row.original,
+            [accessorKey]: newValue
+          } as ReplicateType);
+        }
       }
-    }
-  }),
+    };
+  },
   ...alignRight
 });
 
@@ -122,18 +143,24 @@ export const getColumns = (
     validationErrors,
     setValidationErrors
   ),
-  createEditableNumberColumn(
-    'dryWeight',
-    'Dry weight',
-    'Dry weight must be between 0 and 1000',
-    updateRow,
-    validationErrors,
-    setValidationErrors
-  ),
+  {
+    accessorKey: 'dryWeight',
+    header: 'Dry weight',
+    enableEditing: false,
+    muiEditTextFieldProps: ({ row }) => ({
+      type: 'text',
+      value: row.original.dryWeight ?? ''
+    })
+  },
   {
     accessorKey: 'mcValue',
     header: 'MC value (%)',
     size: 80,
+    muiEditTextFieldProps: ({ row }) => ({
+      type: 'text',
+      value: row.original.mcValue ?? ''
+    }),
+    enableEditing: false,
     ...alignRight
   },
   {
@@ -162,6 +189,7 @@ export const getColumns = (
     size: 300,
     muiEditTextFieldProps: ({ row }) => ({
       type: 'text',
+      value: row.original.replicateComment ?? '',
       onChange: (event) => {
         updateRow({
           ...row.original,

--- a/frontend/src/views/CONSEP/TestingActivities/ActivityResult/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/ActivityResult/index.tsx
@@ -152,6 +152,9 @@ const ActivityResult = ({
         ? Math.round(
           ((item.freshSeed - item.dryWeight) / item.freshSeed + Number.EPSILON) * 100
         ) / 100
+        : undefined,
+      dryWeight: item.containerAndDryWeight && item.containerWeight
+        ? parseFloat((item.containerAndDryWeight - item.containerWeight).toFixed(4))
         : undefined
     }));
     setReplicatesList(updatedListWithMCValue);
@@ -160,9 +163,12 @@ const ActivityResult = ({
   const replicateListWithMCValue = replicatesList.map((item) => ({
     ...item,
     mcValue: item.freshSeed && item.dryWeight
-      ? (Math.round(
+      ? Math.round(
         ((item.freshSeed - item.dryWeight) / item.freshSeed + Number.EPSILON) * 100
-      )).toFixed(2)
+      ) / 100
+      : undefined,
+    dryWeight: item.containerAndDryWeight && item.containerWeight
+      ? parseFloat((item.containerAndDryWeight - item.containerWeight).toFixed(4))
       : undefined
   }));
 


### PR DESCRIPTION
# Description
Closes #1981 

### Changelog


#### Changed
- Given that I am entering data in the table, When I use the tab button, then the cursor moves to the next cell
- Given that I am entering data in the table, When I use the up, down, side arrow buttons, then the cursor moves to the next cell in the appropriate direction
- remove the little arrows in the cell that move the integer up and down. Because the staff measure to the thousandth decimal place, this feature is not needed in the table
- Given that I have enter data that does not match validation rules, I get a validation warning that persists until the data validation issue is resolved
- Given that I know the container weight and the container weight + dry weight, When I enter the data for these fields in the the results table, Then the the dry weight field it auto populated [dry weight = (ontainer weight + dry weight) - (container weight)]

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->
