### PR TITLE
chore(ci): drop Docker Compose pins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ x-frontend: &frontend
 services:
   database:
     container_name: database
-    image: postgis/postgis:15-master@sha256:c1288c91f8671521bb7c7d3f08a3e2b537d48cdd1725c78bdf8fa34ac81225f4
+    image: postgis/postgis:15-master
     environment:
       <<: *postgres-vars
     volumes:
@@ -48,7 +48,7 @@ services:
       AWS_COGNITO_ISSUER_URI: "https://cognito-idp.ca-central-1.amazonaws.com/ca-central-1_t2HSZBHur"
       <<: *postgres-vars
     ports: ["8090:8090", "5005:5005"]
-    image: maven:3.9.9-eclipse-temurin-17@sha256:75c4d813eab02660a1dd7c5af04c2531db326b2b2998fa48082303cb28c1022c
+    image: maven:3.9.9-eclipse-temurin-17
     entrypoint: sh -c './encora-cert.sh'
     working_dir: /app
     volumes:
@@ -59,7 +59,7 @@ services:
 
   frontend:
     container_name: frontend
-    image: node:20-bullseye-slim@sha256:d22f9a922b63416d8e96f8c4b3eaa7e8451cd1eee7d5b676966cd44a43655dfa
+    image: node:20-bullseye-slim
     ports: ["3000:3000"]
     entrypoint: sh -c "npm i --no-update-notifier && npm run start"
     user: root
@@ -86,7 +86,7 @@ services:
       CYPRESS_baseUrl: http://frontend:3000
       CYPRESS_USERNAME: LOAD-3-TEST
       CYPRESS_PASSWORD: ${CYPRESS_PASSWORD}
-    image: cypress/included:12.17.4@sha256:658c7ba220b398d0dab9f474811ee8ef527424e5f841a9882d3ba6c0ad2acf9b
+    image: cypress/included:12.17.4
     profiles: ["cypress"]
     user: root
     volumes: ["./frontend:/app"]
@@ -106,7 +106,7 @@ services:
       AWS_COGNITO_ISSUER_URI: "https://cognito-idp.ca-central-1.amazonaws.com/ca-central-1_t2HSZBHur"
     profiles: ["oracle-api"]
     network_mode: host
-    image: maven:3.9.9-eclipse-temurin-17@sha256:75c4d813eab02660a1dd7c5af04c2531db326b2b2998fa48082303cb28c1022c
+    image: maven:3.9.9-eclipse-temurin-17
     entrypoint: sh -c './startup.sh && mvn -ntp spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5006"'
     working_dir: /app
     volumes: ["./oracle-api:/app"]
@@ -116,7 +116,7 @@ services:
   schemaspy:
     container_name: schemaspy
     profiles: ["schemaspy"]
-    image: schemaspy/schemaspy:6.2.4@sha256:08290ff34c0fa4c1b28af555fbedf755159e42d02651a987e6077cb40a06f1ff
+    image: schemaspy/schemaspy:6.2.4
     user: ${UID:-""}:${GID:-""}
     volumes:
       - "./schemaspy/output:/output"
@@ -135,7 +135,7 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@qs.com
       PGADMIN_DEFAULT_PASSWORD: admin
-    image: dpage/pgadmin4@sha256:bd71932cb1ef94719e783f0eed42c227bc67877a7c7e076c7092738711e5f4d4
+    image: dpage/pgadmin4
     ports: [5050:80]
     depends_on:
       database:

--- a/route.nr-spar-prod-frontend-vanity.yml
+++ b/route.nr-spar-prod-frontend-vanity.yml
@@ -1,0 +1,64 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  creationTimestamp: "2024-08-14T12:11:59Z"
+  labels:
+    app: nr-spar-prod
+  name: nr-spar-prod-frontend-vanity
+  namespace: b9d53b-prod
+  resourceVersion: "14682412261"
+  uid: 822bf176-ffe6-494b-b200-f3577ebfb485
+spec:
+  host: spar.nrs.gov.bc.ca
+  port:
+    targetPort: 3000-tcp
+  tls:
+    caCertificate: "-----BEGIN CERTIFICATE-----\r\nMIIFDjCCA/agAwIBAgIMDulMwwAAAABR03eFMA0GCSqGSIb3DQEBCwUAMIG+MQsw\r\nCQYDVQQGEwJVUzEWMBQGA1UEChMNRW50cnVzdCwgSW5jLjEoMCYGA1UECxMfU2Vl\r\nIHd3dy5lbnRydXN0Lm5ldC9sZWdhbC10ZXJtczE5MDcGA1UECxMwKGMpIDIwMDkg\r\nRW50cnVzdCwgSW5jLiAtIGZvciBhdXRob3JpemVkIHVzZSBvbmx5MTIwMAYDVQQD\r\nEylFbnRydXN0IFJvb3QgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgLSBHMjAeFw0x\r\nNTEwMDUxOTEzNTZaFw0zMDEyMDUxOTQzNTZaMIG6MQswCQYDVQQGEwJVUzEWMBQG\r\nA1UEChMNRW50cnVzdCwgSW5jLjEoMCYGA1UECxMfU2VlIHd3dy5lbnRydXN0Lm5l\r\ndC9sZWdhbC10ZXJtczE5MDcGA1UECxMwKGMpIDIwMTIgRW50cnVzdCwgSW5jLiAt\r\nIGZvciBhdXRob3JpemVkIHVzZSBvbmx5MS4wLAYDVQQDEyVFbnRydXN0IENlcnRp\r\nZmljYXRpb24gQXV0aG9yaXR5IC0gTDFLMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A\r\nMIIBCgKCAQEA2j+W0E25L0Tn2zlem1DuXKVh2kFnUwmqAJqOV38pa9vH4SEkqjrQ\r\njUcj0u1yFvCRIdJdt7hLqIOPt5EyaM/OJZMssn2XyP7BtBe6CZ4DkJN7fEmDImiK\r\nm95HwzGYei59QAvS7z7Tsoyqj0ip/wDoKVgG97aTWpRzJiatWA7lQrjV6nN5ZGhT\r\nJbiEz5R6rgZFDKNrTdDGvuoYpDbwkrK6HIiPOlJ/915tgxyd8B/lw9bdpXiSPbBt\r\nLOrJz5RBGXFEaLpHPATpXbo+8DX3Fbae8i4VHj9HyMg4p3NFXU2wO7GOFyk36t0F\r\nASK7lDYqjVs1/lMZLwhGwSqzGmIdTivZGwIDAQABo4IBDDCCAQgwDgYDVR0PAQH/\r\nBAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwMwYIKwYBBQUHAQEEJzAlMCMGCCsG\r\nAQUFBzABhhdodHRwOi8vb2NzcC5lbnRydXN0Lm5ldDAwBgNVHR8EKTAnMCWgI6Ah\r\nhh9odHRwOi8vY3JsLmVudHJ1c3QubmV0L2cyY2EuY3JsMDsGA1UdIAQ0MDIwMAYE\r\nVR0gADAoMCYGCCsGAQUFBwIBFhpodHRwOi8vd3d3LmVudHJ1c3QubmV0L3JwYTAd\r\nBgNVHQ4EFgQUgqJwdN28Uz/Pe9T3zX+nYMYKTL8wHwYDVR0jBBgwFoAUanImetAe\r\n733nO2lR1GyNn5ASZqswDQYJKoZIhvcNAQELBQADggEBADnVjpiDYcgsY9NwHRkw\r\ny/YJrMxp1cncN0HyMg/vdMNY9ngnCTQIlZIv19+4o/0OgemknNM/TWgrFTEKFcxS\r\nBJPok1DD2bHi4Wi3Ogl08TRYCj93mEC45mj/XeTIRsXsgdfJghhcg85x2Ly/rJkC\r\nk9uUmITSnKa1/ly78EqvIazCP0kkZ9Yujs+szGQVGHLlbHfTUqi53Y2sAEo1GdRv\r\nc6N172tkw+CNgxKhiucOhk3YtCAbvmqljEtoZuMrx1gL+1YQ1JH7HdMxWBCMRON1\r\nexCdtTix9qrKgWRs6PLigVWXUX/hwidQosk8WwBD9lu51aX8/wdQQGcHsFXwt35u\r\nLcw=\r\n-----END
+      CERTIFICATE-----\r\n"
+    certificate: "-----BEGIN CERTIFICATE-----\r\nMIIGyTCCBbGgAwIBAgIQJA1JA/Sg9AQ57d3xl55OqjANBgkqhkiG9w0BAQsFADCB\r\nujELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUVudHJ1c3QsIEluYy4xKDAmBgNVBAsT\r\nH1NlZSB3d3cuZW50cnVzdC5uZXQvbGVnYWwtdGVybXMxOTA3BgNVBAsTMChjKSAy\r\nMDEyIEVudHJ1c3QsIEluYy4gLSBmb3IgYXV0aG9yaXplZCB1c2Ugb25seTEuMCwG\r\nA1UEAxMlRW50cnVzdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAtIEwxSzAeFw0y\r\nNDA2MTExODE2NTNaFw0yNTA2MTExODE2NTJaMIGRMQswCQYDVQQGEwJDQTEZMBcG\r\nA1UECBMQQnJpdGlzaCBDb2x1bWJpYTERMA8GA1UEBxMIVmljdG9yaWExNzA1BgNV\r\nBAoTLkdvdmVybm1lbnQgb2YgdGhlIFByb3ZpbmNlIG9mIEJyaXRpc2ggQ29sdW1i\r\naWExGzAZBgNVBAMTEnNwYXIubnJzLmdvdi5iYy5jYTCCASIwDQYJKoZIhvcNAQEB\r\nBQADggEPADCCAQoCggEBAK747Jb+kP4XKyUhW2KhqawmsVXklSEM0WyYxYwD5qVG\r\nGRvsugVF8UB3v6KKaEwg6TJSnHNhPCA1N36/kR+6Vvq5+5rqU0Kj7xgUmKtnklGS\r\n3XaMF+qgzV9LI+q5mjgR5/6kcdJccYdiL+bl1u4ogCfJ4lLtuMOgGhjsWtCvreNV\r\nxyWdWCgv93hYqyxcUd9EKbixSkbX2PdVSAQXLZKVLwnwwaJY8NEteT7AA2pBUKgx\r\nASJQwEFfG9ooAu0aMmUGkOx/h7HG2diCVbjlHvN3lmDyaaxoDSK4088GYGxek/SK\r\nNeGdZXqNR0vJyh7XiOKrv25FYqkxcqIEugu5zRb8mmECAwEAAaOCAvAwggLsMAwG\r\nA1UdEwEB/wQCMAAwHQYDVR0OBBYEFIi7Ofg/vOeSrIGjQ07htHnpCCabMB8GA1Ud\r\nIwQYMBaAFIKicHTdvFM/z3vU981/p2DGCky/MGgGCCsGAQUFBwEBBFwwWjAjBggr\r\nBgEFBQcwAYYXaHR0cDovL29jc3AuZW50cnVzdC5uZXQwMwYIKwYBBQUHMAKGJ2h0\r\ndHA6Ly9haWEuZW50cnVzdC5uZXQvbDFrLWNoYWluMjU2LmNlcjAzBgNVHR8ELDAq\r\nMCigJqAkhiJodHRwOi8vY3JsLmVudHJ1c3QubmV0L2xldmVsMWsuY3JsMDUGA1Ud\r\nEQQuMCyCEnNwYXIubnJzLmdvdi5iYy5jYYIWd3d3LnNwYXIubnJzLmdvdi5iYy5j\r\nYTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\r\nMBMGA1UdIAQMMAowCAYGZ4EMAQICMIIBgAYKKwYBBAHWeQIEAgSCAXAEggFsAWoA\r\ndgCi4wrkRe+9rZt+OO1HZ3dT14JbhJTXK14bLMS5UKRH5wAAAZAIhGjSAAAEAwBH\r\nMEUCIEfwsV/hGvW009p1ez7tn71gO5NX5qfWiE15gvsnFIgZAiEAybv6yG/sleo5\r\noaIhXyi1v8YozWLaytJSeevLnmEYg3YAdwDm0jFjQHeMwRBBBtdxuc7B0kD2loSG\r\n+7qHMh39HjeOUAAAAZAIhGjpAAAEAwBIMEYCIQCAuBhhLbTFBeRpolYBaowuL8gH\r\nXpQey7p4EjIr7Q2epgIhAKftKVAYH9uesxaQnfnQQK5mSfuhV29/oJ3z04OK15y0\r\nAHcATnWjJ1yaEMM4W2zU3z9S6x3w4I4bjWnAsfpksWKaOd8AAAGQCIRo5wAABAMA\r\nSDBGAiEAi/8NJGrfOoj5drrrYrJ7801C2SYhg/jcOCA9U35bqLwCIQDRVkwUHZlM\r\ngtbe9yFDbpUGBCOr+2+yz44QqaK0B681kTANBgkqhkiG9w0BAQsFAAOCAQEAjdAS\r\nnM9AmmfJi5EroCMfw0AKMeSJmM5imyuZb4oLsSdgGmKKDfwb3iJ4dADGyywnuXpb\r\niIib84dI4PTWtxJIaqR3G5lp9ZOfw1BPwtJD15cCpp7BFHfme3T/p/L4voqwTCEz\r\nMpRlSebGMV1BnfHpxNzpClAYpRvS1UfPBmJMFceSbnpm9gxQiagHdb6uClCw2rdT\r\nTRYBUiLJ7OsZbzQqVWJYn02XWF83H8HIwibsyAjOM9m2oBs1qacJlj9i6CxHQosi\r\n75x0OUmzpNgYPaf+HQt9ll6dNcjraQQaqLSPmsYS3ts7V3EcvmrfmJfb8sI3CL0s\r\nbKmwg3kjGLySk989UQ==\r\n-----END
+      CERTIFICATE-----\r\n"
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCu+OyW/pD+Fysl
+      IVtioamsJrFV5JUhDNFsmMWMA+alRhkb7LoFRfFAd7+iimhMIOkyUpxzYTwgNTd+
+      v5Efulb6ufua6lNCo+8YFJirZ5JRkt12jBfqoM1fSyPquZo4Eef+pHHSXHGHYi/m
+      5dbuKIAnyeJS7bjDoBoY7FrQr63jVcclnVgoL/d4WKssXFHfRCm4sUpG19j3VUgE
+      Fy2SlS8J8MGiWPDRLXk+wANqQVCoMQEiUMBBXxvaKALtGjJlBpDsf4exxtnYglW4
+      5R7zd5Zg8mmsaA0iuNPPBmBsXpP0ijXhnWV6jUdLycoe14jiq79uRWKpMXKiBLoL
+      uc0W/JphAgMBAAECggEAR8mghCjowx8tV/wSGur6CsQLQRLaLqesKtKZRmN5V3jl
+      p2PeRHiYTVt0OBNyTD26f6eOQfZ0bUB4RtwBBlP1CMSSmtImG/LXj3kv1C9XxHkt
+      vMwoqd6UtFLHZzAEOpn6JatBec3s1F9wCNtm7eqW/fwiC+U1x6lh27TpY7KYdOsY
+      TG+3jtY3QZardexsiss4ZWEQgRI7DYIAoWuDtxsKxkqUQoLkOVFtGsuA+MgjTyxp
+      JpcAy2jrFAAOdwoZ/GE3l5lFe2e/ECSrcegG6PVIL08OJMc/uBK5S59a9kn1XE3o
+      ziOrfE5AkAxbWdx1DV7JeW/+anjuLc5okVcz+ETXqwKBgQDcb84o132JG/wXlWC8
+      Hp/kmNYVrCfObdf4x3jtaeUbNRAjTQocSQGJCm4V5d38k3wQXPWYiMnRJNlj5BaH
+      P3rYLNIC53mgi577oi2+uQmiOfJ94ZgO+aPlqNOvSA+HpJyO0J1r6b4xGsX49bFs
+      ledtJUY6Low6Py6sfdbIps+r+wKBgQDLM2hU6Y9yL2yV1L7KTOxjZRZOlJjMucwo
+      0jPrygs52YUrtOtK8xph918hb6QhghlDSaVnelbDm977DYWUYLraysfFhAWOatab
+      g9Mu4dAWhr0SO+pzfeJRpw0TEQ74wQX48d8z/YKo48wXvvEBHWg+FHJsTjpB5SWA
+      HZr9UlgIUwKBgBL9ltcx6WC8hnVJqzHJuaCqAheP40YHdIm8NZDOhKxZX/CKnIpf
+      R8CUo3NDgGJYGmIWgBoJ/skD0a6nYcF5GI4zHkydwH6ySJoJGMPLkSbmsxthKgZw
+      P0xzxPjezmezKMGs+0LmujnkwpV2JTjjmTJv+aLdi7sg4lZ96NkUdeOtAoGBAKwb
+      xbGuBa6sVmdtw4+rqcjiNQuntugoMrEcoZeEERAVmkMTwPtBf0Yc9PloCvfKrsUc
+      WrmTmGuj2TCBGnQ7neh1OtGj6eTfvxgHhta9srdxtjD8iK77n7aTLHLKzwiIzRs3
+      Glt5zLJqB1LRimXsV3/FZ8kuVQ+9G48xBDauCRw7AoGAV9getC9SHbc4DJCzqCbr
+      f79wJx3KX3xmbpirohjgtXTUfqG+O9gdsWRf8yqVcc/RNIqXVcjWj6j21TXX9Gxx
+      hjhFZhf4aeD83+yetaz+cV1bG+EUYWNNe/t23nH1Cwunbtc42/MKEXVCfKS+TQ+m
+      uYJjaaOe1O4EoU8Gqur0u70=
+      -----END PRIVATE KEY-----
+    termination: edge
+  to:
+    kind: Service
+    name: nr-spar-prod-frontend
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - lastTransitionTime: "2025-06-05T23:57:56Z"
+      status: "True"
+      type: Admitted
+    host: spar.nrs.gov.bc.ca
+    routerCanonicalHostname: router-default.apps.silver.devops.gov.bc.ca
+    routerName: default
+    wildcardPolicy: None

--- a/route.nr-spar-test-frontend-vanity.yml
+++ b/route.nr-spar-test-frontend-vanity.yml
@@ -1,0 +1,64 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  creationTimestamp: "2024-07-02T21:48:22Z"
+  labels:
+    app: nr-spar-test
+  name: nr-spar-test-frontend-vanity
+  namespace: b9d53b-test
+  resourceVersion: "14631222124"
+  uid: eea13263-90ee-4928-a90a-803496fd0249
+spec:
+  host: spar-tst.nrs.gov.bc.ca
+  port:
+    targetPort: 3000-tcp
+  tls:
+    caCertificate: "-----BEGIN CERTIFICATE-----\r\nMIIFDjCCA/agAwIBAgIMDulMwwAAAABR03eFMA0GCSqGSIb3DQEBCwUAMIG+MQsw\r\nCQYDVQQGEwJVUzEWMBQGA1UEChMNRW50cnVzdCwgSW5jLjEoMCYGA1UECxMfU2Vl\r\nIHd3dy5lbnRydXN0Lm5ldC9sZWdhbC10ZXJtczE5MDcGA1UECxMwKGMpIDIwMDkg\r\nRW50cnVzdCwgSW5jLiAtIGZvciBhdXRob3JpemVkIHVzZSBvbmx5MTIwMAYDVQQD\r\nEylFbnRydXN0IFJvb3QgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgLSBHMjAeFw0x\r\nNTEwMDUxOTEzNTZaFw0zMDEyMDUxOTQzNTZaMIG6MQswCQYDVQQGEwJVUzEWMBQG\r\nA1UEChMNRW50cnVzdCwgSW5jLjEoMCYGA1UECxMfU2VlIHd3dy5lbnRydXN0Lm5l\r\ndC9sZWdhbC10ZXJtczE5MDcGA1UECxMwKGMpIDIwMTIgRW50cnVzdCwgSW5jLiAt\r\nIGZvciBhdXRob3JpemVkIHVzZSBvbmx5MS4wLAYDVQQDEyVFbnRydXN0IENlcnRp\r\nZmljYXRpb24gQXV0aG9yaXR5IC0gTDFLMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A\r\nMIIBCgKCAQEA2j+W0E25L0Tn2zlem1DuXKVh2kFnUwmqAJqOV38pa9vH4SEkqjrQ\r\njUcj0u1yFvCRIdJdt7hLqIOPt5EyaM/OJZMssn2XyP7BtBe6CZ4DkJN7fEmDImiK\r\nm95HwzGYei59QAvS7z7Tsoyqj0ip/wDoKVgG97aTWpRzJiatWA7lQrjV6nN5ZGhT\r\nJbiEz5R6rgZFDKNrTdDGvuoYpDbwkrK6HIiPOlJ/915tgxyd8B/lw9bdpXiSPbBt\r\nLOrJz5RBGXFEaLpHPATpXbo+8DX3Fbae8i4VHj9HyMg4p3NFXU2wO7GOFyk36t0F\r\nASK7lDYqjVs1/lMZLwhGwSqzGmIdTivZGwIDAQABo4IBDDCCAQgwDgYDVR0PAQH/\r\nBAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwMwYIKwYBBQUHAQEEJzAlMCMGCCsG\r\nAQUFBzABhhdodHRwOi8vb2NzcC5lbnRydXN0Lm5ldDAwBgNVHR8EKTAnMCWgI6Ah\r\nhh9odHRwOi8vY3JsLmVudHJ1c3QubmV0L2cyY2EuY3JsMDsGA1UdIAQ0MDIwMAYE\r\nVR0gADAoMCYGCCsGAQUFBwIBFhpodHRwOi8vd3d3LmVudHJ1c3QubmV0L3JwYTAd\r\nBgNVHQ4EFgQUgqJwdN28Uz/Pe9T3zX+nYMYKTL8wHwYDVR0jBBgwFoAUanImetAe\r\n733nO2lR1GyNn5ASZqswDQYJKoZIhvcNAQELBQADggEBADnVjpiDYcgsY9NwHRkw\r\ny/YJrMxp1cncN0HyMg/vdMNY9ngnCTQIlZIv19+4o/0OgemknNM/TWgrFTEKFcxS\r\nBJPok1DD2bHi4Wi3Ogl08TRYCj93mEC45mj/XeTIRsXsgdfJghhcg85x2Ly/rJkC\r\nk9uUmITSnKa1/ly78EqvIazCP0kkZ9Yujs+szGQVGHLlbHfTUqi53Y2sAEo1GdRv\r\nc6N172tkw+CNgxKhiucOhk3YtCAbvmqljEtoZuMrx1gL+1YQ1JH7HdMxWBCMRON1\r\nexCdtTix9qrKgWRs6PLigVWXUX/hwidQosk8WwBD9lu51aX8/wdQQGcHsFXwt35u\r\nLcw=\r\n-----END
+      CERTIFICATE-----\r\n"
+    certificate: "-----BEGIN CERTIFICATE-----\r\nMIIG1DCCBbygAwIBAgIQChvTuJT+hokyxtmruftzFDANBgkqhkiG9w0BAQsFADCB\r\nujELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUVudHJ1c3QsIEluYy4xKDAmBgNVBAsT\r\nH1NlZSB3d3cuZW50cnVzdC5uZXQvbGVnYWwtdGVybXMxOTA3BgNVBAsTMChjKSAy\r\nMDEyIEVudHJ1c3QsIEluYy4gLSBmb3IgYXV0aG9yaXplZCB1c2Ugb25seTEuMCwG\r\nA1UEAxMlRW50cnVzdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAtIEwxSzAeFw0y\r\nNDA2MTExODE5NTBaFw0yNTA2MTExODE5NDlaMIGVMQswCQYDVQQGEwJDQTEZMBcG\r\nA1UECBMQQnJpdGlzaCBDb2x1bWJpYTERMA8GA1UEBxMIVmljdG9yaWExNzA1BgNV\r\nBAoTLkdvdmVybm1lbnQgb2YgdGhlIFByb3ZpbmNlIG9mIEJyaXRpc2ggQ29sdW1i\r\naWExHzAdBgNVBAMTFnNwYXItdHN0Lm5ycy5nb3YuYmMuY2EwggEiMA0GCSqGSIb3\r\nDQEBAQUAA4IBDwAwggEKAoIBAQC3hcwrFhRkN9idENioXhbcZJi05d5e9qJLjbt7\r\nOpBoSGbdQHenxwqtIUqU/xQPoywkiqu0h7/vC0YWx392c0aeZYo5a2yP2ZtO1ibU\r\nWHO0MV6Oi/peIGQmwwSDNmmQHKqzoWRhlyx3RMHTdUsqDD7JbVjLYwHK2HhF3jnC\r\nq2cgZg0vjP8v4iPt/f2oJO3zasrS8cQ+fGer9cF2nhKxKW47758LVaqTUu90K+N+\r\nK/OP4MwXybmN2BoYh/NkajBDFCQ7niBRrA5uZHbbv24b3kJW3FciQQyFrMCyNJi2\r\nkyI5W+Hh7Y7fGf3brIt2zMBRaSxh4o27ErJhw6aZ0KOGzgBlAgMBAAGjggL3MIIC\r\n8zAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQllUKqqRJ7m665NcwkqWbpQJMOQzAf\r\nBgNVHSMEGDAWgBSConB03bxTP8971PfNf6dgxgpMvzBoBggrBgEFBQcBAQRcMFow\r\nIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmVudHJ1c3QubmV0MDMGCCsGAQUFBzAC\r\nhidodHRwOi8vYWlhLmVudHJ1c3QubmV0L2wxay1jaGFpbjI1Ni5jZXIwMwYDVR0f\r\nBCwwKjAooCagJIYiaHR0cDovL2NybC5lbnRydXN0Lm5ldC9sZXZlbDFrLmNybDA9\r\nBgNVHREENjA0ghZzcGFyLXRzdC5ucnMuZ292LmJjLmNhghp3d3cuc3Bhci10c3Qu\r\nbnJzLmdvdi5iYy5jYTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUH\r\nAwEGCCsGAQUFBwMCMBMGA1UdIAQMMAowCAYGZ4EMAQICMIIBfwYKKwYBBAHWeQIE\r\nAgSCAW8EggFrAWkAdgBOdaMnXJoQwzhbbNTfP1LrHfDgjhuNacCx+mSxYpo53wAA\r\nAZAIhxurAAAEAwBHMEUCIQCsS5KHc50JHyyleitDToIdnmAn0N+r7t8liyiN71hJ\r\nnAIgDPTA3gw7ArsFp72Zzu1ulXoaC8BTk8LY+6evsfPvGdwAdgDm0jFjQHeMwRBB\r\nBtdxuc7B0kD2loSG+7qHMh39HjeOUAAAAZAIhxvNAAAEAwBHMEUCIQCFDQ+NVjFq\r\n6+LlMQq0aCm8WdBhTzc9v2Vzsf3tUUcJuAIgPknvjf9aq19mwXsVJHU+CFWRU/qc\r\nktO4EeSu6pyL3CoAdwDgkrP8DB3I52g2H95huZZNClJ4GYpy1nLEsE2lbW9UBAAA\r\nAZAIhxu/AAAEAwBIMEYCIQC77/LgEKYysoBuwSR1kAAyKHewafk8NnxerMlr/asr\r\nJQIhAI0tQBM0cUwlVMPtaRnq4I5y2EEC8SQWRVnE/Mxvryz6MA0GCSqGSIb3DQEB\r\nCwUAA4IBAQBQ7UuXMU0QyVwKAIav60yqp0Rf7+pmFCGEacXuscYjrTzagDF0RaBk\r\nOtlzHe5euuEtpKx7wpzmVrk3U0LW4lcck6121ktkvkY3W0VKTjyh6546ZtN7aV6b\r\nOlgsjz4udNxk4dmKrDV16tpC6v/bxEc+0HtBrjm6wr/bcSW48xjrtV/4Fih3UA8G\r\nl6mdXQsBhMG9e/BS+vDAQ8SsmvO4mBrebw9bM3RzS2Fx3GflM7/3noRA8V3zSrbO\r\nG9grlgGkEktxhaUq0sLUxvLERlPw9tKfcJNnBwHwybrKY4g4Rs/1iMcfeKj9p+IP\r\nfNMoyBrW2AMbrghlF9dqmA8/YZaihkdt\r\n-----END
+      CERTIFICATE-----\r\n"
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC3hcwrFhRkN9id
+      ENioXhbcZJi05d5e9qJLjbt7OpBoSGbdQHenxwqtIUqU/xQPoywkiqu0h7/vC0YW
+      x392c0aeZYo5a2yP2ZtO1ibUWHO0MV6Oi/peIGQmwwSDNmmQHKqzoWRhlyx3RMHT
+      dUsqDD7JbVjLYwHK2HhF3jnCq2cgZg0vjP8v4iPt/f2oJO3zasrS8cQ+fGer9cF2
+      nhKxKW47758LVaqTUu90K+N+K/OP4MwXybmN2BoYh/NkajBDFCQ7niBRrA5uZHbb
+      v24b3kJW3FciQQyFrMCyNJi2kyI5W+Hh7Y7fGf3brIt2zMBRaSxh4o27ErJhw6aZ
+      0KOGzgBlAgMBAAECggEAJf15/r9S2E4hNp5aozva8qOWYvgkuLbIcOh1k3RTmWrH
+      dGyYeHBBGwbFuCM3hWcrR6M3GSdyyWqlhyikD6KcT0TIwMsmjX6n4kF9hz6KMRZ5
+      MvvyB5Mf+FAtenYEkzMD+SxjKbqQF15x2zKwLROc2bibhXrIz7NQ7nGqtkwiDHgJ
+      nx56S/OX6mXFRCEbgIaE5K2lIr/i3RPvQBE04Vr7mzpCEoJpwIXwtNEhi4Yu3Qpr
+      x8OWIpmgp9/7IWbfY8hqfkv5PpJA/MQOxHHVShgmYuJx+7t/Y9cAdHVyJDBwB54H
+      zJy+ihlAMcvrtF/xe7hSzP1rxajKESIszXiMYAd2bwKBgQDrSMakkrIhv4x2s9B6
+      X8XtjeJ+c1pR97DVYd++HdEuxE/OK7oLEcr63IllF8NroW4OBYyLikU+o4fa9qmU
+      kqGJmupBUEETueJRZVM6PcdjClaVYGl+mULX93aSS321+dnxiehTloR1Xx19WeKq
+      lO3QY3rz9Yx64pfy0p1mLGizTwKBgQDHrlUuwu38H9M7pWYmKPZFZnMNI2WvOMml
+      zLVBQGKi9wJDuIJvpLXotXPSRjihr03FInNp/4o6lKljO02n7tXpYxyNPa3mlHKH
+      4Qu3QFi9B8NqyC7E7sFxBz5BHGTtcMkUklGJ/kmTaVGTnNmrsXJR+jFHRTdruJGX
+      kvrvOGn0CwKBgQDGa9CCF+i7x1OJA6nsmfpMlVyOcW+ZMr7hpTHQnkq8GviGkZ/L
+      GA1LNFN2euzmRvSORKW7RDeTVMwMn/pxfptWddvaivjmztuK812V/2W4I47TWMR+
+      7HdPtLU9OQbiQbxIE5pna8d3SGiRPw2F+CT6mfql5M29EH0+Xdo5wXfmxwKBgF0l
+      IlE01uTUR6m8JuFIHFEVUDfhui45dD7mNerhSOGyDZlfeWDw2XZbJlMBNKufZcy+
+      nE3mySk4bad/Y2Mh0yESfaAZFITJ3H8r6FYsKvjKpUqrZL2yjgPWmCCxSRdFlFcH
+      Rgfz2YhtCYOtGBCyLpy088XGMOsL5sZo5qsuiqYvAoGBAMXZ+iysH3oDthzqqnP/
+      TYSCOzRQBtYK0NWubzYGzqP92dem+VwaONRzv/zexxf47hZZPgWyktgej5KbDNxC
+      IL1a5yix5x4ehHscxeXgcgb0Yzc2oWaM7YXCQlNCghONWF0jE7fVschfTGAFqol5
+      I83YSP5keUg1rD9DLp84nvZ5
+      -----END PRIVATE KEY-----
+    termination: edge
+  to:
+    kind: Service
+    name: nr-spar-test-frontend
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - lastTransitionTime: "2024-07-02T21:48:22Z"
+      status: "True"
+      type: Admitted
+    host: spar-tst.nrs.gov.bc.ca
+    routerCanonicalHostname: router-default.apps.silver.devops.gov.bc.ca
+    routerName: default
+    wildcardPolicy: None

--- a/route.nr-spar-test-frontend.yml
+++ b/route.nr-spar-test-frontend.yml
@@ -1,0 +1,35 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"route.openshift.io/v1","kind":"Route","metadata":{"annotations":{},"labels":{"app":"nr-spar-test"},"name":"nr-spar-test-frontend","namespace":"b9d53b-test"},"spec":{"host":"nr-spar-test.apps.silver.devops.gov.bc.ca","port":{"targetPort":"3000-tcp"},"tls":{"insecureEdgeTerminationPolicy":"Redirect","termination":"edge"},"to":{"kind":"Service","name":"nr-spar-test-frontend","weight":100}}}
+  creationTimestamp: "2025-06-05T23:34:41Z"
+  labels:
+    app: nr-spar-test
+  name: nr-spar-test-frontend
+  namespace: b9d53b-test
+  resourceVersion: "14682221958"
+  uid: 6faa9b80-d2d0-4163-b611-56a3c84de836
+spec:
+  host: nr-spar-test.apps.silver.devops.gov.bc.ca
+  port:
+    targetPort: 3000-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: nr-spar-test-frontend
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - lastTransitionTime: "2025-06-05T23:34:41Z"
+      status: "True"
+      type: Admitted
+    host: nr-spar-test.apps.silver.devops.gov.bc.ca
+    routerCanonicalHostname: router-default.apps.silver.devops.gov.bc.ca
+    routerName: default
+    wildcardPolicy: None


### PR DESCRIPTION
Stop using pins (SHAs) for Docker Compose.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-10.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2010-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2010-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)