### PR TITLE
feat: 1988 add mc variations to custom some fields for different mc type

### DIFF
--- a/frontend/src/utils/TestActivitiesUtils.ts
+++ b/frontend/src/utils/TestActivitiesUtils.ts
@@ -5,9 +5,9 @@
  * @param {string} activityRiaKey the activity riakey to generate the list
  * @returns {any} a list of empty rows
  */
-export const initReplicatesList = (activityRiaKey: string): any => {
+export const initReplicatesList = (activityRiaKey: string, numberOfRows: number): any => {
   const emptyRows = [];
-  for (let i = 0; i < 4; i += 1) {
+  for (let i = 0; i < numberOfRows; i += 1) {
     emptyRows.push({
       riaKey: activityRiaKey,
       replicateNumber: i + 1,

--- a/frontend/src/views/CONSEP/TestingActivities/MoistureContent/constants.ts
+++ b/frontend/src/views/CONSEP/TestingActivities/MoistureContent/constants.ts
@@ -1,9 +1,6 @@
 export const DATE_FORMAT = 'Y/m/d';
 
 export const fieldsConfig = {
-  titleSection: {
-    title: 'Moisture content cones for seedlot'
-  },
   startDate: {
     name: 'startDate',
     placeholder: 'yyyy/mm/dd',
@@ -21,11 +18,44 @@ export const fieldsConfig = {
     placeholder: 'Choose a category',
     label: 'category',
     invalid: 'Please select an option',
-    options: ['Quality assurance', 'Standard']
+    options: ['QA', 'STD', 'QAK', 'QAR']
   },
   comments: {
     name: 'comments',
     labelText: 'Comments (optional)',
     placeholder: 'My comments about this activity'
+  }
+};
+
+export const mccVariations = {
+  MCC: {
+    defaultCategory: 'QA',
+    description: 'Moisture content cones',
+    defaultNumberOfRows: 4
+  },
+  MCK: {
+    defaultCategory: 'QAK',
+    description: 'Moisture content unkilned seed',
+    defaultNumberOfRows: 1
+  },
+  MCR: {
+    defaultCategory: 'QAR',
+    description: 'Moisture content QAR',
+    defaultNumberOfRows: 8
+  },
+  MC: {
+    defaultCategory: 'STD',
+    description: 'Moisture content oven',
+    defaultNumberOfRows: 2
+  },
+  MCQ: {
+    defaultCategory: 'QA',
+    description: 'Moisture content QA',
+    defaultNumberOfRows: 2
+  },
+  MCM: {
+    defaultCategory: 'QA',
+    description: 'Moisture content meter',
+    defaultNumberOfRows: 1
   }
 };

--- a/frontend/src/views/CONSEP/TestingActivities/MoistureContent/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/MoistureContent/index.tsx
@@ -37,9 +37,8 @@ import StatusTag from '../../../../components/StatusTag';
 import ButtonGroup from '../ButtonGroup';
 import ActivityResult from '../ActivityResult';
 
-import { categoryMap, categoryMapReverse } from '../SharedConstants';
 import {
-  DATE_FORMAT, fieldsConfig
+  DATE_FORMAT, fieldsConfig, mccVariations
 } from './constants';
 
 import './styles.scss';
@@ -53,6 +52,7 @@ const MoistureContent = () => {
   const [activitySummary, setActivitySummary] = useState<ActivitySummaryType>();
   const [activityRiaKey, setActivityRiaKey] = useState<number>(0);
   const [activityRecord, setActivityRecord] = useState<ActivityRecordType>();
+  const [mcType, setMCType] = useState<string>('MCC');
   const [alert, setAlert] = useState<{ isSuccess: boolean; message: string } | null>(null);
 
   // Reference to the table body for extracting MC Values
@@ -109,6 +109,7 @@ const MoistureContent = () => {
     } else if (testActivityQuery.data) {
       setTestActivity(testActivityQuery.data);
       setSeedlotNumber(testActivityQuery.data.seedlotNumber);
+      setMCType(testActivityQuery.data.activityType);
       const activityRecordData = {
         testCategoryCode: testActivityQuery.data.testCategoryCode,
         riaComment: testActivityQuery.data.riaComment,
@@ -301,6 +302,8 @@ const MoistureContent = () => {
     }
   ];
 
+  const mcVariation = mccVariations[mcType as keyof typeof mccVariations];
+
   return (
     <FlexGrid className="consep-moisture-content">
       {alert?.message
@@ -310,7 +313,7 @@ const MoistureContent = () => {
         <Breadcrumbs crumbs={createBreadcrumbItems()} />
       </Row>
       <Row className="consep-moisture-content-title">
-        <PageTitle title={`${fieldsConfig.titleSection.title} ${activitySummary && activitySummary.seedlotNumber}`} />
+        <PageTitle title={`${mcVariation.description} for seedlot ${activitySummary && activitySummary.seedlotNumber}`} />
         <>
           {
             testActivity?.testCompleteInd
@@ -336,7 +339,7 @@ const MoistureContent = () => {
       </Row>
       <Row className="consep-moisture-content-activity-result">
         <ActivityResult
-          replicatesData={testActivity?.replicatesList || initReplicatesList(riaKey ?? '')}
+          replicatesData={testActivity?.replicatesList || initReplicatesList(riaKey ?? '', mcVariation.defaultNumberOfRows)}
           replicateType="moistureTest"
           riaKey={activityRiaKey}
           isEditable={!testActivity?.testCompleteInd}
@@ -399,16 +402,11 @@ const MoistureContent = () => {
             titleText={fieldsConfig.category.title as string}
             invalidText={fieldsConfig.category.invalid as string}
             value={
-              activityRecord?.testCategoryCode
-              && activityRecord.testCategoryCode in categoryMap
-                ? categoryMap[activityRecord.testCategoryCode as keyof typeof categoryMap]
-                : 'Quality assurance'
+              activityRecord?.testCategoryCode || mcVariation.defaultCategory
             }
             onChange={(e: { selectedItem: string }) => {
               handleUpdateActivityRecord({
-                testCategoryCode: categoryMapReverse[
-                  e.selectedItem as keyof typeof categoryMapReverse
-                ]
+                testCategoryCode: e.selectedItem
               });
             }}
           />

--- a/frontend/src/views/CONSEP/TestingActivities/MoistureContent/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/MoistureContent/index.tsx
@@ -402,7 +402,7 @@ const MoistureContent = () => {
             titleText={fieldsConfig.category.title as string}
             invalidText={fieldsConfig.category.invalid as string}
             value={
-              activityRecord?.testCategoryCode || mcVariation.defaultCategory
+              activityRecord?.testCategoryCode ?? mcVariation.defaultCategory
             }
             onChange={(e: { selectedItem: string }) => {
               handleUpdateActivityRecord({

--- a/frontend/src/views/CONSEP/TestingActivities/PurityContent/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/PurityContent/index.tsx
@@ -40,7 +40,6 @@ import ROUTES from '../../../../routes/constants';
 import ActivityResult from '../ActivityResult';
 import ButtonGroup from '../ButtonGroup';
 
-import { categoryMap, categoryMapReverse } from '../SharedConstants';
 import { ImpurityType } from './definitions';
 import {
   DATE_FORMAT, fieldsConfig, actionModalOptions, COMPLETE, ACCEPT
@@ -449,7 +448,7 @@ const PurityContent = () => {
       <Row className="consep-purity-content-activity-result">
         <ActivityResult
           replicateType="purityTest"
-          replicatesData={testActivity?.replicatesList || initReplicatesList(riaKey ?? '')}
+          replicatesData={testActivity?.replicatesList || initReplicatesList(riaKey ?? '', 4)}
           riaKey={Number(riaKey)}
           isEditable={!testActivity?.testCompleteInd}
           setAlert={handleAlert}
@@ -511,16 +510,11 @@ const PurityContent = () => {
             titleText={fieldsConfig.category.title}
             invalidText={fieldsConfig.category.invalid}
             value={
-              activityRecord?.testCategoryCode
-              && activityRecord.testCategoryCode in categoryMap
-                ? categoryMap[activityRecord.testCategoryCode as keyof typeof categoryMap]
-                : 'Quality assurance'
+              activityRecord?.testCategoryCode ?? 'QA'
             }
             onChange={(e: { selectedItem: string }) => {
               handleUpdateActivityRecord({
-                testCategoryCode: categoryMapReverse[
-                  e.selectedItem as keyof typeof categoryMapReverse
-                ]
+                testCategoryCode: e.selectedItem
               });
             }}
           />

--- a/frontend/src/views/CONSEP/TestingActivities/SharedConstants.ts
+++ b/frontend/src/views/CONSEP/TestingActivities/SharedConstants.ts
@@ -1,9 +1,0 @@
-export const categoryMap = {
-  QA: 'Quality assurance',
-  STD: 'Standard'
-};
-
-export const categoryMapReverse = {
-  'Quality assurance': 'QA',
-  Standard: 'STD'
-};


### PR DESCRIPTION
# Description
Closes #1988 

### Changelog
#### New
- add mc variations to custom some fields for different mc type

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-22.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2072-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2072-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)