### PR TITLE
fix: 2080 add impurity button not working

### DIFF
--- a/frontend/src/api-service/consep/impuritiesAPI.ts
+++ b/frontend/src/api-service/consep/impuritiesAPI.ts
@@ -4,7 +4,7 @@ import { ImpurityPayload, RichImpurityType } from '../../views/CONSEP/TestingAct
 
 export const patchImpurities = (
   riaKey: string,
-  payload: ImpurityPayload
+  payload: ImpurityPayload[]
 ) => {
   const url = `${ApiConfig.purityTest}/debris/${riaKey}`;
   return api.patch(url, payload).then((res): RichImpurityType[] => res.data);

--- a/frontend/src/views/CONSEP/TestingActivities/PurityContent/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/PurityContent/index.tsx
@@ -82,7 +82,7 @@ const PurityContent = () => {
   });
 
   const updateImpuritiesMutation = useMutation({
-    mutationFn: (impurityPayload: ImpurityPayload) => patchImpurities(
+    mutationFn: (impurityPayload: ImpurityPayload[]) => patchImpurities(
       riaKey || '',
       impurityPayload
     ),
@@ -280,13 +280,13 @@ const PurityContent = () => {
         nextRank = lastItem.debrisRank + 1;
       }
     }
-    updateImpuritiesMutation.mutate(
+    updateImpuritiesMutation.mutate([
       {
         replicateNumber,
         debrisRank: nextRank,
         debrisTypeCode: ''
       }
-    );
+    ]);
   };
 
   const handleCalculateAverage = () => {};
@@ -364,13 +364,13 @@ const PurityContent = () => {
           }
           onChange={(e: ComboBoxEvent) => {
             const { selectedItem } = e;
-            updateImpuritiesMutation.mutate(
+            updateImpuritiesMutation.mutate([
               {
                 replicateNumber,
                 debrisRank: impurity.debrisRank,
                 debrisTypeCode: selectedItem
               }
-            );
+            ]);
           }}
         />
       </Column>


### PR DESCRIPTION
# Description
Closes #2080

### Changelog
#### New
- Nothing :)

#### Changed
-  Changed the parameters passed to the backend.

#### Removed
- Nothing :)

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<img width="250" src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYzh4ZXM1cXBscmxtcXp0aG5kcTdmN2dqOXhxZ2xqMmhxM3U4c3ZmZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/d4blalI6x2oc4xAA/giphy.gif"/>

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-31.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2081-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2081-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)