### PR TITLE
fix: update local npm script

### DIFF
--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node_version: "22"
           commands: |
-            npm ci
+            npm ci --ignore-scripts 
             npx start-server-and-test start http://localhost:3000 cy:run
           dir: frontend
           sonar_args: >

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: bcgov/action-test-and-analyse@51b50be3bb2522e480ed8eab72735612deff7f15 # v1.4.0
         with:
           commands: |
-            npm ci
+            npm ci --ignore-scripts 
             npm run lint
           dir: frontend
           node_version: "22"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     container_name: frontend
     image: node:22-bullseye-slim
     ports: ["3000:3000"]
-    entrypoint: sh -c "npm i --no-update-notifier && npm run start"
+    entrypoint: sh -c "npm ci --ignore-scripts --no-update-notifier && npm run start"
     user: root
     volumes: ["./frontend:/app"]
     working_dir: /app


### PR DESCRIPTION
Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)

Our frontend Docker file is using `npm ci --ignore-scripts ` already, updated the places for running tests and local deployment.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-33.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2233-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2233-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)