### PR TITLE
feat: add release workflow for manual TEST deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
         if: ${{ inputs.release != '' }}
         run: |
           VERSION="${{ inputs.release }}"
-          # Validate semantic version format: vMAJOR.MINOR.PATCH[-prerelease][+build]
-          # Examples: v1.2.3, v1.2.3-alpha.1, v1.2.3+build.1
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$ ]]; then
+          # Validate semantic version format: vMAJOR.MINOR.PATCH
+          # Example: v1.2.3
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Release names must use semantic versioning (e.g., v1.2.3). Got: $VERSION"
             exit 1
           fi


### PR DESCRIPTION
## Summary

This PR adds a new `release.yml` workflow for manual PROD deployments with semantic versioning support.

NOTE: this PR and future changes will deploy to TEST until we are ready!

## Changes

- **New workflow**: `.github/workflows/release.yml`
  - `workflow_dispatch` trigger with optional `release` input
  - If `release` input is provided, uses that version
  - If not provided, calculates version from semantic commits using `TriPSs/conventional-changelog-action`
  - Gets last merged PR number using `bcgov/action-get-pr`
  - Deploys to TEST environment using existing PR number builds (no new builds)
  - Creates GitHub release with calculated or provided version

## Usage

1. Go to Actions → Release workflow
2. Click "Run workflow"
3. Optionally provide a release version (e.g., `v1.2.3`) or leave empty to calculate from commits
4. The workflow will:
   - Find the last merged PR
   - Create a release (manual or calculated)
   - Deploy to TEST using the PR number tag

## Notes

- `merge.yml` is left unchanged for now (as requested)
- Only TEST deployment is implemented (PROD can be added later)
- Uses existing PR number builds instead of building new images

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-16.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2316-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2316-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)