### PR TITLE
chore(ci): nightly workflow improvements (#2330)

### DIFF
--- a/.github/workflows/job-nightly.yml
+++ b/.github/workflows/job-nightly.yml
@@ -14,8 +14,9 @@ jobs:
   db-bk-test:
     environment: test
     name: Database Backup (TEST)
-    continue-on-error: true
+    continue-on-error: true # Tests still run after; failures surfaced by results job
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: bcgov/action-oc-runner@f900830adadd4d9eef3ca6ff80103e839ba8b7c0 # v1.3.0
         with:
@@ -29,6 +30,7 @@ jobs:
     name: Database Backup (PROD)
     continue-on-error: false
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: bcgov/action-oc-runner@f900830adadd4d9eef3ca6ff80103e839ba8b7c0 # v1.3.0
         with:
@@ -37,8 +39,9 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           commands: ./common/db_bk_run.sh prod
 
-  ageOutPRs:
+  age-out-prs:
     name: PR Env Purge
+    # No environment = default (DEV); intentional
     env:
       # https://tecadmin.net/getting-yesterdays-date-in-bash/
       DATE: "4 days ago"
@@ -51,8 +54,8 @@ jobs:
           oc: "4"
       - run: |
           # Login to OpenShift
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
-          oc project ${{ vars.OC_NAMESPACE }} # Safeguard!
+          oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}
+          oc project ${{ vars.oc_namespace }} # Safeguard!
 
           oc get ${{ env.TYPE }} -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | \
             grep -v workspace | \
@@ -74,6 +77,7 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca
       PREFIX: ${{ github.event.repository.name }}-test
@@ -86,3 +90,13 @@ jobs:
           cmd_options: "-a"
           issue_title: "ZAP: frontend"
           target: https://${{ env.PREFIX }}.${{ env.DOMAIN }}
+
+  results:
+    name: Results
+    if: always()
+    needs: [db-bk-test, db-bk-prod, age-out-prs, tests, zap_scan]
+    runs-on: ubuntu-24.04
+    steps:
+      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
+        run: echo "At least one job has failed." && exit 1
+      - run: echo "Success!"


### PR DESCRIPTION
**What**
- Nightly runs **daily** (was weekly); schedule comment corrected (3 AM PST / 11:00 UTC).
- Backups run first, then tests, then ZAP so test DB isn’t under backup I/O during Cypress.
- Timeouts added: 10 min for backups, 30 min for ZAP to avoid stuck runs.
- **Results** job fails the run if any job failed or was canceled—so backup/test failures are visible and don’t get lost.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-30.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2330-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2330-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)