### PR TITLE
fix(frontend): #2354 Fix test search species selection and validation check on parameters

### DIFF
--- a/frontend/src/views/CONSEP/TestingActivities/TestSearch/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/TestSearch/index.tsx
@@ -638,7 +638,12 @@ const TestSearch = () => {
         <Row>
           <Column>
             {alert?.message && (
-              <InlineNotification lowContrast kind={alert.status} subtitle={alert?.message} />
+              <InlineNotification
+                lowContrast
+                kind={alert.status}
+                subtitle={alert?.message}
+                onCloseButtonClick={() => setAlert(null)}
+              />
             )}
           </Column>
         </Row>


### PR DESCRIPTION
- Fix the test search species selection
- Fix the validation check on at least need one search parameters: removed the field from search parameters when cleanup the value 

# Description
Closes #2354

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-6.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2356-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2356-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)