### PR TITLE
feat: #2398 get request type api

### DIFF
--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpoint.java
@@ -8,6 +8,7 @@ import ca.bc.gov.oracleapi.entity.consep.ActivityEntity;
 import ca.bc.gov.oracleapi.response.ApiAuthResponse;
 import ca.bc.gov.oracleapi.security.RoleAccessConfig;
 import ca.bc.gov.oracleapi.service.consep.ActivityService;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -116,7 +117,9 @@ public class ActivityEndpoint {
   @ApiResponse(
       responseCode = "200",
       description = "Successfully retrieved germination test activity types.",
-      content = @Content(schema = @Schema(implementation = StandardActivityDto.class))
+      content = @Content(
+        array = @ArraySchema(schema = @Schema(implementation = StandardActivityDto.class))
+    )
   )
   @ApiAuthResponse
   @RoleAccessConfig({ "SPAR_TSC_SUBMITTER", "SPAR_TSC_SUPERVISOR" })

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpoint.java
@@ -119,7 +119,7 @@ public class ActivityEndpoint {
       content = @Content(schema = @Schema(implementation = StandardActivityDto.class))
   )
   @ApiAuthResponse
-  @RoleAccessConfig({"SPAR_TSC_SUBMITTER", "SPAR_TSC_SUPERVISOR"})
+  @RoleAccessConfig({ "SPAR_TSC_SUBMITTER", "SPAR_TSC_SUPERVISOR" })
   public List<StandardActivityDto> getGerminationTestTypes() {
     return activityService.getGerminationTestTypes();
   }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpoint.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-
 /**
  * This class exposes activities resources API.
  */
@@ -105,5 +104,23 @@ public class ActivityEndpoint {
       @RequestParam(required = false) String familyLotNumber
   ) {
     return activityService.validateAddGermTest(activityTypeCd, seedlotNumber, familyLotNumber);
+  }
+
+  /**
+   * Retrieves all standard activities that correspond to a germination test type, ordered by
+   * activity description for use in a dropdown.
+   *
+   * @return a list of {@link StandardActivityDto} representing germination test activity types
+   */
+  @GetMapping("/germination-test-types")
+  @ApiResponse(
+      responseCode = "200",
+      description = "Successfully retrieved germination test activity types.",
+      content = @Content(schema = @Schema(implementation = StandardActivityDto.class))
+  )
+  @ApiAuthResponse
+  @RoleAccessConfig({"SPAR_TSC_SUBMITTER", "SPAR_TSC_SUPERVISOR"})
+  public List<StandardActivityDto> getGerminationTestTypes() {
+    return activityService.getGerminationTestTypes();
   }
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/StandardActivityRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/StandardActivityRepository.java
@@ -10,7 +10,8 @@ import org.springframework.data.jpa.repository.Query;
  * from consep to be retrieved from the database.
  */
 public interface StandardActivityRepository extends JpaRepository<StandardActivityEntity, String> {
-  @Query("""
+  @Query(
+      """
       SELECT sa
       FROM StandardActivityEntity sa
       JOIN TestCodeEntity c
@@ -18,4 +19,14 @@ public interface StandardActivityRepository extends JpaRepository<StandardActivi
       WHERE c.id.columnName = 'FAMILYLOT_TEST_CD'
       """)
   List<StandardActivityEntity> findAllFamilyLotActivities();
+
+  @Query(
+      """
+      SELECT sa
+      FROM StandardActivityEntity sa
+      JOIN TestRegimeEntity r
+      ON sa.activityTypeCd = r.seedlotTestCode
+      ORDER BY sa.activityDesc
+      """)
+  List<StandardActivityEntity> findGerminationTestActivities();
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/ActivityService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/ActivityService.java
@@ -39,6 +39,17 @@ public class ActivityService {
   private final TestRegimeRepository testRegimeRepository;
   private final SparRequestRepository sparRequestRepository;
 
+  private StandardActivityDto toStandardActivityDto(StandardActivityEntity a) {
+    return new StandardActivityDto(
+        a.getStandardActivityId(),
+        a.getActivityDesc(),
+        a.getActivityTypeCd(),
+        a.getTestCategoryCd(),
+        a.getSignificantStatusIndicator(),
+        a.getActivityDuration(),
+        a.getActivityTimeUnit());
+  }
+
   /**
    * Update activity table.
    *
@@ -240,8 +251,8 @@ public class ActivityService {
   }
 
   /**
-   * Retrieves all unique standard activity IDs and descriptions
-   * used for seedlot and/or family lot contexts.
+   * Retrieves all unique standard activity IDs and descriptions used for seedlot and/or family lot
+   * contexts.
    *
    * @param isFamilyLot true for familylot
    * @param isSeedlot true for seedlot
@@ -267,18 +278,10 @@ public class ActivityService {
     }
     return map.values().stream()
         .sorted(
-            Comparator.comparing(StandardActivityEntity::getActivityDesc,
-                Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
-        )
-        .map(a -> new StandardActivityDto(
-            a.getStandardActivityId(),
-            a.getActivityDesc(),
-            a.getActivityTypeCd(),
-            a.getTestCategoryCd(),
-            a.getSignificantStatusIndicator(),
-            a.getActivityDuration(),
-            a.getActivityTimeUnit()
-        ))
+            Comparator.comparing(
+                StandardActivityEntity::getActivityDesc,
+                Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+        .map(this::toStandardActivityDto)
         .toList();
   }
 
@@ -401,16 +404,7 @@ public class ActivityService {
    */
   public List<StandardActivityDto> getGerminationTestTypes() {
     return standardActivityRepository.findGerminationTestActivities().stream()
-        .map(
-            a ->
-                new StandardActivityDto(
-                    a.getStandardActivityId(),
-                    a.getActivityDesc(),
-                    a.getActivityTypeCd(),
-                    a.getTestCategoryCd(),
-                    a.getSignificantStatusIndicator(),
-                    a.getActivityDuration(),
-                    a.getActivityTimeUnit()))
+        .map(this::toStandardActivityDto)
         .toList();
   }
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/ActivityService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/ActivityService.java
@@ -392,4 +392,25 @@ public class ActivityService {
         null
     );
   }
+
+  /**
+   * Retrieves all standard activities that correspond to a germination test type, ordered by
+   * activity description for display in a dropdown.
+   *
+   * @return list of StandardActivityDto
+   */
+  public List<StandardActivityDto> getGerminationTestTypes() {
+    return standardActivityRepository.findGerminationTestActivities().stream()
+        .map(
+            a ->
+                new StandardActivityDto(
+                    a.getStandardActivityId(),
+                    a.getActivityDesc(),
+                    a.getActivityTypeCd(),
+                    a.getTestCategoryCd(),
+                    a.getSignificantStatusIndicator(),
+                    a.getActivityDuration(),
+                    a.getActivityTimeUnit()))
+        .toList();
+  }
 }

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpointTest.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.oracleapi.endpoint.consep;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -376,4 +377,45 @@ class ActivityEndpointTest {
         .validateAddGermTest(activityTypeCd, null, null);
   }
 
+  /* ----------------------- Get Germination Test Types ----------------------------*/
+  @Test
+  void getGerminationTestTypes_shouldReturn200AndList() throws Exception {
+    var dto1 = new StandardActivityDto("G11", "Germination Test 11", "G11", "GM", 0, 10, "DY");
+
+    var dto2 = new StandardActivityDto("G10", "Germination Test 10", "G10", "GM", -1, 14, "DY");
+
+    when(activityService.getGerminationTestTypes()).thenReturn(List.of(dto1, dto2));
+
+    mockMvc
+        .perform(get("/api/activities/germination-test-types").with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$[0].standardActivityId").value(dto1.standardActivityId()))
+        .andExpect(jsonPath("$[0].activityDescription").value(dto1.activityDescription()))
+        .andExpect(jsonPath("$[0].activityTypeCd").value(dto1.activityTypeCd()))
+        .andExpect(jsonPath("$[0].testCategoryCd").value(dto1.testCategoryCd()))
+        .andExpect(
+            jsonPath("$[0].significantStatusIndicator").value(dto1.significantStatusIndicator()))
+        .andExpect(jsonPath("$[0].activityDuration").value(dto1.activityDuration()))
+        .andExpect(jsonPath("$[0].activityTimeUnit").value(dto1.activityTimeUnit()))
+        .andExpect(jsonPath("$[1].standardActivityId").value(dto2.standardActivityId()))
+        .andExpect(jsonPath("$[1].activityDescription").value(dto2.activityDescription()))
+        .andExpect(jsonPath("$[1].activityTypeCd").value(dto2.activityTypeCd()));
+
+    verify(activityService, times(1)).getGerminationTestTypes();
+  }
+
+  @Test
+  void getGerminationTestTypes_shouldReturn200_withEmptyList() throws Exception {
+    when(activityService.getGerminationTestTypes()).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/activities/germination-test-types").with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$", hasSize(0)));
+
+    verify(activityService, times(1)).getGerminationTestTypes();
+  }
 }

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/ActivityEndpointTest.java
@@ -2,7 +2,6 @@ package ca.bc.gov.oracleapi.endpoint.consep;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/ActivityServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/ActivityServiceTest.java
@@ -43,7 +43,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-
 /**
  * The test class for Moisture Content Service.
  */
@@ -628,7 +627,8 @@ class ActivityServiceTest {
       + " matchesCurrentTypeCode true when no current A-rank exists")
   void validateAddGermTest_shouldReturnTrueWhenNoCurrentRankA() {
     when(testRegimeRepository.findAllGermTestActivityTypeCodes()).thenReturn(List.of("G11", "G12"));
-    when(activityRepository.findTypeCodeForAcceptedGermTestRankA("00098", null)).thenReturn(List.of());
+    when(activityRepository.findTypeCodeForAcceptedGermTestRankA("00098", null))
+        .thenReturn(List.of());
 
     AddGermTestValidationResponseDto result =
         activityService.validateAddGermTest("G11", "00098", null);
@@ -704,4 +704,59 @@ class ActivityServiceTest {
     );
   }
 
+  /* ----------------------- Get Germination Test Types ----------------------------*/
+  @Test
+  void getGerminationTestTypes_shouldReturnMappedDtos_whenActivitiesExist() {
+    StandardActivityEntity activity1 = new StandardActivityEntity();
+    activity1.setStandardActivityId("G11");
+    activity1.setActivityTypeCd("G11");
+    activity1.setTestCategoryCd("GM");
+    activity1.setActivityDesc("Germination Test 11");
+    activity1.setSignificantStatusIndicator(0);
+    activity1.setActivityDuration(10);
+    activity1.setActivityTimeUnit("DY");
+
+    StandardActivityEntity activity2 = new StandardActivityEntity();
+    activity2.setStandardActivityId("G10");
+    activity2.setActivityTypeCd("G10");
+    activity2.setTestCategoryCd("GM");
+    activity2.setActivityDesc("Germination Test 10");
+    activity2.setSignificantStatusIndicator(-1);
+    activity2.setActivityDuration(14);
+    activity2.setActivityTimeUnit("DY");
+
+    when(standardActivityRepository.findGerminationTestActivities())
+        .thenReturn(List.of(activity1, activity2));
+
+    List<StandardActivityDto> result = activityService.getGerminationTestTypes();
+
+    assertThat(result)
+        .hasSize(2)
+        .extracting(StandardActivityDto::standardActivityId)
+        .containsExactly(activity1.getStandardActivityId(), activity2.getStandardActivityId());
+
+    assertThat(result)
+        .extracting(StandardActivityDto::activityTypeCd)
+        .containsExactly(activity1.getActivityTypeCd(), activity2.getActivityTypeCd());
+
+    assertThat(result)
+        .extracting(StandardActivityDto::activityDescription)
+        .containsExactly(activity1.getActivityDesc(), activity2.getActivityDesc());
+
+    assertThat(result)
+        .extracting(StandardActivityDto::testCategoryCd)
+        .containsExactly(activity1.getTestCategoryCd(), activity2.getTestCategoryCd());
+
+    verify(standardActivityRepository, times(1)).findGerminationTestActivities();
+  }
+
+  @Test
+  void getGerminationTestTypes_shouldReturnEmpty_whenNoActivitiesExist() {
+    when(standardActivityRepository.findGerminationTestActivities()).thenReturn(List.of());
+
+    List<StandardActivityDto> result = activityService.getGerminationTestTypes();
+
+    assertThat(result).isEmpty();
+    verify(standardActivityRepository, times(1)).findGerminationTestActivities();
+  }
 }


### PR DESCRIPTION
# Description
Closes #2398 

### Changelog
#### New
- Add API for getting the test type for the germination test

#### Changed
-

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-20.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2420-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2420-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)