### PR TITLE
feat: enable deletion of germ tray and contents from the ui

### DIFF
--- a/frontend/src/api-service/consep/germinatorTrayAPI.ts
+++ b/frontend/src/api-service/consep/germinatorTrayAPI.ts
@@ -1,7 +1,12 @@
 import ApiConfig from '../ApiConfig';
 import api from '../api';
 import { CreateGermTrayRequest } from '../../views/CONSEP/TestingActivities/TestSearch/ToolbarControls/CreateGermTray/definitions';
-import { GermTrayTestType, GermTrayCreateResponseType, GerminatorIdAssignResponseDto } from '../../types/consep/GerminatorTrayType';
+import {
+  GermTrayTestType,
+  GermTrayCreateResponseType,
+  GermTrayDeleteContentType,
+  GerminatorIdAssignResponseDto
+} from '../../types/consep/GerminatorTrayType';
 
 export const assignGerminatorTrays = (
   requests: CreateGermTrayRequest[]
@@ -39,4 +44,13 @@ export const deleteTestFromTray = (
       + `?activityUpdateTimestamp=${encodeURIComponent(activityUpdateTimestamp)}`;
 
   return api.delete(url).then(() => undefined);
+};
+
+export const deleteGerminatorTray = (
+  germinatorTrayId: number,
+  contents: GermTrayDeleteContentType[]
+): Promise<void> => {
+  const url = `${ApiConfig.germinatorTrays}/${germinatorTrayId}/delete`;
+
+  return api.post(url, contents).then(() => undefined);
 };

--- a/frontend/src/api-service/consep/germinatorTrayAPI.ts
+++ b/frontend/src/api-service/consep/germinatorTrayAPI.ts
@@ -29,3 +29,14 @@ export const getGerminatorTrayContents = (
   const url = `${ApiConfig.germinatorTrays}/${germinatorTrayId}/tests`;
   return api.get(url).then((res: { data: GermTrayTestType[] }) => res.data);
 };
+
+export const deleteTestFromTray = (
+  germinatorTrayId: number,
+  riaSkey: number,
+  activityUpdateTimestamp: string
+): Promise<void> => {
+  const url = `${ApiConfig.germinatorTrays}/${germinatorTrayId}/tests/${riaSkey}`
+      + `?activityUpdateTimestamp=${encodeURIComponent(activityUpdateTimestamp)}`;
+
+  return api.delete(url).then(() => undefined);
+};

--- a/frontend/src/types/consep/GerminatorTrayType.ts
+++ b/frontend/src/types/consep/GerminatorTrayType.ts
@@ -22,3 +22,8 @@ export type GermTrayTestType = {
   riaSkey: number | null;
   updateTimestamp: string | null;
 };
+
+export type GermTrayDeleteContentType = {
+  riaSkey: number;
+  updateTimestamp: string;
+};

--- a/frontend/src/types/consep/GerminatorTrayType.ts
+++ b/frontend/src/types/consep/GerminatorTrayType.ts
@@ -19,4 +19,6 @@ export type GermTrayTestType = {
   stratStartDate: string | null;
   testCompleteInd: -1 | 0;
   acceptResultInd: -1 | 0;
+  riaSkey: number;
+  updateTimestamp: string;
 };

--- a/frontend/src/types/consep/GerminatorTrayType.ts
+++ b/frontend/src/types/consep/GerminatorTrayType.ts
@@ -19,6 +19,6 @@ export type GermTrayTestType = {
   stratStartDate: string | null;
   testCompleteInd: -1 | 0;
   acceptResultInd: -1 | 0;
-  riaSkey: number;
-  updateTimestamp: string;
+  riaSkey: number | null;
+  updateTimestamp: string | null;
 };

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { type MRT_ColumnDef } from 'material-react-table';
 import { Checkbox } from '@mui/material';
+import { Button } from '@carbon/react';
 import { TrashCan } from '@carbon/icons-react';
 import { formatDateCell } from '../../TestSearch/constants';
 import { GermTrayColumn } from './definitions';
@@ -116,11 +117,15 @@ export const getGermTrayTestsColumns = (
     enableEditing: false,
     size: 50,
     Cell: ({ row }: { row: { original: GermTrayTestType } }) => (
-      <TrashCan
-        size={15}
-        style={{ cursor: 'pointer' }}
+      <Button
+        kind="ghost"
+        size="sm"
+        aria-label="Remove from tray"
+        disabled={row.original.riaSkey == null || row.original.updateTimestamp == null}
         onClick={() => onDeleteRow?.(row.original)}
-      />
+      >
+        <TrashCan size={15} />
+      </Button>
     )
   }
 ];

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { type MRT_ColumnDef } from 'material-react-table';
 import { Checkbox } from '@mui/material';
-import { Icons } from '@carbon/icons-react';
+import { TrashCan } from '@carbon/icons-react';
 import { formatDateCell } from '../../TestSearch/constants';
 import { GermTrayColumn } from './definitions';
 import { GermTrayTestType } from '../../../../../types/consep/GerminatorTrayType';
@@ -116,7 +116,7 @@ export const getGermTrayTestsColumns = (
     enableEditing: false,
     size: 50,
     Cell: ({ row }: { row: { original: GermTrayTestType } }) => (
-      <Icons.TrashCan
+      <TrashCan
         size={15}
         style={{ cursor: 'pointer' }}
         onClick={() => onDeleteRow?.(row.original)}

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
@@ -13,7 +13,8 @@ import { GermTrayTestType } from '../../../../../types/consep/GerminatorTrayType
 const isIndicatorChecked = (value: unknown): boolean => value === -1 || value === 1;
 
 export const getGermTrayColumns = (
-  updateRow: (row: GermTrayColumn) => void
+  updateRow: (row: GermTrayColumn) => void,
+  onDeleteTray?: (row: GermTrayColumn) => void
 ): MRT_ColumnDef<GermTrayColumn>[] => [
   {
     accessorKey: 'germinatorTrayId',
@@ -44,6 +45,28 @@ export const getGermTrayColumns = (
         });
       }
     })
+  },
+  {
+    accessorKey: 'actions',
+    header: '',
+    enableSorting: false,
+    enableEditing: false,
+    size: 50,
+    muiTableHeadCellProps: { align: 'center' },
+    muiTableBodyCellProps: { align: 'center' },
+    Cell: ({ row }: { row: { original: GermTrayColumn } }) => (
+      <Button
+        kind="ghost"
+        size="sm"
+        aria-label="Delete tray"
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          onDeleteTray?.(row.original);
+        }}
+      >
+        <TrashCan size={15} />
+      </Button>
+    )
   }
 ];
 
@@ -53,41 +76,48 @@ export const getGermTrayTestsColumns = (
   {
     accessorKey: 'seedlotNumber',
     header: 'Lot #',
-    enableEditing: false
+    enableEditing: false,
+    size: 80
   },
   {
     accessorKey: 'requestId',
     header: 'Request ID',
-    enableEditing: false
+    enableEditing: false,
+    size: 120
   },
   {
     accessorKey: 'warmStratStartDate',
     header: 'Warm strat date',
     enableEditing: false,
+    size: 110,
     Cell: ({ cell }) => formatDateCell(cell.getValue<string | null>())
   },
   {
     accessorKey: 'drybackStartDate',
     header: 'Dryback',
     enableEditing: false,
+    size: 90,
     Cell: ({ cell }) => formatDateCell(cell.getValue<string | null>())
   },
   {
     accessorKey: 'stratStartDate',
     header: 'Cold strat start',
     enableEditing: false,
+    size: 110,
     Cell: ({ cell }) => formatDateCell(cell.getValue<string | null>())
   },
   {
     accessorKey: 'germinatorEntry',
     header: 'Germinator Entry',
     enableEditing: false,
+    size: 120,
     Cell: ({ cell }) => formatDateCell(cell.getValue<string | null>())
   },
   {
     accessorKey: 'testCompleteInd',
     header: 'Complete',
     enableEditing: false,
+    size: 80,
     muiTableHeadCellProps: { align: 'center' },
     muiTableBodyCellProps: { align: 'center' },
     Cell: ({ cell }) => (
@@ -101,6 +131,7 @@ export const getGermTrayTestsColumns = (
     accessorKey: 'acceptResultInd',
     header: 'Accepted',
     enableEditing: false,
+    size: 80,
     muiTableHeadCellProps: { align: 'center' },
     muiTableBodyCellProps: { align: 'center' },
     Cell: ({ cell }) => (
@@ -116,6 +147,8 @@ export const getGermTrayTestsColumns = (
     enableSorting: false,
     enableEditing: false,
     size: 50,
+    muiTableHeadCellProps: { align: 'center' },
+    muiTableBodyCellProps: { align: 'center' },
     Cell: ({ row }: { row: { original: GermTrayTestType } }) => (
       <Button
         kind="ghost"

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/constants.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { type MRT_ColumnDef } from 'material-react-table';
 import { Checkbox } from '@mui/material';
+import { Icons } from '@carbon/icons-react';
 import { formatDateCell } from '../../TestSearch/constants';
 import { GermTrayColumn } from './definitions';
 import { GermTrayTestType } from '../../../../../types/consep/GerminatorTrayType';
@@ -45,7 +46,9 @@ export const getGermTrayColumns = (
   }
 ];
 
-export const getGermTrayTestsColumns = (): MRT_ColumnDef<GermTrayTestType>[] => [
+export const getGermTrayTestsColumns = (
+  onDeleteRow?: (row: GermTrayTestType) => void
+): MRT_ColumnDef<GermTrayTestType>[] => [
   {
     accessorKey: 'seedlotNumber',
     header: 'Lot #',
@@ -103,6 +106,20 @@ export const getGermTrayTestsColumns = (): MRT_ColumnDef<GermTrayTestType>[] => 
       <Checkbox
         checked={isIndicatorChecked(cell.getValue<number | null>())}
         disabled
+      />
+    )
+  },
+  {
+    accessorKey: 'actions',
+    header: '',
+    enableSorting: false,
+    enableEditing: false,
+    size: 50,
+    Cell: ({ row }: { row: { original: GermTrayTestType } }) => (
+      <Icons.TrashCan
+        size={15}
+        style={{ cursor: 'pointer' }}
+        onClick={() => onDeleteRow?.(row.original)}
       />
     )
   }

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/index.tsx
@@ -58,11 +58,12 @@ const MaintainGermTray = () => {
   }, []);
 
   const deleteFromTrayMutation = useMutation({
-    mutationFn: (row: GermTrayTestType) => deleteTestFromTray(
-      row.germinatorTrayId,
-      row.riaSkey,
-      row.updateTimestamp
-    ),
+    mutationFn: (row: GermTrayTestType) => {
+      if (row.riaSkey == null || row.updateTimestamp == null) {
+        return Promise.reject(new Error('Cannot delete: missing test data'));
+      }
+      return deleteTestFromTray(row.germinatorTrayId, row.riaSkey, row.updateTimestamp);
+    },
     onSuccess: (_, row) => {
       setAlert(null);
       const remainingCount = (trayContentsQuery.data?.length ?? 0) - 1;
@@ -70,7 +71,7 @@ const MaintainGermTray = () => {
         setTrays((prev) => prev.filter((t) => t.germinatorTrayId !== row.germinatorTrayId));
         setSelectedTrayId(null);
       } else {
-        queryClient.invalidateQueries({ queryKey: ['germinatorTrayContents', selectedTrayId] });
+        queryClient.invalidateQueries({ queryKey: ['germinatorTrayContents', row.germinatorTrayId] });
       }
     },
     onError: (error: any) => {
@@ -133,6 +134,10 @@ const MaintainGermTray = () => {
   }, [trays, assignMutation]);
 
   const germTrayColumns = useMemo(() => getGermTrayColumns(updateRow), [updateRow]);
+  const germTrayTestsColumns = useMemo(
+    () => getGermTrayTestsColumns((row) => deleteFromTrayMutation.mutate(row)),
+    [deleteFromTrayMutation]
+  );
 
   return (
     <FlexGrid className="consep-maintain-germ-tray">
@@ -166,7 +171,7 @@ const MaintainGermTray = () => {
       </Row>
       <Row className="consep-maintain-germ-tray-tests-table">
         <GenericTable
-          columns={getGermTrayTestsColumns((row) => deleteFromTrayMutation.mutate(row))}
+          columns={germTrayTestsColumns}
           data={(trayContentsQuery.data ?? [])}
           isLoading={trayContentsQuery.isLoading}
           hideToolbar

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/index.tsx
@@ -7,13 +7,27 @@ import React, {
 } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { FlexGrid, Row, InlineNotification } from '@carbon/react';
+import {
+  FlexGrid,
+  Row,
+  InlineNotification,
+  Modal
+} from '@carbon/react';
 import GenericTable from '../../../../../components/GenericTable';
 import ROUTES from '../../../../../routes/constants';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
 import PageTitle from '../../../../../components/PageTitle';
-import { assignGerminatorId, deleteTestFromTray, getGerminatorTrayContents } from '../../../../../api-service/consep/germinatorTrayAPI';
-import { GermTrayCreateResponseType, GermTrayTestType } from '../../../../../types/consep/GerminatorTrayType';
+import {
+  assignGerminatorId,
+  deleteTestFromTray,
+  deleteGerminatorTray,
+  getGerminatorTrayContents
+} from '../../../../../api-service/consep/germinatorTrayAPI';
+import {
+  GermTrayCreateResponseType,
+  GermTrayDeleteContentType,
+  GermTrayTestType
+} from '../../../../../types/consep/GerminatorTrayType';
 import { getGermTrayColumns, getGermTrayTestsColumns } from './constants';
 import { GermTrayColumn } from './definitions';
 import './styles.scss';
@@ -36,6 +50,8 @@ const MaintainGermTray = () => {
   const [trays, setTrays] = useState<GermTrayColumn[]>(germinatorTrays);
   const lastSyncedRef = useRef<string | null>(JSON.stringify(germinatorTrays));
   const [selectedTrayId, setSelectedTrayId] = useState<number | null>(null);
+  const [pendingDeleteTray, setPendingDeleteTray] = useState<GermTrayColumn | null>(null);
+  const [pendingDeleteTest, setPendingDeleteTest] = useState<GermTrayTestType | null>(null);
 
   const trayContentsQuery = useQuery({
     queryKey: ['germinatorTrayContents', selectedTrayId],
@@ -79,6 +95,56 @@ const MaintainGermTray = () => {
       setAlert({ status: 'error', message });
     }
   });
+
+  const deleteTrayMutation = useMutation({
+    mutationFn: async (tray: GermTrayColumn) => {
+      const queryKey = [
+        'germinatorTrayContents',
+        tray.germinatorTrayId
+      ];
+      const cachedContents = queryClient.getQueryData<GermTrayTestType[]>(queryKey);
+      const contents = cachedContents ?? await queryClient.fetchQuery<GermTrayTestType[]>({
+        queryKey,
+        queryFn: () => getGerminatorTrayContents(tray.germinatorTrayId)
+      });
+
+      const deleteContents: GermTrayDeleteContentType[] = contents.map((content) => {
+        if (content.riaSkey == null || content.updateTimestamp == null) {
+          throw new Error('Cannot delete: missing test data');
+        }
+        return {
+          riaSkey: content.riaSkey,
+          updateTimestamp: content.updateTimestamp
+        };
+      });
+
+      return deleteGerminatorTray(tray.germinatorTrayId, deleteContents);
+    },
+    onSuccess: (_, tray) => {
+      setAlert(null);
+      setTrays((prev) => prev.filter((t) => t.germinatorTrayId !== tray.germinatorTrayId));
+      if (selectedTrayId === tray.germinatorTrayId) {
+        setSelectedTrayId(null);
+        queryClient.removeQueries({ queryKey: ['germinatorTrayContents', tray.germinatorTrayId] });
+      }
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Failed to delete tray';
+      setAlert({ status: 'error', message });
+    }
+  });
+
+  const handleConfirmDeleteTray = useCallback(() => {
+    if (!pendingDeleteTray) return;
+    deleteTrayMutation.mutate(pendingDeleteTray);
+    setPendingDeleteTray(null);
+  }, [pendingDeleteTray, deleteTrayMutation]);
+
+  const handleConfirmDeleteTest = useCallback(() => {
+    if (!pendingDeleteTest) return;
+    deleteFromTrayMutation.mutate(pendingDeleteTest);
+    setPendingDeleteTest(null);
+  }, [pendingDeleteTest, deleteFromTrayMutation]);
 
   const assignMutation = useMutation({
     mutationFn: ({
@@ -133,10 +199,22 @@ const MaintainGermTray = () => {
     return () => clearInterval(interval);
   }, [trays, assignMutation]);
 
-  const germTrayColumns = useMemo(() => getGermTrayColumns(updateRow), [updateRow]);
+  const handleDeleteTrayClick = useCallback(
+    (tray: GermTrayColumn) => setPendingDeleteTray(tray),
+    []
+  );
+  const handleDeleteTestClick = useCallback(
+    (test: GermTrayTestType) => setPendingDeleteTest(test),
+    []
+  );
+
+  const germTrayColumns = useMemo(
+    () => getGermTrayColumns(updateRow, handleDeleteTrayClick),
+    [updateRow, handleDeleteTrayClick]
+  );
   const germTrayTestsColumns = useMemo(
-    () => getGermTrayTestsColumns((row) => deleteFromTrayMutation.mutate(row)),
-    [deleteFromTrayMutation]
+    () => getGermTrayTestsColumns(handleDeleteTestClick),
+    [handleDeleteTestClick]
   );
 
   return (
@@ -181,6 +259,33 @@ const MaintainGermTray = () => {
           }}
         />
       </Row>
+      <Modal
+        open={pendingDeleteTray !== null}
+        danger
+        size="sm"
+        modalHeading="Confirm deletion"
+        primaryButtonText="Delete germ tray"
+        secondaryButtonText="Back"
+        onRequestSubmit={handleConfirmDeleteTray}
+        onRequestClose={() => setPendingDeleteTray(null)}
+      >
+        <p>
+          {`Please confirm you want to delete germination tray ${pendingDeleteTray?.germinatorTrayId}. This action cannot be undone.`}
+        </p>
+      </Modal>
+      <Modal
+        open={pendingDeleteTest !== null}
+        danger
+        modalHeading="Confirm deletion"
+        primaryButtonText="Delete germ test"
+        secondaryButtonText="Back"
+        onRequestSubmit={handleConfirmDeleteTest}
+        onRequestClose={() => setPendingDeleteTest(null)}
+      >
+        <p>
+          {`Please confirm you want to delete germination test ID ${pendingDeleteTest?.requestId} for seedlot #${pendingDeleteTest?.seedlotNumber}. This action cannot be undone.`}
+        </p>
+      </Modal>
     </FlexGrid>
   );
 };

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/index.tsx
@@ -6,14 +6,14 @@ import React, {
   useCallback
 } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { FlexGrid, Row, InlineNotification } from '@carbon/react';
 import GenericTable from '../../../../../components/GenericTable';
 import ROUTES from '../../../../../routes/constants';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
 import PageTitle from '../../../../../components/PageTitle';
-import { assignGerminatorId, getGerminatorTrayContents } from '../../../../../api-service/consep/germinatorTrayAPI';
-import { GermTrayCreateResponseType } from '../../../../../types/consep/GerminatorTrayType';
+import { assignGerminatorId, deleteTestFromTray, getGerminatorTrayContents } from '../../../../../api-service/consep/germinatorTrayAPI';
+import { GermTrayCreateResponseType, GermTrayTestType } from '../../../../../types/consep/GerminatorTrayType';
 import { getGermTrayColumns, getGermTrayTestsColumns } from './constants';
 import { GermTrayColumn } from './definitions';
 import './styles.scss';
@@ -22,6 +22,7 @@ const BREAD_CRUMB_ITEMS = [{ name: 'CONSEP', path: ROUTES.CONSEP_FAVOURITE_ACTIV
 
 const MaintainGermTray = () => {
   const location = useLocation();
+  const queryClient = useQueryClient();
   const germinatorTrays = location.state?.germinatorTrays?.map(
     (tray: GermTrayCreateResponseType) => ({
       ...tray,
@@ -55,6 +56,28 @@ const MaintainGermTray = () => {
   const handleTrayRowClick = useCallback((row: GermTrayColumn) => {
     setSelectedTrayId(row.germinatorTrayId);
   }, []);
+
+  const deleteFromTrayMutation = useMutation({
+    mutationFn: (row: GermTrayTestType) => deleteTestFromTray(
+      row.germinatorTrayId,
+      row.riaSkey,
+      row.updateTimestamp
+    ),
+    onSuccess: (_, row) => {
+      setAlert(null);
+      const remainingCount = (trayContentsQuery.data?.length ?? 0) - 1;
+      if (remainingCount === 0) {
+        setTrays((prev) => prev.filter((t) => t.germinatorTrayId !== row.germinatorTrayId));
+        setSelectedTrayId(null);
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['germinatorTrayContents', selectedTrayId] });
+      }
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Failed to remove test from tray';
+      setAlert({ status: 'error', message });
+    }
+  });
 
   const assignMutation = useMutation({
     mutationFn: ({
@@ -110,7 +133,6 @@ const MaintainGermTray = () => {
   }, [trays, assignMutation]);
 
   const germTrayColumns = useMemo(() => getGermTrayColumns(updateRow), [updateRow]);
-  const germTrayTestsColumns = useMemo(() => getGermTrayTestsColumns(), []);
 
   return (
     <FlexGrid className="consep-maintain-germ-tray">
@@ -144,7 +166,7 @@ const MaintainGermTray = () => {
       </Row>
       <Row className="consep-maintain-germ-tray-tests-table">
         <GenericTable
-          columns={germTrayTestsColumns}
+          columns={getGermTrayTestsColumns((row) => deleteFromTrayMutation.mutate(row))}
           data={(trayContentsQuery.data ?? [])}
           isLoading={trayContentsQuery.isLoading}
           hideToolbar

--- a/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/styles.scss
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray/styles.scss
@@ -11,6 +11,7 @@
   .consep-maintain-germ-tray-table, .consep-maintain-germ-tray-alert {
     margin-top: 0.5rem;
     width: 50%;
-    min-width: 46rem;
+    min-width: 52rem;
   }
+
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminatorTrayContentsDto.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminatorTrayContentsDto.java
@@ -28,6 +28,9 @@ public record GerminatorTrayContentsDto(
     @Schema(description = "Accept result indicator", example = "0")
     Integer acceptResultInd,
 
+    @Schema(description = "Request item activity key", example = "12345")
+    java.math.BigDecimal riaSkey,
+
     @Schema(description = "Timestamp for the last update", example = "2025-01-20T12:00:00")
     LocalDateTime updateTimestamp
 ) {

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminatorTrayDeleteContentDto.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminatorTrayDeleteContentDto.java
@@ -1,0 +1,18 @@
+package ca.bc.gov.oracleapi.dto.consep;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/** A DTO containing optimistic-lock data for deleting one germinator tray content item. */
+public record GerminatorTrayDeleteContentDto(
+    @NotNull
+    @Schema(description = "Request item activity key", example = "12345")
+    BigDecimal riaSkey,
+
+    @NotNull
+    @Schema(description = "Activity update timestamp originally fetched by the user")
+    LocalDateTime updateTimestamp
+) {
+}

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpoint.java
@@ -4,6 +4,7 @@ import ca.bc.gov.oracleapi.dto.consep.GerminatorIdAssignResponseDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayContentsDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayCreateDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayCreateResponseDto;
+import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayDeleteContentDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchRequestDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchResponseDto;
 import ca.bc.gov.oracleapi.response.ApiAuthResponse;
@@ -136,12 +137,14 @@ public class GerminatorTrayEndpoint {
 
   /**
    * Deletes a germinator tray. All tests on the tray are detached, each parent activity's
-   * update_timestamp is updated, then the tray is deleted. Uses optimistic concurrency; if any
-   * DML affects 0 rows, returns 409 and rolls back.
+   * update_timestamp is updated, then the tray is deleted. Uses optimistic concurrency with the
+   * original timestamp for each tray content item; if any DML affects 0 rows, returns 409 and
+   * rolls back.
    *
    * @param germinatorTrayId the tray to delete
+   * @param contents         the tray contents with the activity timestamps
    */
-  @DeleteMapping("/{germinatorTrayId}")
+  @PostMapping("/{germinatorTrayId}/delete")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiResponse(responseCode = "204", description = "Tray deleted.")
   @ApiResponse(responseCode = "404", description = "Tray not found.")
@@ -150,9 +153,9 @@ public class GerminatorTrayEndpoint {
   @RoleAccessConfig({ "SPAR_TSC_SUBMITTER", "SPAR_TSC_SUPERVISOR" })
   public void deleteTray(
     @PathVariable Integer germinatorTrayId,
-    @RequestParam @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime activityUpdateTimestamp
+    @Valid @RequestBody List<@Valid GerminatorTrayDeleteContentDto> contents
   ) {
-    germinatorTrayService.deleteTray(germinatorTrayId, activityUpdateTimestamp);
+    germinatorTrayService.deleteTray(germinatorTrayId, contents);
   }
 
   /**

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayService.java
@@ -247,6 +247,7 @@ public class GerminatorTrayService {
         entity.getStratStartDate(),
         entity.getTestCompleteInd(),
         entity.getAcceptResultInd(),
+        entity.getRiaSkey(),
         updateTimestamp);
   }
 

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayService.java
@@ -3,6 +3,7 @@ package ca.bc.gov.oracleapi.service.consep;
 import ca.bc.gov.oracleapi.config.SparLog;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorIdAssignResponseDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayContentsDto;
+import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayDeleteContentDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchRequestDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchResponseDto;
 import ca.bc.gov.oracleapi.entity.consep.GerminationTrayContentsEntity;
@@ -14,7 +15,10 @@ import ca.bc.gov.oracleapi.repository.consep.GerminatorTrayRepository;
 import ca.bc.gov.oracleapi.repository.consep.TestResultRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -155,18 +159,23 @@ public class GerminatorTrayService {
 
   /**
    * Delete a tray: detach all tests, update each parent activity timestamp, then delete the tray.
-   * Uses optimistic concurrency; if any DML affects 0 rows, throws and rolls back.
+   * Uses optimistic concurrency with one timestamp per tray item; if any DML affects 0 rows,
+   * throws and rolls back.
    *
    * @param germinatorTrayId the tray to delete
-   * @param activityUpdateTimestamp the current update_timestamp of the parent activity (optimistic lock)
-   * @throws ResponseStatusException 404 if tray not found, 409 with RESELECT_MESSAGE if any DML affects 0 rows
+   * @param contents the tray contents with the current update_timestamp of each parent activity
+   * @throws ResponseStatusException 404 if tray not found, 409 with RESELECT_MESSAGE if any
+   *         DML affects 0 rows
    */
   @Transactional(rollbackFor = ResponseStatusException.class)
-  public void deleteTray(Integer germinatorTrayId, LocalDateTime activityUpdateTimestamp) {
-    if (germinatorTrayId == null || activityUpdateTimestamp == null) {
+  public void deleteTray(
+      Integer germinatorTrayId,
+      List<GerminatorTrayDeleteContentDto> contents
+  ) {
+    if (germinatorTrayId == null || contents == null) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST,
-          "Germinator tray ID and activity update timestamp are required");
+          "Germinator tray ID and contents are required");
     }
 
     if (!germinatorTrayRepository.existsById(germinatorTrayId)) {
@@ -177,9 +186,13 @@ public class GerminatorTrayService {
 
     List<BigDecimal> riaKeys = testResultRepository.findRiaKeysByGerminatorTrayId(germinatorTrayId);
     SparLog.info("Deleting tray {} with {} tests", germinatorTrayId, riaKeys.size());
+    Map<BigDecimal, LocalDateTime> timestampsByRiaKey = getTimestampsByRiaKey(contents);
+    if (!timestampsByRiaKey.keySet().equals(new HashSet<>(riaKeys))) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, RESELECT_MESSAGE);
+    }
 
     for (BigDecimal riaKey : riaKeys) {
-      detachTestAndTouchParent(riaKey, activityUpdateTimestamp, germinatorTrayId);
+      detachTestAndTouchParent(riaKey, timestampsByRiaKey.get(riaKey), germinatorTrayId);
     }
 
     int deleteRows = germinatorTrayRepository.deleteByGerminatorTrayId(germinatorTrayId);
@@ -187,6 +200,25 @@ public class GerminatorTrayService {
       throw new ResponseStatusException(HttpStatus.CONFLICT, RESELECT_MESSAGE);
     }
     SparLog.info("Tray {} deleted", germinatorTrayId);
+  }
+
+  private Map<BigDecimal, LocalDateTime> getTimestampsByRiaKey(
+      List<GerminatorTrayDeleteContentDto> contents
+  ) {
+    Map<BigDecimal, LocalDateTime> timestampsByRiaKey = new HashMap<>();
+    for (GerminatorTrayDeleteContentDto content : contents) {
+      if (content == null || content.riaSkey() == null || content.updateTimestamp() == null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "RIA key and activity update timestamp are required for each tray content item");
+      }
+      if (timestampsByRiaKey.put(content.riaSkey(), content.updateTimestamp()) != null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "Duplicate RIA key in tray contents");
+      }
+    }
+    return timestampsByRiaKey;
   }
 
   /**

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayService.java
@@ -207,7 +207,7 @@ public class GerminatorTrayService {
   ) {
     Map<BigDecimal, LocalDateTime> timestampsByRiaKey = new HashMap<>();
     for (GerminatorTrayDeleteContentDto content : contents) {
-      if (content == null || content.riaSkey() == null || content.updateTimestamp() == null) {
+      if (content.riaSkey() == null || content.updateTimestamp() == null) {
         throw new ResponseStatusException(
             HttpStatus.BAD_REQUEST,
             "RIA key and activity update timestamp are required for each tray content item");

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpointTest.java
@@ -20,6 +20,7 @@ import ca.bc.gov.oracleapi.dto.consep.GerminatorIdAssignResponseDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayContentsDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayCreateDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayCreateResponseDto;
+import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayDeleteContentDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchRequestDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchResponseDto;
 import ca.bc.gov.oracleapi.service.consep.GerminatorTrayService;
@@ -626,24 +627,26 @@ class GerminatorTrayEndpointTest {
   void deleteTray_returns204_whenSuccessful() throws Exception {
     Integer germinatorTrayId = 101;
     LocalDateTime expectedTimestamp = LocalDateTime.parse("2025-03-12T00:00:00");
-    String timestamp = "2025-03-12T00:00:00";
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(new BigDecimal("881191"), expectedTimestamp));
 
-    doNothing().when(germinatorTrayService).deleteTray(germinatorTrayId, expectedTimestamp);
+    doNothing().when(germinatorTrayService).deleteTray(germinatorTrayId, contents);
 
     mockMvc
         .perform(
-            delete(BASE_URL + "/" + germinatorTrayId)
+            post(BASE_URL + "/" + germinatorTrayId + "/delete")
                 .with(csrf())
-                .param("activityUpdateTimestamp", timestamp))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(contents)))
         .andExpect(status().isNoContent());
 
-    verify(germinatorTrayService, times(1)).deleteTray(germinatorTrayId, expectedTimestamp);
+    verify(germinatorTrayService, times(1)).deleteTray(germinatorTrayId, contents);
   }
 
   @Test
-  void deleteTray_returns400_whenTimestampParamMissing() throws Exception {
-    // Missing required activityUpdateTimestamp param -> 400
-    mockMvc.perform(delete(BASE_URL + "/101").with(csrf())).andExpect(status().isBadRequest());
+  void deleteTray_returns400_whenRequestBodyMissing() throws Exception {
+    // Missing required tray contents body -> 400
+    mockMvc.perform(post(BASE_URL + "/101/delete").with(csrf())).andExpect(status().isBadRequest());
 
     verify(germinatorTrayService, times(0)).deleteTray(any(), any());
   }
@@ -652,44 +655,48 @@ class GerminatorTrayEndpointTest {
   void deleteTray_returns404_whenTrayNotFound() throws Exception {
     Integer germinatorTrayId = 999;
     LocalDateTime expectedTimestamp = LocalDateTime.parse("2025-03-12T00:00:00");
-    String timestamp = "2025-03-12T00:00:00";
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(new BigDecimal("881191"), expectedTimestamp));
 
     doThrow(
             new ResponseStatusException(
                 HttpStatus.NOT_FOUND, "Germinator tray not found with ID: " + germinatorTrayId))
         .when(germinatorTrayService)
-        .deleteTray(germinatorTrayId, expectedTimestamp);
+        .deleteTray(germinatorTrayId, contents);
 
     mockMvc
         .perform(
-            delete(BASE_URL + "/" + germinatorTrayId)
+            post(BASE_URL + "/" + germinatorTrayId + "/delete")
                 .with(csrf())
-                .param("activityUpdateTimestamp", timestamp))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(contents)))
         .andExpect(status().isNotFound());
 
-    verify(germinatorTrayService, times(1)).deleteTray(germinatorTrayId, expectedTimestamp);
+    verify(germinatorTrayService, times(1)).deleteTray(germinatorTrayId, contents);
   }
 
   @Test
   void deleteTray_returns409_whenOptimisticConcurrencyConflict() throws Exception {
     Integer germinatorTrayId = 101;
     LocalDateTime expectedTimestamp = LocalDateTime.parse("2025-03-12T00:00:00");
-    String timestamp = "2025-03-12T00:00:00";
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(new BigDecimal("881191"), expectedTimestamp));
 
     doThrow(
             new ResponseStatusException(
                 HttpStatus.CONFLICT, GerminatorTrayService.RESELECT_MESSAGE))
         .when(germinatorTrayService)
-        .deleteTray(germinatorTrayId, expectedTimestamp);
+        .deleteTray(germinatorTrayId, contents);
 
     mockMvc
         .perform(
-            delete(BASE_URL + "/" + germinatorTrayId)
+            post(BASE_URL + "/" + germinatorTrayId + "/delete")
                 .with(csrf())
-                .param("activityUpdateTimestamp", timestamp))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(contents)))
         .andExpect(status().isConflict());
 
-    verify(germinatorTrayService, times(1)).deleteTray(germinatorTrayId, expectedTimestamp);
+    verify(germinatorTrayService, times(1)).deleteTray(germinatorTrayId, contents);
   }
 
   @Test
@@ -697,9 +704,12 @@ class GerminatorTrayEndpointTest {
   void deleteTray_returns401_whenUnauthorized() throws Exception {
     mockMvc
         .perform(
-            delete(BASE_URL + "/101")
+            post(BASE_URL + "/101/delete")
                 .with(csrf())
-                .param("activityUpdateTimestamp", "2025-03-12T00:00:00"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    [{"riaSkey":881191,"updateTimestamp":"2025-03-12T00:00:00"}]
+                    """))
         .andExpect(status().isUnauthorized());
 
     verify(germinatorTrayService, times(0)).deleteTray(any(), any());
@@ -710,9 +720,12 @@ class GerminatorTrayEndpointTest {
   void deleteTray_returns403_whenUserDoesNotHaveRequiredRole() throws Exception {
     mockMvc
         .perform(
-            delete(BASE_URL + "/101")
+            post(BASE_URL + "/101/delete")
                 .with(csrf())
-                .param("activityUpdateTimestamp", "2025-03-12T00:00:00"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    [{"riaSkey":881191,"updateTimestamp":"2025-03-12T00:00:00"}]
+                    """))
         .andExpect(status().isForbidden());
 
     verify(germinatorTrayService, times(0)).deleteTray(any(), any());

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpointTest.java
@@ -375,6 +375,7 @@ class GerminatorTrayEndpointTest {
                 null,
                 null,
                 null,
+                null,
                 null
             ));
 

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminatorTrayEndpointTest.java
@@ -652,6 +652,40 @@ class GerminatorTrayEndpointTest {
   }
 
   @Test
+  void deleteTray_returns400_whenRiaSkeyIsNull() throws Exception {
+    String body = """
+        [{"riaSkey":null,"updateTimestamp":"2025-03-12T00:00:00"}]
+        """;
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/101/delete")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isBadRequest());
+
+    verify(germinatorTrayService, times(0)).deleteTray(any(), any());
+  }
+
+  @Test
+  void deleteTray_returns400_whenUpdateTimestampIsNull() throws Exception {
+    String body = """
+        [{"riaSkey":881191,"updateTimestamp":null}]
+        """;
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/101/delete")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isBadRequest());
+
+    verify(germinatorTrayService, times(0)).deleteTray(any(), any());
+  }
+
+  @Test
   void deleteTray_returns404_whenTrayNotFound() throws Exception {
     Integer germinatorTrayId = 999;
     LocalDateTime expectedTimestamp = LocalDateTime.parse("2025-03-12T00:00:00");

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import ca.bc.gov.oracleapi.dto.consep.GerminatorIdAssignResponseDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayContentsDto;
+import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayDeleteContentDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchRequestDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTraySearchResponseDto;
 import ca.bc.gov.oracleapi.entity.consep.GerminationTrayContentsEntity;
@@ -275,26 +276,31 @@ class GerminatorTrayServiceTest {
   @Test
   void deleteTray_shouldDetachAllTestsAndDeleteTray() {
     Integer trayId = 101;
-    LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
+    LocalDateTime firstUpdateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
+    LocalDateTime secondUpdateTimestamp = LocalDateTime.of(2026, 4, 1, 11, 0);
     List<BigDecimal> riaKeys = List.of(BigDecimal.valueOf(1), BigDecimal.valueOf(2));
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(
+            new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), firstUpdateTimestamp),
+            new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(2), secondUpdateTimestamp));
 
     when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
     when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId)).thenReturn(riaKeys);
     when(testResultRepository.detachTestFromTray(BigDecimal.valueOf(1))).thenReturn(1);
     when(testResultRepository.detachTestFromTray(BigDecimal.valueOf(2))).thenReturn(1);
-    when(activityRepository.updateTimestampWhereMatch(BigDecimal.valueOf(1), updateTimestamp))
+    when(activityRepository.updateTimestampWhereMatch(BigDecimal.valueOf(1), firstUpdateTimestamp))
         .thenReturn(1);
-    when(activityRepository.updateTimestampWhereMatch(BigDecimal.valueOf(2), updateTimestamp))
+    when(activityRepository.updateTimestampWhereMatch(BigDecimal.valueOf(2), secondUpdateTimestamp))
         .thenReturn(1);
     when(germinatorTrayRepository.deleteByGerminatorTrayId(trayId)).thenReturn(1);
 
-    germinatorTrayService.deleteTray(trayId, updateTimestamp);
+    germinatorTrayService.deleteTray(trayId, contents);
 
     verify(testResultRepository).findRiaKeysByGerminatorTrayId(trayId);
     verify(testResultRepository).detachTestFromTray(BigDecimal.valueOf(1));
     verify(testResultRepository).detachTestFromTray(BigDecimal.valueOf(2));
-    verify(activityRepository).updateTimestampWhereMatch(BigDecimal.valueOf(1), updateTimestamp);
-    verify(activityRepository).updateTimestampWhereMatch(BigDecimal.valueOf(2), updateTimestamp);
+    verify(activityRepository).updateTimestampWhereMatch(BigDecimal.valueOf(1), firstUpdateTimestamp);
+    verify(activityRepository).updateTimestampWhereMatch(BigDecimal.valueOf(2), secondUpdateTimestamp);
     verify(germinatorTrayRepository).deleteByGerminatorTrayId(trayId);
   }
 
@@ -302,13 +308,15 @@ class GerminatorTrayServiceTest {
   void deleteTray_shouldThrowNotFound_whenTrayDoesNotExist() {
     Integer trayId = 999;
     LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp));
 
     when(germinatorTrayRepository.existsById(trayId)).thenReturn(false);
 
     ResponseStatusException ex =
         assertThrows(
             ResponseStatusException.class,
-            () -> germinatorTrayService.deleteTray(trayId, updateTimestamp));
+            () -> germinatorTrayService.deleteTray(trayId, contents));
 
     assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
     assertEquals("Germinator tray not found with ID: " + trayId, ex.getReason());
@@ -318,10 +326,35 @@ class GerminatorTrayServiceTest {
   }
 
   @Test
+  void deleteTray_shouldThrowConflict_whenContentsDoNotMatchCurrentTray() {
+    Integer trayId = 101;
+    LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
+    List<BigDecimal> riaKeys = List.of(BigDecimal.valueOf(1), BigDecimal.valueOf(2));
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp));
+
+    when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
+    when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId)).thenReturn(riaKeys);
+
+    ResponseStatusException ex =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> germinatorTrayService.deleteTray(trayId, contents));
+
+    assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
+    assertEquals(GerminatorTrayService.RESELECT_MESSAGE, ex.getReason());
+
+    verify(testResultRepository, never()).detachTestFromTray(any());
+    verify(activityRepository, never()).updateTimestampWhereMatch(any(), any());
+  }
+
+  @Test
   void deleteTray_shouldThrowConflict_whenDetachAffectsZeroRows() {
     Integer trayId = 101;
     LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
     List<BigDecimal> riaKeys = List.of(BigDecimal.valueOf(1));
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp));
 
     when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
     when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId)).thenReturn(riaKeys);
@@ -330,7 +363,7 @@ class GerminatorTrayServiceTest {
     ResponseStatusException ex =
         assertThrows(
             ResponseStatusException.class,
-            () -> germinatorTrayService.deleteTray(trayId, updateTimestamp));
+            () -> germinatorTrayService.deleteTray(trayId, contents));
 
     assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
     assertEquals(GerminatorTrayService.RESELECT_MESSAGE, ex.getReason());
@@ -344,6 +377,8 @@ class GerminatorTrayServiceTest {
     Integer trayId = 101;
     LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
     List<BigDecimal> riaKeys = List.of(BigDecimal.valueOf(1));
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp));
 
     when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
     when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId)).thenReturn(riaKeys);
@@ -354,7 +389,7 @@ class GerminatorTrayServiceTest {
     ResponseStatusException ex =
         assertThrows(
             ResponseStatusException.class,
-            () -> germinatorTrayService.deleteTray(trayId, updateTimestamp));
+            () -> germinatorTrayService.deleteTray(trayId, contents));
 
     assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
     assertEquals(GerminatorTrayService.RESELECT_MESSAGE, ex.getReason());
@@ -367,6 +402,8 @@ class GerminatorTrayServiceTest {
     Integer trayId = 101;
     LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
     List<BigDecimal> riaKeys = List.of(BigDecimal.valueOf(1));
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp));
 
     when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
     when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId)).thenReturn(riaKeys);
@@ -378,7 +415,7 @@ class GerminatorTrayServiceTest {
     ResponseStatusException ex =
         assertThrows(
             ResponseStatusException.class,
-            () -> germinatorTrayService.deleteTray(trayId, updateTimestamp));
+            () -> germinatorTrayService.deleteTray(trayId, contents));
 
     assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
     assertEquals(GerminatorTrayService.RESELECT_MESSAGE, ex.getReason());

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/GerminatorTrayServiceTest.java
@@ -398,6 +398,72 @@ class GerminatorTrayServiceTest {
   }
 
   @Test
+  void deleteTray_shouldThrowBadRequest_whenDuplicateRiaKeyInContents() {
+    Integer trayId = 101;
+    LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(
+            new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp),
+            new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp));
+
+    when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
+    when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId))
+        .thenReturn(List.of(BigDecimal.valueOf(1)));
+
+    ResponseStatusException ex =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> germinatorTrayService.deleteTray(trayId, contents));
+
+    assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+    assertEquals("Duplicate RIA key in tray contents", ex.getReason());
+
+    verify(testResultRepository, never()).detachTestFromTray(any());
+    verify(activityRepository, never()).updateTimestampWhereMatch(any(), any());
+  }
+
+  @Test
+  void deleteTray_shouldThrowConflict_whenContentsHaveExtraRiaKeyNotOnTray() {
+    Integer trayId = 101;
+    LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);
+    List<BigDecimal> riaKeys = List.of(BigDecimal.valueOf(1));
+    List<GerminatorTrayDeleteContentDto> contents =
+        List.of(
+            new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(1), updateTimestamp),
+            new GerminatorTrayDeleteContentDto(BigDecimal.valueOf(99), updateTimestamp));
+
+    when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
+    when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId)).thenReturn(riaKeys);
+
+    ResponseStatusException ex =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> germinatorTrayService.deleteTray(trayId, contents));
+
+    assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
+    assertEquals(GerminatorTrayService.RESELECT_MESSAGE, ex.getReason());
+
+    verify(testResultRepository, never()).detachTestFromTray(any());
+    verify(activityRepository, never()).updateTimestampWhereMatch(any(), any());
+  }
+
+  @Test
+  void deleteTray_shouldSucceed_whenTrayHasNoTests() {
+    Integer trayId = 101;
+    List<GerminatorTrayDeleteContentDto> contents = List.of();
+
+    when(germinatorTrayRepository.existsById(trayId)).thenReturn(true);
+    when(testResultRepository.findRiaKeysByGerminatorTrayId(trayId)).thenReturn(List.of());
+    when(germinatorTrayRepository.deleteByGerminatorTrayId(trayId)).thenReturn(1);
+
+    germinatorTrayService.deleteTray(trayId, contents);
+
+    verify(testResultRepository, never()).detachTestFromTray(any());
+    verify(activityRepository, never()).updateTimestampWhereMatch(any(), any());
+    verify(germinatorTrayRepository).deleteByGerminatorTrayId(trayId);
+  }
+
+  @Test
   void deleteTray_shouldThrowConflict_whenDeleteAffectsZeroRows() {
     Integer trayId = 101;
     LocalDateTime updateTimestamp = LocalDateTime.of(2026, 4, 1, 10, 0);


### PR DESCRIPTION
# Description
Closes #2308

### Changelog
#### New
- enable deletion of germ tray and contents from the ui

### How was this tested?
- [ ] 🧠 Not needed
- [x] 👀 Eyeball
- [ ] 🤖 Added tests

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-44.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2444-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2444-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)