### PR TITLE
fix: #2434 populate seedlot mean elevation/lat/long for SPRR048

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -59,6 +59,7 @@ import ca.bc.gov.backendstartapi.repository.SeedlotSeedPlanZoneRepository;
 import ca.bc.gov.backendstartapi.repository.SeedlotSourceRepository;
 import ca.bc.gov.backendstartapi.security.LoggedUserService;
 import ca.bc.gov.backendstartapi.security.UserInfo;
+import ca.bc.gov.backendstartapi.util.SeedlotMeanGeoCalculator;
 import ca.bc.gov.backendstartapi.util.ValueUtil;
 import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
@@ -839,6 +840,10 @@ public class SeedlotService {
       // Set values in the Seedlot instance only
       tscAdminService.overrideSeedlotCollElevLatLong(seedlot, form.seedlotReviewGeoInformation());
 
+      // Recompute seedlot mean elevation/lat/long now that the TSC has revised the
+      // area-of-use min/max and the collection mean (legacy SPRR048 reads these mean cols).
+      SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
       // Override Seedlot Genetic Worth values
       seedlotGeneticWorthService.overrideSeedlotGenWorth(seedlot, form.seedlotReviewGeneticWorth());
     }
@@ -1087,6 +1092,11 @@ public class SeedlotService {
     // Seconds default to 0
     seedlot.setLongitudeSecMax(0);
     seedlot.setLongitudeSecMin(0);
+
+    // STEP 5: derive seedlot mean elevation/lat/long from min/max & collection mean.
+    // Without this the seedlot.elevation column is left NULL and legacy reports
+    // (e.g. SPRR048 Short Form) silently exclude the row.
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
 
     // Set SPZs
     List<SeedlotSeedPlanZoneEntity> spzSaveList = new ArrayList<>();

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -826,6 +826,10 @@ public class SeedlotService {
       if (!hasAreaOfUseData(seedlot)) {
         SparLog.info("Area of Use data has NOT been set previously, setting area of use data");
         setAreaOfUse(seedlot, form.seedlotFormOrchardDto().primaryOrchardId());
+      } else {
+        // Area of Use was set on a prior save; the collection mean above may have
+        // changed, so recompute the mean elevation/lat/long for SPRR048.
+        SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
       }
     } else {
       updateApplicantAndSeedlot(seedlot, form.applicantAndSeedlotInfo());

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculator.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculator.java
@@ -1,0 +1,54 @@
+package ca.bc.gov.backendstartapi.util;
+
+import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
+import java.util.Objects;
+
+/**
+ * Implements STEP 5 ("Set Mean Area of Use") of the Forestry Calculating Area of Use Geography
+ * specification. For each of elevation / latitude / longitude, the seedlot mean column is set to
+ * the area-of-use max when min == max across all DMS components, otherwise it falls back to the
+ * collection mean.
+ *
+ * <p>The seedlot mean columns are read by legacy reports (e.g. SPRR048 Short Form). Leaving them
+ * NULL silently drops rows from those reports.
+ */
+public final class SeedlotMeanGeoCalculator {
+
+  private SeedlotMeanGeoCalculator() {}
+
+  /**
+   * Apply the mean Area-of-Use rule. Must be called only after the area-of-use min/max and the
+   * collection mean values have been populated on the seedlot.
+   */
+  public static void applyMeanAreaOfUse(Seedlot seedlot) {
+    // Mean Elevation
+    seedlot.setElevation(
+        Objects.equals(seedlot.getElevationMin(), seedlot.getElevationMax())
+            ? seedlot.getElevationMax()
+            : seedlot.getCollectionElevation());
+
+    // Mean Latitude (DMS components must all match for min == max)
+    boolean latEqual =
+        Objects.equals(seedlot.getLatitudeDegMin(), seedlot.getLatitudeDegMax())
+            && Objects.equals(seedlot.getLatitudeMinMin(), seedlot.getLatitudeMinMax())
+            && Objects.equals(seedlot.getLatitudeSecMin(), seedlot.getLatitudeSecMax());
+    seedlot.setLatitudeDegrees(
+        latEqual ? seedlot.getLatitudeDegMax() : seedlot.getCollectionLatitudeDeg());
+    seedlot.setLatitudeMinutes(
+        latEqual ? seedlot.getLatitudeMinMax() : seedlot.getCollectionLatitudeMin());
+    seedlot.setLatitudeSeconds(
+        latEqual ? seedlot.getLatitudeSecMax() : seedlot.getCollectionLatitudeSec());
+
+    // Mean Longitude
+    boolean longEqual =
+        Objects.equals(seedlot.getLongitudeDegMin(), seedlot.getLongitudeDegMax())
+            && Objects.equals(seedlot.getLongitudeMinMin(), seedlot.getLongitudeMinMax())
+            && Objects.equals(seedlot.getLongitudeSecMin(), seedlot.getLongitudeSecMax());
+    seedlot.setLongitudeDegrees(
+        longEqual ? seedlot.getLongitudeDegMax() : seedlot.getCollectionLongitudeDeg());
+    seedlot.setLongitudeMinutes(
+        longEqual ? seedlot.getLongitudeMinMax() : seedlot.getCollectionLongitudeMin());
+    seedlot.setLongitudeSeconds(
+        longEqual ? seedlot.getLongitudeSecMax() : seedlot.getCollectionLongitudeSec());
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculator.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculator.java
@@ -6,8 +6,8 @@ import java.util.Objects;
 /**
  * Implements STEP 5 ("Set Mean Area of Use") of the Forestry Calculating Area of Use Geography
  * specification. For each of elevation / latitude / longitude, the seedlot mean column is set to
- * the area-of-use max when min == max across all DMS components, otherwise it falls back to the
- * collection mean.
+ * the area-of-use max when min == max across all DMS components and max is populated, otherwise
+ * it falls back to the collection mean.
  *
  * <p>The seedlot mean columns are read by legacy reports (e.g. SPRR048 Short Form). Leaving them
  * NULL silently drops rows from those reports.
@@ -22,33 +22,40 @@ public final class SeedlotMeanGeoCalculator {
    */
   public static void applyMeanAreaOfUse(Seedlot seedlot) {
     // Mean Elevation
+    boolean elevationUseMax =
+        seedlot.getElevationMax() != null
+            && Objects.equals(seedlot.getElevationMin(), seedlot.getElevationMax());
     seedlot.setElevation(
-        Objects.equals(seedlot.getElevationMin(), seedlot.getElevationMax())
-            ? seedlot.getElevationMax()
-            : seedlot.getCollectionElevation());
+        elevationUseMax ? seedlot.getElevationMax() : seedlot.getCollectionElevation());
 
-    // Mean Latitude (DMS components must all match for min == max)
-    boolean latEqual =
-        Objects.equals(seedlot.getLatitudeDegMin(), seedlot.getLatitudeDegMax())
+    // Mean Latitude (all DMS max components must be populated and equal to min)
+    boolean latUseMax =
+        seedlot.getLatitudeDegMax() != null
+            && seedlot.getLatitudeMinMax() != null
+            && seedlot.getLatitudeSecMax() != null
+            && Objects.equals(seedlot.getLatitudeDegMin(), seedlot.getLatitudeDegMax())
             && Objects.equals(seedlot.getLatitudeMinMin(), seedlot.getLatitudeMinMax())
             && Objects.equals(seedlot.getLatitudeSecMin(), seedlot.getLatitudeSecMax());
     seedlot.setLatitudeDegrees(
-        latEqual ? seedlot.getLatitudeDegMax() : seedlot.getCollectionLatitudeDeg());
+        latUseMax ? seedlot.getLatitudeDegMax() : seedlot.getCollectionLatitudeDeg());
     seedlot.setLatitudeMinutes(
-        latEqual ? seedlot.getLatitudeMinMax() : seedlot.getCollectionLatitudeMin());
+        latUseMax ? seedlot.getLatitudeMinMax() : seedlot.getCollectionLatitudeMin());
     seedlot.setLatitudeSeconds(
-        latEqual ? seedlot.getLatitudeSecMax() : seedlot.getCollectionLatitudeSec());
+        latUseMax ? seedlot.getLatitudeSecMax() : seedlot.getCollectionLatitudeSec());
 
     // Mean Longitude
-    boolean longEqual =
-        Objects.equals(seedlot.getLongitudeDegMin(), seedlot.getLongitudeDegMax())
+    boolean longUseMax =
+        seedlot.getLongitudeDegMax() != null
+            && seedlot.getLongitudeMinMax() != null
+            && seedlot.getLongitudeSecMax() != null
+            && Objects.equals(seedlot.getLongitudeDegMin(), seedlot.getLongitudeDegMax())
             && Objects.equals(seedlot.getLongitudeMinMin(), seedlot.getLongitudeMinMax())
             && Objects.equals(seedlot.getLongitudeSecMin(), seedlot.getLongitudeSecMax());
     seedlot.setLongitudeDegrees(
-        longEqual ? seedlot.getLongitudeDegMax() : seedlot.getCollectionLongitudeDeg());
+        longUseMax ? seedlot.getLongitudeDegMax() : seedlot.getCollectionLongitudeDeg());
     seedlot.setLongitudeMinutes(
-        longEqual ? seedlot.getLongitudeMinMax() : seedlot.getCollectionLongitudeMin());
+        longUseMax ? seedlot.getLongitudeMinMax() : seedlot.getCollectionLongitudeMin());
     seedlot.setLongitudeSeconds(
-        longEqual ? seedlot.getLongitudeSecMax() : seedlot.getCollectionLongitudeSec());
+        longUseMax ? seedlot.getLongitudeSecMax() : seedlot.getCollectionLongitudeSec());
   }
 }

--- a/backend/src/main/resources/db/migration/V49__backfill_seedlot_mean_area_of_use.sql
+++ b/backend/src/main/resources/db/migration/V49__backfill_seedlot_mean_area_of_use.sql
@@ -1,0 +1,64 @@
+-- ENG/SPRR048: backfill seedlot.elevation / latitude_* / longitude_* mean columns.
+--
+-- Historical rows saved via SPAR were left with NULL representative (mean) elevation,
+-- latitude and longitude because STEP 5 of the "Calculating Area of Use Geography"
+-- spec was missing from the backend. SPRR048 (Short Form Report) reads these mean
+-- columns and silently excluded affected seedlots (e.g. 64220).
+--
+-- Rule (per the Forestry Confluence spec, mirrored in the new Java helper
+-- SeedlotMeanGeoCalculator): when min == max the mean = max; otherwise mean falls
+-- back to the corresponding collection mean.
+
+update spar.seedlot
+   set elevation = case
+                     when elevation_min is not distinct from elevation_max then elevation_max
+                     else collection_elevation
+                   end
+ where elevation is null
+   and (elevation_min is not null
+        or elevation_max is not null
+        or collection_elevation is not null);
+
+update spar.seedlot
+   set latitude_degrees = case when lat_components_match then latitude_deg_max
+                               else collection_latitude_deg end,
+       latitude_minutes = case when lat_components_match then latitude_min_max
+                               else collection_latitude_min end,
+       latitude_seconds = case when lat_components_match then latitude_sec_max
+                               else collection_latitude_sec end
+  from (
+    select seedlot_number,
+           (latitude_deg_min is not distinct from latitude_deg_max
+              and latitude_min_min is not distinct from latitude_min_max
+              and latitude_sec_min is not distinct from latitude_sec_max) as lat_components_match
+      from spar.seedlot
+  ) src
+ where spar.seedlot.seedlot_number = src.seedlot_number
+   and (spar.seedlot.latitude_degrees is null
+        or spar.seedlot.latitude_minutes is null
+        or spar.seedlot.latitude_seconds is null)
+   and (spar.seedlot.latitude_deg_min is not null
+        or spar.seedlot.latitude_deg_max is not null
+        or spar.seedlot.collection_latitude_deg is not null);
+
+update spar.seedlot
+   set longitude_degrees = case when long_components_match then longitude_deg_max
+                                else collection_longitude_deg end,
+       longitude_minutes = case when long_components_match then longitude_min_max
+                                else collection_longitude_min end,
+       longitude_seconds = case when long_components_match then longitude_sec_max
+                                else collection_longitude_sec end
+  from (
+    select seedlot_number,
+           (longitude_deg_min is not distinct from longitude_deg_max
+              and longitude_min_min is not distinct from longitude_min_max
+              and longitude_sec_min is not distinct from longitude_sec_max) as long_components_match
+      from spar.seedlot
+  ) src
+ where spar.seedlot.seedlot_number = src.seedlot_number
+   and (spar.seedlot.longitude_degrees is null
+        or spar.seedlot.longitude_minutes is null
+        or spar.seedlot.longitude_seconds is null)
+   and (spar.seedlot.longitude_deg_min is not null
+        or spar.seedlot.longitude_deg_max is not null
+        or spar.seedlot.collection_longitude_deg is not null);

--- a/backend/src/main/resources/db/migration/V49__backfill_seedlot_mean_area_of_use.sql
+++ b/backend/src/main/resources/db/migration/V49__backfill_seedlot_mean_area_of_use.sql
@@ -6,12 +6,15 @@
 -- columns and silently excluded affected seedlots (e.g. 64220).
 --
 -- Rule (per the Forestry Confluence spec, mirrored in the new Java helper
--- SeedlotMeanGeoCalculator): when min == max the mean = max; otherwise mean falls
--- back to the corresponding collection mean.
+-- SeedlotMeanGeoCalculator): when min == max and max is populated the mean = max;
+-- otherwise mean falls back to the corresponding collection mean. The lat/long
+-- updates use COALESCE per column so already-populated components are preserved.
 
 update spar.seedlot
    set elevation = case
-                     when elevation_min is not distinct from elevation_max then elevation_max
+                     when elevation_max is not null
+                          and elevation_min is not distinct from elevation_max
+                       then elevation_max
                      else collection_elevation
                    end
  where elevation is null
@@ -20,15 +23,21 @@ update spar.seedlot
         or collection_elevation is not null);
 
 update spar.seedlot
-   set latitude_degrees = case when lat_components_match then latitude_deg_max
-                               else collection_latitude_deg end,
-       latitude_minutes = case when lat_components_match then latitude_min_max
-                               else collection_latitude_min end,
-       latitude_seconds = case when lat_components_match then latitude_sec_max
-                               else collection_latitude_sec end
+   set latitude_degrees = coalesce(latitude_degrees,
+                                   case when lat_components_match then latitude_deg_max
+                                        else collection_latitude_deg end),
+       latitude_minutes = coalesce(latitude_minutes,
+                                   case when lat_components_match then latitude_min_max
+                                        else collection_latitude_min end),
+       latitude_seconds = coalesce(latitude_seconds,
+                                   case when lat_components_match then latitude_sec_max
+                                        else collection_latitude_sec end)
   from (
     select seedlot_number,
-           (latitude_deg_min is not distinct from latitude_deg_max
+           (latitude_deg_max is not null
+              and latitude_min_max is not null
+              and latitude_sec_max is not null
+              and latitude_deg_min is not distinct from latitude_deg_max
               and latitude_min_min is not distinct from latitude_min_max
               and latitude_sec_min is not distinct from latitude_sec_max) as lat_components_match
       from spar.seedlot
@@ -42,15 +51,21 @@ update spar.seedlot
         or spar.seedlot.collection_latitude_deg is not null);
 
 update spar.seedlot
-   set longitude_degrees = case when long_components_match then longitude_deg_max
-                                else collection_longitude_deg end,
-       longitude_minutes = case when long_components_match then longitude_min_max
-                                else collection_longitude_min end,
-       longitude_seconds = case when long_components_match then longitude_sec_max
-                                else collection_longitude_sec end
+   set longitude_degrees = coalesce(longitude_degrees,
+                                    case when long_components_match then longitude_deg_max
+                                         else collection_longitude_deg end),
+       longitude_minutes = coalesce(longitude_minutes,
+                                    case when long_components_match then longitude_min_max
+                                         else collection_longitude_min end),
+       longitude_seconds = coalesce(longitude_seconds,
+                                    case when long_components_match then longitude_sec_max
+                                         else collection_longitude_sec end)
   from (
     select seedlot_number,
-           (longitude_deg_min is not distinct from longitude_deg_max
+           (longitude_deg_max is not null
+              and longitude_min_max is not null
+              and longitude_sec_max is not null
+              and longitude_deg_min is not distinct from longitude_deg_max
               and longitude_min_min is not distinct from longitude_min_max
               and longitude_sec_min is not distinct from longitude_sec_max) as long_components_match
       from spar.seedlot

--- a/backend/src/main/resources/db/migration/V49__backfill_seedlot_mean_area_of_use.sql
+++ b/backend/src/main/resources/db/migration/V49__backfill_seedlot_mean_area_of_use.sql
@@ -9,6 +9,10 @@
 -- SeedlotMeanGeoCalculator): when min == max and max is populated the mean = max;
 -- otherwise mean falls back to the corresponding collection mean. The lat/long
 -- updates use COALESCE per column so already-populated components are preserved.
+--
+-- Each WHERE clause is tightened so the UPDATE only runs when the derived value
+-- is actually non-NULL and would change the row, avoiding no-op writes that
+-- would still trip the seedlot audit trigger.
 
 update spar.seedlot
    set elevation = case
@@ -18,62 +22,66 @@ update spar.seedlot
                      else collection_elevation
                    end
  where elevation is null
-   and (elevation_min is not null
-        or elevation_max is not null
+   and ((elevation_max is not null
+            and elevation_min is not distinct from elevation_max)
         or collection_elevation is not null);
 
 update spar.seedlot
-   set latitude_degrees = coalesce(latitude_degrees,
-                                   case when lat_components_match then latitude_deg_max
-                                        else collection_latitude_deg end),
-       latitude_minutes = coalesce(latitude_minutes,
-                                   case when lat_components_match then latitude_min_max
-                                        else collection_latitude_min end),
-       latitude_seconds = coalesce(latitude_seconds,
-                                   case when lat_components_match then latitude_sec_max
-                                        else collection_latitude_sec end)
+   set latitude_degrees = coalesce(latitude_degrees, src.derived_lat_deg),
+       latitude_minutes = coalesce(latitude_minutes, src.derived_lat_min),
+       latitude_seconds = coalesce(latitude_seconds, src.derived_lat_sec)
   from (
     select seedlot_number,
-           (latitude_deg_max is not null
-              and latitude_min_max is not null
-              and latitude_sec_max is not null
-              and latitude_deg_min is not distinct from latitude_deg_max
-              and latitude_min_min is not distinct from latitude_min_max
-              and latitude_sec_min is not distinct from latitude_sec_max) as lat_components_match
-      from spar.seedlot
+           case when lat_components_match then latitude_deg_max
+                else collection_latitude_deg end as derived_lat_deg,
+           case when lat_components_match then latitude_min_max
+                else collection_latitude_min end as derived_lat_min,
+           case when lat_components_match then latitude_sec_max
+                else collection_latitude_sec end as derived_lat_sec
+      from (
+        select seedlot_number,
+               latitude_deg_max, latitude_min_max, latitude_sec_max,
+               collection_latitude_deg, collection_latitude_min, collection_latitude_sec,
+               (latitude_deg_max is not null
+                  and latitude_min_max is not null
+                  and latitude_sec_max is not null
+                  and latitude_deg_min is not distinct from latitude_deg_max
+                  and latitude_min_min is not distinct from latitude_min_max
+                  and latitude_sec_min is not distinct from latitude_sec_max) as lat_components_match
+          from spar.seedlot
+      ) base
   ) src
  where spar.seedlot.seedlot_number = src.seedlot_number
-   and (spar.seedlot.latitude_degrees is null
-        or spar.seedlot.latitude_minutes is null
-        or spar.seedlot.latitude_seconds is null)
-   and (spar.seedlot.latitude_deg_min is not null
-        or spar.seedlot.latitude_deg_max is not null
-        or spar.seedlot.collection_latitude_deg is not null);
+   and ((spar.seedlot.latitude_degrees is null and src.derived_lat_deg is not null)
+        or (spar.seedlot.latitude_minutes is null and src.derived_lat_min is not null)
+        or (spar.seedlot.latitude_seconds is null and src.derived_lat_sec is not null));
 
 update spar.seedlot
-   set longitude_degrees = coalesce(longitude_degrees,
-                                    case when long_components_match then longitude_deg_max
-                                         else collection_longitude_deg end),
-       longitude_minutes = coalesce(longitude_minutes,
-                                    case when long_components_match then longitude_min_max
-                                         else collection_longitude_min end),
-       longitude_seconds = coalesce(longitude_seconds,
-                                    case when long_components_match then longitude_sec_max
-                                         else collection_longitude_sec end)
+   set longitude_degrees = coalesce(longitude_degrees, src.derived_long_deg),
+       longitude_minutes = coalesce(longitude_minutes, src.derived_long_min),
+       longitude_seconds = coalesce(longitude_seconds, src.derived_long_sec)
   from (
     select seedlot_number,
-           (longitude_deg_max is not null
-              and longitude_min_max is not null
-              and longitude_sec_max is not null
-              and longitude_deg_min is not distinct from longitude_deg_max
-              and longitude_min_min is not distinct from longitude_min_max
-              and longitude_sec_min is not distinct from longitude_sec_max) as long_components_match
-      from spar.seedlot
+           case when long_components_match then longitude_deg_max
+                else collection_longitude_deg end as derived_long_deg,
+           case when long_components_match then longitude_min_max
+                else collection_longitude_min end as derived_long_min,
+           case when long_components_match then longitude_sec_max
+                else collection_longitude_sec end as derived_long_sec
+      from (
+        select seedlot_number,
+               longitude_deg_max, longitude_min_max, longitude_sec_max,
+               collection_longitude_deg, collection_longitude_min, collection_longitude_sec,
+               (longitude_deg_max is not null
+                  and longitude_min_max is not null
+                  and longitude_sec_max is not null
+                  and longitude_deg_min is not distinct from longitude_deg_max
+                  and longitude_min_min is not distinct from longitude_min_max
+                  and longitude_sec_min is not distinct from longitude_sec_max) as long_components_match
+          from spar.seedlot
+      ) base
   ) src
  where spar.seedlot.seedlot_number = src.seedlot_number
-   and (spar.seedlot.longitude_degrees is null
-        or spar.seedlot.longitude_minutes is null
-        or spar.seedlot.longitude_seconds is null)
-   and (spar.seedlot.longitude_deg_min is not null
-        or spar.seedlot.longitude_deg_max is not null
-        or spar.seedlot.collection_longitude_deg is not null);
+   and ((spar.seedlot.longitude_degrees is null and src.derived_long_deg is not null)
+        or (spar.seedlot.longitude_minutes is null and src.derived_long_min is not null)
+        or (spar.seedlot.longitude_seconds is null and src.derived_long_sec is not null));

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculatorTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculatorTest.java
@@ -1,0 +1,125 @@
+package ca.bc.gov.backendstartapi.util;
+
+import ca.bc.gov.backendstartapi.entity.seedlot.Seedlot;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SeedlotMeanGeoCalculatorTest {
+
+  private Seedlot baseSeedlot() {
+    Seedlot seedlot = new Seedlot("64220");
+    seedlot.setCollectionElevation(450);
+    seedlot.setCollectionLatitudeDeg(49);
+    seedlot.setCollectionLatitudeMin(30);
+    seedlot.setCollectionLatitudeSec(0);
+    seedlot.setCollectionLongitudeDeg(124);
+    seedlot.setCollectionLongitudeMin(15);
+    seedlot.setCollectionLongitudeSec(0);
+    return seedlot;
+  }
+
+  @Test
+  void elevation_minEqualsMax_usesMax() {
+    Seedlot seedlot = baseSeedlot();
+    seedlot.setElevationMin(500);
+    seedlot.setElevationMax(500);
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(500, seedlot.getElevation());
+  }
+
+  @Test
+  void elevation_minNotEqualsMax_usesCollection() {
+    Seedlot seedlot = baseSeedlot();
+    seedlot.setElevationMin(200);
+    seedlot.setElevationMax(800);
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(450, seedlot.getElevation());
+  }
+
+  @Test
+  void elevation_bothNull_fallsBackToCollection() {
+    // Regression for SPRR048 / issue 2434: when min/max are NULL the mean must still
+    // be populated (not left NULL) so the legacy report does not silently drop the row.
+    Seedlot seedlot = baseSeedlot();
+    seedlot.setElevationMin(null);
+    seedlot.setElevationMax(null);
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    // min == max (both null) -> rule says use max, which is null. Caller is expected
+    // to set min/max before calling, but verify behaviour is deterministic.
+    Assertions.assertNull(seedlot.getElevation());
+  }
+
+  @Test
+  void latitude_allDmsComponentsEqual_usesMax() {
+    Seedlot seedlot = baseSeedlot();
+    seedlot.setLatitudeDegMin(50);
+    seedlot.setLatitudeDegMax(50);
+    seedlot.setLatitudeMinMin(15);
+    seedlot.setLatitudeMinMax(15);
+    seedlot.setLatitudeSecMin(0);
+    seedlot.setLatitudeSecMax(0);
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(50, seedlot.getLatitudeDegrees());
+    Assertions.assertEquals(15, seedlot.getLatitudeMinutes());
+    Assertions.assertEquals(0, seedlot.getLatitudeSeconds());
+  }
+
+  @Test
+  void latitude_anyDmsComponentDiffers_usesCollection() {
+    Seedlot seedlot = baseSeedlot();
+    seedlot.setLatitudeDegMin(50);
+    seedlot.setLatitudeDegMax(50);
+    seedlot.setLatitudeMinMin(10);
+    seedlot.setLatitudeMinMax(20);
+    seedlot.setLatitudeSecMin(0);
+    seedlot.setLatitudeSecMax(0);
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(49, seedlot.getLatitudeDegrees());
+    Assertions.assertEquals(30, seedlot.getLatitudeMinutes());
+    Assertions.assertEquals(0, seedlot.getLatitudeSeconds());
+  }
+
+  @Test
+  void longitude_allDmsComponentsEqual_usesMax() {
+    Seedlot seedlot = baseSeedlot();
+    seedlot.setLongitudeDegMin(125);
+    seedlot.setLongitudeDegMax(125);
+    seedlot.setLongitudeMinMin(45);
+    seedlot.setLongitudeMinMax(45);
+    seedlot.setLongitudeSecMin(0);
+    seedlot.setLongitudeSecMax(0);
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(125, seedlot.getLongitudeDegrees());
+    Assertions.assertEquals(45, seedlot.getLongitudeMinutes());
+    Assertions.assertEquals(0, seedlot.getLongitudeSeconds());
+  }
+
+  @Test
+  void longitude_dmsComponentsDiffer_usesCollection() {
+    Seedlot seedlot = baseSeedlot();
+    seedlot.setLongitudeDegMin(124);
+    seedlot.setLongitudeDegMax(125);
+    seedlot.setLongitudeMinMin(0);
+    seedlot.setLongitudeMinMax(0);
+    seedlot.setLongitudeSecMin(0);
+    seedlot.setLongitudeSecMax(0);
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(124, seedlot.getLongitudeDegrees());
+    Assertions.assertEquals(15, seedlot.getLongitudeMinutes());
+    Assertions.assertEquals(0, seedlot.getLongitudeSeconds());
+  }
+}

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculatorTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculatorTest.java
@@ -19,7 +19,7 @@ class SeedlotMeanGeoCalculatorTest {
   }
 
   @Test
-  void elevation_minEqualsMax_usesMax() {
+  void elevationMinEqualsMaxUsesMaxTest() {
     Seedlot seedlot = baseSeedlot();
     seedlot.setElevationMin(500);
     seedlot.setElevationMax(500);
@@ -30,7 +30,7 @@ class SeedlotMeanGeoCalculatorTest {
   }
 
   @Test
-  void elevation_minNotEqualsMax_usesCollection() {
+  void elevationMinNotEqualsMaxUsesCollectionTest() {
     Seedlot seedlot = baseSeedlot();
     seedlot.setElevationMin(200);
     seedlot.setElevationMax(800);
@@ -41,7 +41,7 @@ class SeedlotMeanGeoCalculatorTest {
   }
 
   @Test
-  void elevation_bothNull_fallsBackToCollection() {
+  void elevationBothNullFallsBackToCollectionTest() {
     // Regression for SPRR048 / issue 2434: when min/max are NULL the mean must still
     // be populated (not left NULL) so the legacy report does not silently drop the row.
     Seedlot seedlot = baseSeedlot();
@@ -50,13 +50,11 @@ class SeedlotMeanGeoCalculatorTest {
 
     SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
 
-    // min == max (both null) -> rule says use max, which is null. Caller is expected
-    // to set min/max before calling, but verify behaviour is deterministic.
-    Assertions.assertNull(seedlot.getElevation());
+    Assertions.assertEquals(450, seedlot.getElevation());
   }
 
   @Test
-  void latitude_allDmsComponentsEqual_usesMax() {
+  void latitudeAllDmsComponentsEqualUsesMaxTest() {
     Seedlot seedlot = baseSeedlot();
     seedlot.setLatitudeDegMin(50);
     seedlot.setLatitudeDegMax(50);
@@ -73,7 +71,7 @@ class SeedlotMeanGeoCalculatorTest {
   }
 
   @Test
-  void latitude_anyDmsComponentDiffers_usesCollection() {
+  void latitudeAnyDmsComponentDiffersUsesCollectionTest() {
     Seedlot seedlot = baseSeedlot();
     seedlot.setLatitudeDegMin(50);
     seedlot.setLatitudeDegMax(50);
@@ -90,7 +88,18 @@ class SeedlotMeanGeoCalculatorTest {
   }
 
   @Test
-  void longitude_allDmsComponentsEqual_usesMax() {
+  void latitudeAllDmsComponentsNullFallsBackToCollectionTest() {
+    Seedlot seedlot = baseSeedlot();
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(49, seedlot.getLatitudeDegrees());
+    Assertions.assertEquals(30, seedlot.getLatitudeMinutes());
+    Assertions.assertEquals(0, seedlot.getLatitudeSeconds());
+  }
+
+  @Test
+  void longitudeAllDmsComponentsEqualUsesMaxTest() {
     Seedlot seedlot = baseSeedlot();
     seedlot.setLongitudeDegMin(125);
     seedlot.setLongitudeDegMax(125);
@@ -107,7 +116,7 @@ class SeedlotMeanGeoCalculatorTest {
   }
 
   @Test
-  void longitude_dmsComponentsDiffer_usesCollection() {
+  void longitudeDmsComponentsDifferUsesCollectionTest() {
     Seedlot seedlot = baseSeedlot();
     seedlot.setLongitudeDegMin(124);
     seedlot.setLongitudeDegMax(125);

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculatorTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/util/SeedlotMeanGeoCalculatorTest.java
@@ -131,4 +131,15 @@ class SeedlotMeanGeoCalculatorTest {
     Assertions.assertEquals(15, seedlot.getLongitudeMinutes());
     Assertions.assertEquals(0, seedlot.getLongitudeSeconds());
   }
+
+  @Test
+  void longitudeAllDmsComponentsNullFallsBackToCollectionTest() {
+    Seedlot seedlot = baseSeedlot();
+
+    SeedlotMeanGeoCalculator.applyMeanAreaOfUse(seedlot);
+
+    Assertions.assertEquals(124, seedlot.getLongitudeDegrees());
+    Assertions.assertEquals(15, seedlot.getLongitudeMinutes());
+    Assertions.assertEquals(0, seedlot.getLongitudeSeconds());
+  }
 }


### PR DESCRIPTION
# Description
Closes #2434

### Changelog
#### Changed
The Confluence "Calculating Area of Use Geography" spec defines a STEP 5 that derives the seedlot mean elevation, latitude and longitude from the area-of-use min/max and the collection mean. STEP 5 was missing from the backend, so seedlot.elevation / latitude_degrees / longitude_degrees were left NULL on every save. SPRR048 (Short Form Report) reads those mean columns and silently dropped the affected seedlots (e.g. 64220).

- Add SeedlotMeanGeoCalculator utility implementing STEP 5
- Invoke it at the tail of setAreaOfUse and after the TSC override path
- Backfill historical NULL means via V49 Flyway migration


### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-11.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2461-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2461-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)