### PR TITLE
fix: include geospatial data in form response when already submitted

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/dto/SeedlotAclassFormDto.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/dto/SeedlotAclassFormDto.java
@@ -11,9 +11,13 @@ import java.util.List;
  * @param parentTrees a list with all parent trees related to the orchard
  * @param calculatedValues the results of all calculation made on the backend related
  *                         to the seedlot
+ * @param meanGeomSeedlot the persisted weighted-mean geospatial data for the seedlot
+ * @param meanGeomSmpMix the computed weighted-mean geospatial data for the SMP mix
  */
 @Schema(description = "An object with seedlot related data, for a-class seedlots")
 public record SeedlotAclassFormDto(
     SeedlotFormSubmissionDto seedlotData,
-    List<GeneticWorthTraitsDto> calculatedValues
+    List<GeneticWorthTraitsDto> calculatedValues,
+    GeospatialRespondDto meanGeomSeedlot,
+    GeospatialRespondDto meanGeomSmpMix
 ) {}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
@@ -625,7 +625,7 @@ public class ParentTreeService {
    * @param ptreeIdAndProportions List of parent tree id and proportion.
    * @return A List of {@link GeospatialRespondDto}
    */
-  public GeospatialRespondDto calcMeanGeospatial(
+  GeospatialRespondDto calcMeanGeospatial(
       List<GeospatialRequestDto> ptreeIdAndProportions) {
     SparLog.info(
         "{} parent tree record(s) received to calculate lat long and elevation",

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/ParentTreeService.java
@@ -625,7 +625,7 @@ public class ParentTreeService {
    * @param ptreeIdAndProportions List of parent tree id and proportion.
    * @return A List of {@link GeospatialRespondDto}
    */
-  private GeospatialRespondDto calcMeanGeospatial(
+  public GeospatialRespondDto calcMeanGeospatial(
       List<GeospatialRequestDto> ptreeIdAndProportions) {
     SparLog.info(
         "{} parent tree record(s) received to calculate lat long and elevation",

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -47,6 +47,7 @@ import ca.bc.gov.backendstartapi.exception.GeneticClassNotFoundException;
 import ca.bc.gov.backendstartapi.exception.InvalidSeedlotRequestException;
 import ca.bc.gov.backendstartapi.exception.NoSpuForOrchardException;
 import ca.bc.gov.backendstartapi.exception.OracleApiProviderException;
+import ca.bc.gov.backendstartapi.exception.PtGeoDataNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SeedlotConflictDataException;
 import ca.bc.gov.backendstartapi.exception.SeedlotFormValidationException;
 import ca.bc.gov.backendstartapi.exception.SeedlotNotFoundException;
@@ -664,7 +665,8 @@ public class SeedlotService {
   }
 
   private GeospatialRespondDto buildMeanGeomSeedlot(Seedlot seedlotInfo) {
-    if (seedlotInfo.getCollectionLatitudeDeg() == null) {
+    if (seedlotInfo.getCollectionLatitudeDeg() == null
+        || seedlotInfo.getCollectionLongitudeDeg() == null) {
       return null;
     }
     return new GeospatialRespondDto(
@@ -678,16 +680,23 @@ public class SeedlotService {
         null,
         seedlotInfo.getCollectionElevation());
   }
-  
+
   private GeospatialRespondDto buildMeanGeomSmpMix(List<SmpMix> smpMixsData) {
     if (smpMixsData.isEmpty()) {
       return null;
     }
     List<GeospatialRequestDto> smpMixIdAndProps = smpMixsData.stream()
         .map(smpMix -> new GeospatialRequestDto(
-            Long.valueOf(smpMix.getParentTreeId()), smpMix.getProportion()))
-        .collect(Collectors.toList());
-    return parentTreeService.calcMeanGeospatial(smpMixIdAndProps);
+            (long) smpMix.getParentTreeId(), smpMix.getProportion()))
+        .toList();
+    try {
+      return parentTreeService.calcMeanGeospatial(smpMixIdAndProps);
+    } catch (PtGeoDataNotFoundException e) {
+      SparLog.warn(
+          "Oracle geospatial data unavailable for SMP mix parent trees: {}",
+          e.getMessage());
+      return null;
+    }
   }
 
   /**

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -639,6 +639,29 @@ public class SeedlotService {
     SeedlotFormSmpParentOutsideDto smpParentOutsideDto =
         new SeedlotFormSmpParentOutsideDto(seedlotInfo.getParentsOutsideTheOrchardUsedInSmp());
 
+    GeospatialRespondDto meanGeomSeedlot = null;
+    if (seedlotInfo.getCollectionLatitudeDeg() != null) {
+      meanGeomSeedlot = new GeospatialRespondDto(
+          seedlotInfo.getCollectionLatitudeDeg(),
+          seedlotInfo.getCollectionLatitudeMin(),
+          seedlotInfo.getCollectionLatitudeSec(),
+          seedlotInfo.getCollectionLongitudeDeg(),
+          seedlotInfo.getCollectionLongitudeMin(),
+          seedlotInfo.getCollectionLongitudeSec(),
+          null,
+          null,
+          seedlotInfo.getCollectionElevation());
+    }
+
+    GeospatialRespondDto meanGeomSmpMix = null;
+    if (!smpMixsData.isEmpty()) {
+      List<GeospatialRequestDto> smpMixIdAndProps = smpMixsData.stream()
+          .map(smpMix -> new GeospatialRequestDto(
+              Long.valueOf(smpMix.getParentTreeId()), smpMix.getProportion()))
+          .collect(Collectors.toList());
+      meanGeomSmpMix = parentTreeService.calcMeanGeospatial(smpMixIdAndProps);
+    }
+
     SeedlotAclassFormDto seedlotAclassFullInfo =
         new SeedlotAclassFormDto(
             new SeedlotFormSubmissionDto(
@@ -655,7 +678,9 @@ public class SeedlotService {
                 List.of(),
                 null,
                 null),
-            calculatedGenWorth);
+            calculatedGenWorth,
+            meanGeomSeedlot,
+            meanGeomSmpMix);
 
     SparLog.info("Seedlot registration info found for seedlot {}", seedlotNumber);
     return seedlotAclassFullInfo;

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -678,6 +678,7 @@ public class SeedlotService {
         null,
         seedlotInfo.getCollectionElevation());
   }
+  
   private GeospatialRespondDto buildMeanGeomSmpMix(List<SmpMix> smpMixsData) {
     if (smpMixsData.isEmpty()) {
       return null;

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -639,29 +639,6 @@ public class SeedlotService {
     SeedlotFormSmpParentOutsideDto smpParentOutsideDto =
         new SeedlotFormSmpParentOutsideDto(seedlotInfo.getParentsOutsideTheOrchardUsedInSmp());
 
-    GeospatialRespondDto meanGeomSeedlot = null;
-    if (seedlotInfo.getCollectionLatitudeDeg() != null) {
-      meanGeomSeedlot = new GeospatialRespondDto(
-          seedlotInfo.getCollectionLatitudeDeg(),
-          seedlotInfo.getCollectionLatitudeMin(),
-          seedlotInfo.getCollectionLatitudeSec(),
-          seedlotInfo.getCollectionLongitudeDeg(),
-          seedlotInfo.getCollectionLongitudeMin(),
-          seedlotInfo.getCollectionLongitudeSec(),
-          null,
-          null,
-          seedlotInfo.getCollectionElevation());
-    }
-
-    GeospatialRespondDto meanGeomSmpMix = null;
-    if (!smpMixsData.isEmpty()) {
-      List<GeospatialRequestDto> smpMixIdAndProps = smpMixsData.stream()
-          .map(smpMix -> new GeospatialRequestDto(
-              Long.valueOf(smpMix.getParentTreeId()), smpMix.getProportion()))
-          .collect(Collectors.toList());
-      meanGeomSmpMix = parentTreeService.calcMeanGeospatial(smpMixIdAndProps);
-    }
-
     SeedlotAclassFormDto seedlotAclassFullInfo =
         new SeedlotAclassFormDto(
             new SeedlotFormSubmissionDto(
@@ -679,11 +656,37 @@ public class SeedlotService {
                 null,
                 null),
             calculatedGenWorth,
-            meanGeomSeedlot,
-            meanGeomSmpMix);
+            buildMeanGeomSeedlot(seedlotInfo),
+            buildMeanGeomSmpMix(smpMixsData));
 
     SparLog.info("Seedlot registration info found for seedlot {}", seedlotNumber);
     return seedlotAclassFullInfo;
+  }
+
+  private GeospatialRespondDto buildMeanGeomSeedlot(Seedlot seedlotInfo) {
+    if (seedlotInfo.getCollectionLatitudeDeg() == null) {
+      return null;
+    }
+    return new GeospatialRespondDto(
+        seedlotInfo.getCollectionLatitudeDeg(),
+        seedlotInfo.getCollectionLatitudeMin(),
+        seedlotInfo.getCollectionLatitudeSec(),
+        seedlotInfo.getCollectionLongitudeDeg(),
+        seedlotInfo.getCollectionLongitudeMin(),
+        seedlotInfo.getCollectionLongitudeSec(),
+        null,
+        null,
+        seedlotInfo.getCollectionElevation());
+  }
+  private GeospatialRespondDto buildMeanGeomSmpMix(List<SmpMix> smpMixsData) {
+    if (smpMixsData.isEmpty()) {
+      return null;
+    }
+    List<GeospatialRequestDto> smpMixIdAndProps = smpMixsData.stream()
+        .map(smpMix -> new GeospatialRequestDto(
+            Long.valueOf(smpMix.getParentTreeId()), smpMix.getProportion()))
+        .collect(Collectors.toList());
+    return parentTreeService.calcMeanGeospatial(smpMixIdAndProps);
   }
 
   /**

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
@@ -499,7 +499,7 @@ class SeedlotEndpointTest {
   @Test
   @DisplayName("getSingleSeedlotAclassFullInfoTest")
   void getSingleSeedlotAclassFullInfoTest() throws Exception {
-    SeedlotAclassFormDto seedlotFullInfo = new SeedlotAclassFormDto(null, null);
+    SeedlotAclassFormDto seedlotFullInfo = new SeedlotAclassFormDto(null, null, null, null);
 
     when(seedlotService.getAclassSeedlotFormInfo(any())).thenReturn(seedlotFullInfo);
 

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
@@ -15,8 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ca.bc.gov.backendstartapi.dto.GeospatialRespondDto;
 import ca.bc.gov.backendstartapi.dto.GeneticWorthTraitsDto;
+import ca.bc.gov.backendstartapi.dto.GeospatialRespondDto;
 import ca.bc.gov.backendstartapi.dto.RevisionCountDto;
 import ca.bc.gov.backendstartapi.dto.SaveSeedlotFormDtoClassA;
 import ca.bc.gov.backendstartapi.dto.SeedlotAclassFormDto;

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/endpoint/SeedlotEndpointTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import ca.bc.gov.backendstartapi.dto.GeospatialRespondDto;
 import ca.bc.gov.backendstartapi.dto.GeneticWorthTraitsDto;
 import ca.bc.gov.backendstartapi.dto.RevisionCountDto;
 import ca.bc.gov.backendstartapi.dto.SaveSeedlotFormDtoClassA;
@@ -506,6 +507,32 @@ class SeedlotEndpointTest {
     mockMvc
         .perform(get("/api/seedlots/0000000/a-class-full-form").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$.meanGeomSeedlot").doesNotExist())
+        .andExpect(jsonPath("$.meanGeomSmpMix").doesNotExist())
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("getSingleSeedlotAclassFullInfoWithGeomTest")
+  void getSingleSeedlotAclassFullInfoWithGeomTest() throws Exception {
+    GeospatialRespondDto meanGeomSeedlot = new GeospatialRespondDto(
+        49, 30, 0, 124, 15, 0, null, null, 800);
+    GeospatialRespondDto meanGeomSmpMix = new GeospatialRespondDto(
+        50, 0, 0, 125, 0, 0, null, null, 900);
+    SeedlotAclassFormDto seedlotFullInfo =
+        new SeedlotAclassFormDto(null, null, meanGeomSeedlot, meanGeomSmpMix);
+
+    when(seedlotService.getAclassSeedlotFormInfo(any())).thenReturn(seedlotFullInfo);
+
+    mockMvc
+        .perform(get("/api/seedlots/0000000/a-class-full-form").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.meanGeomSeedlot.meanLatitudeDegree").value(49))
+        .andExpect(jsonPath("$.meanGeomSeedlot.meanLongitudeDegree").value(124))
+        .andExpect(jsonPath("$.meanGeomSeedlot.meanElevation").value(800))
+        .andExpect(jsonPath("$.meanGeomSmpMix.meanLatitudeDegree").value(50))
+        .andExpect(jsonPath("$.meanGeomSmpMix.meanLongitudeDegree").value(125))
+        .andExpect(jsonPath("$.meanGeomSmpMix.meanElevation").value(900))
         .andReturn();
   }
 

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -11,8 +11,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import ca.bc.gov.backendstartapi.dto.GeospatialRespondDto;
 import ca.bc.gov.backendstartapi.dto.GeneticWorthTraitsDto;
+import ca.bc.gov.backendstartapi.dto.GeospatialRespondDto;
 import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.ParentTreeGeneticQualityDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotAclassFormDto;
@@ -895,7 +895,7 @@ class SeedlotServiceTest {
   }
 
   @Test
-  @DisplayName("getAclassSeedlotFormInfo with collection coordinates returns populated meanGeomSeedlot")
+  @DisplayName("getAclassSeedlotFormInfo with collection coords returns meanGeomSeedlot")
   void getAclassSeedlotFormInfo_withCollectionCoords_returnsMeanGeomSeedlot() {
     String seedlotNumber = "0000011";
     Seedlot seedlotEntity = new Seedlot(seedlotNumber);
@@ -963,7 +963,7 @@ class SeedlotServiceTest {
   }
 
   @Test
-  @DisplayName("getAclassSeedlotFormInfo with smpMix and Oracle success returns populated meanGeomSmpMix")
+  @DisplayName("getAclassSeedlotFormInfo with smpMix Oracle success returns meanGeomSmpMix")
   void getAclassSeedlotFormInfo_withSmpMix_oracleSuccess_returnsMeanGeomSmpMix() {
     String seedlotNumber = "0000015";
     Seedlot seedlotEntity = new Seedlot(seedlotNumber);

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ca.bc.gov.backendstartapi.dto.GeospatialRespondDto;
 import ca.bc.gov.backendstartapi.dto.GeneticWorthTraitsDto;
 import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.ParentTreeGeneticQualityDto;
@@ -52,6 +53,7 @@ import ca.bc.gov.backendstartapi.entity.seedlot.SeedlotOwnerQuantity;
 import ca.bc.gov.backendstartapi.exception.ClientIdForbiddenException;
 import ca.bc.gov.backendstartapi.exception.GeneticClassNotFoundException;
 import ca.bc.gov.backendstartapi.exception.InvalidSeedlotRequestException;
+import ca.bc.gov.backendstartapi.exception.PtGeoDataNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SeedlotConflictDataException;
 import ca.bc.gov.backendstartapi.exception.SeedlotNotFoundException;
 import ca.bc.gov.backendstartapi.exception.SeedlotSourceNotFoundException;
@@ -840,5 +842,167 @@ class SeedlotServiceTest {
     verify(tscAdminService, times(1)).overrideAreaOfUse(any(), any());
     verify(tscAdminService, times(1)).overrideSeedlotCollElevLatLong(any(), any());
     verify(seedlotGeneticWorthService, times(1)).overrideSeedlotGenWorth(any(), any());
+  }
+
+  /**
+   * Sets up the minimum Mockito stubs required for getAclassSeedlotFormInfo to reach the
+   * buildMeanGeom* methods without failing on earlier service calls.
+   */
+  private void setupAclassFormMinMocks(
+      String seedlotNumber, Seedlot seedlotEntity, List<SmpMix> smpMixList) {
+    AuditInformation audit = new AuditInformation("userId");
+    when(loggedUserService.createAuditCurrentUser()).thenReturn(audit);
+
+    Integer parentTreeId = 4023;
+    SeedlotFormParentTreeSmpDto parentTreeDto = createParentTreeDto(parentTreeId);
+    ParentTreeGeneticQualityDto sptgqDto = createParentTreeGenQuaDto();
+
+    SeedlotParentTree spt =
+        new SeedlotParentTree(
+            seedlotEntity,
+            parentTreeDto.parentTreeId(),
+            parentTreeDto.parentTreeNumber(),
+            parentTreeDto.coneCount(),
+            parentTreeDto.pollenCount(),
+            audit);
+    SeedlotParentTreeGeneticQuality sptgq =
+        new SeedlotParentTreeGeneticQuality(
+            spt,
+            sptgqDto.geneticTypeCode(),
+            new GeneticWorthEntity(sptgqDto.geneticWorthCode(), "", null, BigDecimal.ZERO),
+            sptgqDto.geneticQualityValue(),
+            audit);
+    SeedlotGeneticWorth seedlotGenWor =
+        new SeedlotGeneticWorth(
+            seedlotEntity,
+            new GeneticWorthEntity(sptgqDto.geneticWorthCode(), "", null, BigDecimal.ZERO),
+            audit);
+
+    when(seedlotRepository.findById(seedlotNumber)).thenReturn(Optional.of(seedlotEntity));
+    when(seedlotParentTreeService.getAllSeedlotParentTree(seedlotNumber)).thenReturn(List.of(spt));
+    when(seedlotParentTreeGeneticQualityService.getAllBySeedlotNumber(seedlotNumber))
+        .thenReturn(List.of(sptgq));
+    when(smpMixService.getAllBySeedlotNumber(seedlotNumber)).thenReturn(smpMixList);
+    when(seedlotParentTreeSmpMixService.getAllBySeedlotNumber(seedlotNumber))
+        .thenReturn(List.of());
+    when(seedlotGeneticWorthService.getAllBySeedlotNumber(seedlotNumber))
+        .thenReturn(List.of(seedlotGenWor));
+    when(seedlotCollectionMethodService.getAllSeedlotCollectionMethodsBySeedlot(seedlotNumber))
+        .thenReturn(List.of());
+    when(seedlotOwnerQuantityService.findAllBySeedlot(seedlotNumber)).thenReturn(List.of());
+    when(seedlotOrchardService.getAllSeedlotOrchardBySeedlotNumber(seedlotNumber))
+        .thenReturn(List.of());
+  }
+
+  @Test
+  @DisplayName("getAclassSeedlotFormInfo with collection coordinates returns populated meanGeomSeedlot")
+  void getAclassSeedlotFormInfo_withCollectionCoords_returnsMeanGeomSeedlot() {
+    String seedlotNumber = "0000011";
+    Seedlot seedlotEntity = new Seedlot(seedlotNumber);
+    seedlotEntity.setCollectionLatitudeDeg(49);
+    seedlotEntity.setCollectionLatitudeMin(30);
+    seedlotEntity.setCollectionLongitudeDeg(124);
+    seedlotEntity.setCollectionLongitudeMin(15);
+    seedlotEntity.setCollectionElevation(800);
+
+    setupAclassFormMinMocks(seedlotNumber, seedlotEntity, List.of());
+
+    SeedlotAclassFormDto result = seedlotService.getAclassSeedlotFormInfo(seedlotNumber);
+
+    Assertions.assertNotNull(result.meanGeomSeedlot());
+    Assertions.assertEquals(49, result.meanGeomSeedlot().getMeanLatitudeDegree());
+    Assertions.assertEquals(30, result.meanGeomSeedlot().getMeanLatitudeMinute());
+    Assertions.assertEquals(124, result.meanGeomSeedlot().getMeanLongitudeDegree());
+    Assertions.assertEquals(15, result.meanGeomSeedlot().getMeanLongitudeMinute());
+    Assertions.assertEquals(800, result.meanGeomSeedlot().getMeanElevation());
+    Assertions.assertNull(result.meanGeomSeedlot().getMeanLatitude());
+    Assertions.assertNull(result.meanGeomSeedlot().getMeanLongitude());
+  }
+
+  @Test
+  @DisplayName("getAclassSeedlotFormInfo with null latitude degree returns null meanGeomSeedlot")
+  void getAclassSeedlotFormInfo_withNullLatDeg_returnsNullMeanGeomSeedlot() {
+    String seedlotNumber = "0000012";
+    Seedlot seedlotEntity = new Seedlot(seedlotNumber);
+    // collectionLatitudeDeg stays null
+    seedlotEntity.setCollectionLongitudeDeg(124);
+
+    setupAclassFormMinMocks(seedlotNumber, seedlotEntity, List.of());
+
+    SeedlotAclassFormDto result = seedlotService.getAclassSeedlotFormInfo(seedlotNumber);
+
+    Assertions.assertNull(result.meanGeomSeedlot());
+  }
+
+  @Test
+  @DisplayName("getAclassSeedlotFormInfo with null longitude degree returns null meanGeomSeedlot")
+  void getAclassSeedlotFormInfo_withNullLonDeg_returnsNullMeanGeomSeedlot() {
+    String seedlotNumber = "0000013";
+    Seedlot seedlotEntity = new Seedlot(seedlotNumber);
+    seedlotEntity.setCollectionLatitudeDeg(49);
+    // collectionLongitudeDeg stays null
+
+    setupAclassFormMinMocks(seedlotNumber, seedlotEntity, List.of());
+
+    SeedlotAclassFormDto result = seedlotService.getAclassSeedlotFormInfo(seedlotNumber);
+
+    Assertions.assertNull(result.meanGeomSeedlot());
+  }
+
+  @Test
+  @DisplayName("getAclassSeedlotFormInfo with empty smpMix list returns null meanGeomSmpMix")
+  void getAclassSeedlotFormInfo_withEmptySmpMix_returnsNullMeanGeomSmpMix() {
+    String seedlotNumber = "0000014";
+    Seedlot seedlotEntity = new Seedlot(seedlotNumber);
+
+    setupAclassFormMinMocks(seedlotNumber, seedlotEntity, List.of());
+
+    SeedlotAclassFormDto result = seedlotService.getAclassSeedlotFormInfo(seedlotNumber);
+
+    Assertions.assertNull(result.meanGeomSmpMix());
+  }
+
+  @Test
+  @DisplayName("getAclassSeedlotFormInfo with smpMix and Oracle success returns populated meanGeomSmpMix")
+  void getAclassSeedlotFormInfo_withSmpMix_oracleSuccess_returnsMeanGeomSmpMix() {
+    String seedlotNumber = "0000015";
+    Seedlot seedlotEntity = new Seedlot(seedlotNumber);
+    AuditInformation audit = new AuditInformation("userId");
+
+    SmpMix smpMix =
+        new SmpMix(seedlotEntity, 4023, "87", 50, new BigDecimal("0.5"), audit, 0);
+
+    GeospatialRespondDto expectedGeom =
+        new GeospatialRespondDto(50, 0, 0, 125, 0, 0, null, null, 900);
+    when(parentTreeService.calcMeanGeospatial(any())).thenReturn(expectedGeom);
+
+    setupAclassFormMinMocks(seedlotNumber, seedlotEntity, List.of(smpMix));
+
+    SeedlotAclassFormDto result = seedlotService.getAclassSeedlotFormInfo(seedlotNumber);
+
+    Assertions.assertNotNull(result.meanGeomSmpMix());
+    Assertions.assertEquals(50, result.meanGeomSmpMix().getMeanLatitudeDegree());
+    Assertions.assertEquals(125, result.meanGeomSmpMix().getMeanLongitudeDegree());
+    Assertions.assertEquals(900, result.meanGeomSmpMix().getMeanElevation());
+  }
+
+  @Test
+  @DisplayName("getAclassSeedlotFormInfo with smpMix and Oracle throws returns null meanGeomSmpMix")
+  void getAclassSeedlotFormInfo_withSmpMix_oracleThrows_returnsNullMeanGeomSmpMix() {
+    String seedlotNumber = "0000016";
+    Seedlot seedlotEntity = new Seedlot(seedlotNumber);
+    AuditInformation audit = new AuditInformation("userId");
+
+    SmpMix smpMix =
+        new SmpMix(seedlotEntity, 4023, "87", 50, new BigDecimal("0.5"), audit, 0);
+
+    when(parentTreeService.calcMeanGeospatial(any())).thenThrow(new PtGeoDataNotFoundException());
+
+    setupAclassFormMinMocks(seedlotNumber, seedlotEntity, List.of(smpMix));
+
+    SeedlotAclassFormDto result = seedlotService.getAclassSeedlotFormInfo(seedlotNumber);
+
+    Assertions.assertNotNull(result);
+    Assertions.assertNull(result.meanGeomSmpMix());
   }
 }

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -182,18 +182,23 @@ const ParentTreeStep = ({ isReviewDisplay, isReviewRead }: ParentTreeStepProps) 
     gcTime: THREE_HALF_HOURS // data is cached 3.5 hours then deleted
   });
 
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
   useEffect(() => {
     if (
       isFormSubmitted
       && allParentTreeQuery.status === 'success'
-      && Object.keys(state.allParentTreeData).length === 0
+      && allParentTreeQuery.data
+      && Object.keys(stateRef.current.allParentTreeData).length === 0
     ) {
       setStepData('parentTreeStep', {
-        ...state,
+        ...stateRef.current,
         allParentTreeData: allParentTreeQuery.data
       });
     }
-  }, [isFormSubmitted, allParentTreeQuery.status]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFormSubmitted, allParentTreeQuery.status, allParentTreeQuery.data]);
 
   // Effects 'SMP mix' tab
   useEffect(

--- a/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
+++ b/frontend/src/components/SeedlotRegistrationSteps/ParentTreeStep/index.tsx
@@ -131,6 +131,9 @@ const ParentTreeStep = ({ isReviewDisplay, isReviewRead }: ParentTreeStepProps) 
 
   const [controlReviewData, setControlReviewData] = useState<boolean>(isReviewDisplay ?? false);
 
+  const canCalculate = !(!isReviewDisplay && isFormSubmitted);
+  const hasSmpMixGeomData = meanGeomInfos.smpMix.meanElevation.value !== '';
+
   const emptySectionDescription = getEmptySectionDescription(setStep);
 
   // Link reference to trigger click event
@@ -178,6 +181,19 @@ const ParentTreeStep = ({ isReviewDisplay, isReviewRead }: ParentTreeStepProps) 
     staleTime: THREE_HOURS, // will not refetch for 3 hours
     gcTime: THREE_HALF_HOURS // data is cached 3.5 hours then deleted
   });
+
+  useEffect(() => {
+    if (
+      isFormSubmitted
+      && allParentTreeQuery.status === 'success'
+      && Object.keys(state.allParentTreeData).length === 0
+    ) {
+      setStepData('parentTreeStep', {
+        ...state,
+        allParentTreeData: allParentTreeQuery.data
+      });
+    }
+  }, [isFormSubmitted, allParentTreeQuery.status]);
 
   // Effects 'SMP mix' tab
   useEffect(
@@ -533,7 +549,7 @@ const ParentTreeStep = ({ isReviewDisplay, isReviewRead }: ParentTreeStepProps) 
                   renderRecalcSection()
                 }
                 {
-                  !(!isReviewDisplay && isFormSubmitted)
+                  (canCalculate || hasSmpMixGeomData)
                     ? (
                       <DetailSection>
                         {/* -------- SMP mix mean geospatial data -------- */}
@@ -543,10 +559,14 @@ const ParentTreeStep = ({ isReviewDisplay, isReviewRead }: ParentTreeStepProps) 
                           />
                         </Row>
                         {
-                          renderCalcSection(true)
+                          canCalculate
+                            ? renderCalcSection(true)
+                            : null
                         }
                         {
-                          showInfoSections || isReviewDisplay
+                          showInfoSections
+                          || isReviewDisplay
+                          || hasSmpMixGeomData
                             ? (
                               <InfoSection
                                 infoItems={Object.values(meanGeomInfos.smpMix)}

--- a/frontend/src/types/PtCalcTypes.ts
+++ b/frontend/src/types/PtCalcTypes.ts
@@ -8,14 +8,14 @@ export type GeneticTrait = {
 
 export type MeanGeomDataType = {
   meanLatitudeDegree: number;
-  meanLatitudeMinute: number;
-  meanLatitudeSecond: number;
+  meanLatitudeMinute: number | null;
+  meanLatitudeSecond: number | null;
   meanLongitudeDegree: number;
-  meanLongitudeMinute: number;
-  meanLongitudeSecond: number;
-  meanLatitude: number;
-  meanLongitude: number;
-  meanElevation: number;
+  meanLongitudeMinute: number | null;
+  meanLongitudeSecond: number | null;
+  meanLatitude: number | null;
+  meanLongitude: number | null;
+  meanElevation: number | null;
 };
 
 export type CalcPayloadResType = {

--- a/frontend/src/types/SeedlotType.ts
+++ b/frontend/src/types/SeedlotType.ts
@@ -323,5 +323,7 @@ export type SeedlotProgressPayloadType = {
 
 export type SeedlotAClassFullResponseType = {
   seedlotData: SeedlotAClassSubmitType,
-  calculatedValues: Array<SeedlotCalculationsResultsType>
+  calculatedValues: Array<SeedlotCalculationsResultsType>,
+  meanGeomSeedlot: MeanGeomDataType | null,
+  meanGeomSmpMix: MeanGeomDataType | null
 }

--- a/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
@@ -338,6 +338,48 @@ const ContextContainerClassA = ({ children }: props) => {
     getAllSeedlotInfoQuery.error
   ]);
 
+  // Hydrate meanGeomInfos from the stored geospatial data returned by the full-form GET,
+  // so the display values are populated on page load without needing to click Recalculate.
+  useEffect(() => {
+    if (getAllSeedlotInfoQuery.status !== 'success') {
+      return;
+    }
+    const { meanGeomSeedlot, meanGeomSmpMix } = getAllSeedlotInfoQuery.data;
+    if (!meanGeomSeedlot && !meanGeomSmpMix) {
+      return;
+    }
+    setMeanGeomInfos((prev) => ({
+      seedlot: meanGeomSeedlot ? {
+        meanLatitudeDm: {
+          ...prev.seedlot.meanLatitudeDm,
+          value: `${meanGeomSeedlot.meanLatitudeDegree}° ${meanGeomSeedlot.meanLatitudeMinute}'`
+        },
+        meanLongitudeDm: {
+          ...prev.seedlot.meanLongitudeDm,
+          value: `${meanGeomSeedlot.meanLongitudeDegree}° ${meanGeomSeedlot.meanLongitudeMinute}'`
+        },
+        meanElevation: {
+          ...prev.seedlot.meanElevation,
+          value: `${meanGeomSeedlot.meanElevation} m`
+        }
+      } : prev.seedlot,
+      smpMix: meanGeomSmpMix ? {
+        meanLatitudeDm: {
+          ...prev.smpMix.meanLatitudeDm,
+          value: `${meanGeomSmpMix.meanLatitudeDegree}° ${meanGeomSmpMix.meanLatitudeMinute}'`
+        },
+        meanLongitudeDm: {
+          ...prev.smpMix.meanLongitudeDm,
+          value: `${meanGeomSmpMix.meanLongitudeDegree}° ${meanGeomSmpMix.meanLongitudeMinute}'`
+        },
+        meanElevation: {
+          ...prev.smpMix.meanElevation,
+          value: `${meanGeomSmpMix.meanElevation} m`
+        }
+      } : prev.smpMix
+    }));
+  }, [getAllSeedlotInfoQuery.status]);
+
   useEffect(() => {
     if (
       getAllSeedlotInfoQuery.status === 'success'

--- a/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
@@ -346,39 +346,52 @@ const ContextContainerClassA = ({ children }: props) => {
     }
     const { meanGeomSeedlot, meanGeomSmpMix } = getAllSeedlotInfoQuery.data;
     if (!meanGeomSeedlot && !meanGeomSmpMix) {
+      setMeanGeomInfos(structuredClone(defaultMeanGeomConfig));
       return;
     }
     setMeanGeomInfos((prev) => ({
       seedlot: meanGeomSeedlot ? {
         meanLatitudeDm: {
           ...prev.seedlot.meanLatitudeDm,
-          value: `${meanGeomSeedlot.meanLatitudeDegree}° ${meanGeomSeedlot.meanLatitudeMinute}'`
+          value: (meanGeomSeedlot.meanLatitudeMinute != null)
+            ? `${meanGeomSeedlot.meanLatitudeDegree}° ${meanGeomSeedlot.meanLatitudeMinute}'`
+            : ''
         },
         meanLongitudeDm: {
           ...prev.seedlot.meanLongitudeDm,
-          value: `${meanGeomSeedlot.meanLongitudeDegree}° ${meanGeomSeedlot.meanLongitudeMinute}'`
+          value: (meanGeomSeedlot.meanLongitudeMinute != null)
+            ? `${meanGeomSeedlot.meanLongitudeDegree}° ${meanGeomSeedlot.meanLongitudeMinute}'`
+            : ''
         },
         meanElevation: {
           ...prev.seedlot.meanElevation,
-          value: `${meanGeomSeedlot.meanElevation} m`
+          value: (meanGeomSeedlot.meanElevation != null)
+            ? `${meanGeomSeedlot.meanElevation} m`
+            : ''
         }
       } : prev.seedlot,
       smpMix: meanGeomSmpMix ? {
         meanLatitudeDm: {
           ...prev.smpMix.meanLatitudeDm,
-          value: `${meanGeomSmpMix.meanLatitudeDegree}° ${meanGeomSmpMix.meanLatitudeMinute}'`
+          value: (meanGeomSmpMix.meanLatitudeMinute != null)
+            ? `${meanGeomSmpMix.meanLatitudeDegree}° ${meanGeomSmpMix.meanLatitudeMinute}'`
+            : ''
         },
         meanLongitudeDm: {
           ...prev.smpMix.meanLongitudeDm,
-          value: `${meanGeomSmpMix.meanLongitudeDegree}° ${meanGeomSmpMix.meanLongitudeMinute}'`
+          value: (meanGeomSmpMix.meanLongitudeMinute != null)
+            ? `${meanGeomSmpMix.meanLongitudeDegree}° ${meanGeomSmpMix.meanLongitudeMinute}'`
+            : ''
         },
         meanElevation: {
           ...prev.smpMix.meanElevation,
-          value: `${meanGeomSmpMix.meanElevation} m`
+          value: (meanGeomSmpMix.meanElevation != null)
+            ? `${meanGeomSmpMix.meanElevation} m`
+            : ''
         }
       } : prev.smpMix
     }));
-  }, [getAllSeedlotInfoQuery.status]);
+  }, [getAllSeedlotInfoQuery.status, getAllSeedlotInfoQuery.data]);
 
   useEffect(() => {
     if (

--- a/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/index.tsx
@@ -49,7 +49,7 @@ import {
   verifyInterimStepCompleteness, validateOrchardStep, verifyOrchardStepCompleteness,
   validateExtractionStep, verifyExtractionStepCompleteness, validateParentStep,
   verifyParentStepCompleteness, checkAllStepsCompletion, getSeedlotPayload,
-  initEmptySteps, resDataToState, fillAreaOfUseData, fillCollectionGeoData
+  initEmptySteps, resDataToState, fillAreaOfUseData, fillCollectionGeoData, buildGeomDisplayValues
 } from './utils';
 import {
   MAX_EDIT_BEFORE_SAVE, initialAreaOfUseData,
@@ -349,46 +349,18 @@ const ContextContainerClassA = ({ children }: props) => {
       setMeanGeomInfos(structuredClone(defaultMeanGeomConfig));
       return;
     }
+    const seedlotDisplay = buildGeomDisplayValues(meanGeomSeedlot);
+    const smpMixDisplay = buildGeomDisplayValues(meanGeomSmpMix);
     setMeanGeomInfos((prev) => ({
-      seedlot: meanGeomSeedlot ? {
-        meanLatitudeDm: {
-          ...prev.seedlot.meanLatitudeDm,
-          value: (meanGeomSeedlot.meanLatitudeMinute != null)
-            ? `${meanGeomSeedlot.meanLatitudeDegree}° ${meanGeomSeedlot.meanLatitudeMinute}'`
-            : ''
-        },
-        meanLongitudeDm: {
-          ...prev.seedlot.meanLongitudeDm,
-          value: (meanGeomSeedlot.meanLongitudeMinute != null)
-            ? `${meanGeomSeedlot.meanLongitudeDegree}° ${meanGeomSeedlot.meanLongitudeMinute}'`
-            : ''
-        },
-        meanElevation: {
-          ...prev.seedlot.meanElevation,
-          value: (meanGeomSeedlot.meanElevation != null)
-            ? `${meanGeomSeedlot.meanElevation} m`
-            : ''
-        }
+      seedlot: seedlotDisplay ? {
+        meanLatitudeDm: { ...prev.seedlot.meanLatitudeDm, value: seedlotDisplay.latDm },
+        meanLongitudeDm: { ...prev.seedlot.meanLongitudeDm, value: seedlotDisplay.lonDm },
+        meanElevation: { ...prev.seedlot.meanElevation, value: seedlotDisplay.elevation }
       } : prev.seedlot,
-      smpMix: meanGeomSmpMix ? {
-        meanLatitudeDm: {
-          ...prev.smpMix.meanLatitudeDm,
-          value: (meanGeomSmpMix.meanLatitudeMinute != null)
-            ? `${meanGeomSmpMix.meanLatitudeDegree}° ${meanGeomSmpMix.meanLatitudeMinute}'`
-            : ''
-        },
-        meanLongitudeDm: {
-          ...prev.smpMix.meanLongitudeDm,
-          value: (meanGeomSmpMix.meanLongitudeMinute != null)
-            ? `${meanGeomSmpMix.meanLongitudeDegree}° ${meanGeomSmpMix.meanLongitudeMinute}'`
-            : ''
-        },
-        meanElevation: {
-          ...prev.smpMix.meanElevation,
-          value: (meanGeomSmpMix.meanElevation != null)
-            ? `${meanGeomSmpMix.meanElevation} m`
-            : ''
-        }
+      smpMix: smpMixDisplay ? {
+        meanLatitudeDm: { ...prev.smpMix.meanLatitudeDm, value: smpMixDisplay.latDm },
+        meanLongitudeDm: { ...prev.smpMix.meanLongitudeDm, value: smpMixDisplay.lonDm },
+        meanElevation: { ...prev.smpMix.meanElevation, value: smpMixDisplay.elevation }
       } : prev.smpMix
     }));
   }, [getAllSeedlotInfoQuery.status, getAllSeedlotInfoQuery.data]);

--- a/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
@@ -47,6 +47,35 @@ import {
 } from './definitions';
 import { GenWorthCodeEnum, SingleParentTreeGeneticObj } from '../../../types/ParentTreeGeneticQualityType';
 import { ParentTreeByVegCodeResType } from '../../../types/ParentTreeTypes';
+import { MeanGeomDataType } from '../../../types/PtCalcTypes';
+
+export type GeomDisplayValues = {
+  latDm: string;
+  lonDm: string;
+  elevation: string;
+};
+
+/**
+ * Formats the DMS geospatial fields from a MeanGeomDataType into display strings,
+ * returning empty strings for individual fields that are null to avoid rendering
+ * literal "null" in the UI.
+ */
+export const buildGeomDisplayValues = (
+  geomData: MeanGeomDataType | null
+): GeomDisplayValues | null => {
+  if (!geomData) return null;
+  return {
+    latDm: geomData.meanLatitudeMinute != null
+      ? `${geomData.meanLatitudeDegree}° ${geomData.meanLatitudeMinute}'`
+      : '',
+    lonDm: geomData.meanLongitudeMinute != null
+      ? `${geomData.meanLongitudeDegree}° ${geomData.meanLongitudeMinute}'`
+      : '',
+    elevation: geomData.meanElevation != null
+      ? `${geomData.meanElevation} m`
+      : ''
+  };
+};
 
 export const initProgressBar = (
   currentStep: number,


### PR DESCRIPTION
# Description
Closes #2455

### Changelog
#### New
- return geospatial data with seedlot a full form response

#### Changed
- Allow viewing smp details when submitted or data exists

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-38.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2488-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2488-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)