### PR TITLE
feat: #2447 CONSEP API update germination test (header + activity)

### DIFF
--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminationTestHeaderDto.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminationTestHeaderDto.java
@@ -164,6 +164,22 @@ public record GerminationTestHeaderDto(
     Integer intrmdtCleanrInd,
 
     @Schema(description = "Request type status", example = "TSC")
-    String requestTypeSt
+    String requestTypeSt,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(
+        description = "update_timestamp of the test result row;"
+            + " echo back as testResultUpdateTimestamp when updating (optimistic lock)",
+        example = "2026-05-01T10:00:00"
+    )
+    LocalDateTime testResultUpdateTimestamp,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(
+        description = "update_timestamp of the activity row;"
+            + " echo back as riaUpdateTimestamp when updating (optimistic lock)",
+        example = "2026-05-01T11:00:00"
+    )
+    LocalDateTime riaUpdateTimestamp
 ) {
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminationTestUpdateFormDto.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminationTestUpdateFormDto.java
@@ -1,0 +1,57 @@
+package ca.bc.gov.oracleapi.dto.consep;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * Fields the FE sends to update a germination test header and its activity.
+ *
+ * <p>original_test_ind, current_test_ind and test_rank are intentionally
+ * absent: the backend computes them (issue #2447 AC #4).
+ */
+@Schema(
+    description =
+        "JSON object with the values to update a germination test (header + activity)"
+)
+public record GerminationTestUpdateFormDto(
+    @Schema(description = "Test category code", example = "STD")
+    @NotNull
+    String testCategoryCode,
+    @Schema(description = "Whether the test result is accepted", example = "true")
+    @NotNull
+    Boolean acceptResultInd,
+    @Schema(description = "Whether the test is complete", example = "true")
+    @NotNull
+    Boolean testCompleteInd,
+    @Schema(description = "Germinator id", example = "A")
+    @Size(max = 1)
+    String germinatorId,
+    @Schema(description = "Seed withdrawal date", example = "2026-05-01")
+    LocalDate seedWithdrawalDate,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(description = "Actual begin datetime", example = "2026-05-02T08:00:00")
+    LocalDateTime actualBeginDateTime,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(description = "Actual end datetime (Test End)", example = "2026-05-20T16:00:00")
+    LocalDateTime actualEndDateTime,
+    @Schema(description = "Comment for the activity", example = "unkilned portion only")
+    @Size(max = 2000)
+    String riaComment,
+    @Schema(description = "Whether the comment is critical", example = "false")
+    Boolean commentIsCritical,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(
+        description =
+            "update_timestamp of the test result row as read (optimistic lock)"
+    )
+    @NotNull
+    LocalDateTime testResultUpdateTimestamp,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(description = "update_timestamp of the activity row as read (optimistic lock)")
+    @NotNull
+    LocalDateTime riaUpdateTimestamp
+) {}

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpoint.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpoint.java
@@ -3,6 +3,7 @@ package ca.bc.gov.oracleapi.endpoint.consep;
 import ca.bc.gov.oracleapi.config.SparLog;
 import ca.bc.gov.oracleapi.dto.consep.DailyAbnormalResponseDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminationTestHeaderDto;
+import ca.bc.gov.oracleapi.dto.consep.GerminationTestUpdateFormDto;
 import ca.bc.gov.oracleapi.dto.consep.TestRankResponseDto;
 import ca.bc.gov.oracleapi.response.ApiAuthResponse;
 import ca.bc.gov.oracleapi.security.RoleAccessConfig;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
@@ -22,7 +24,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -182,5 +186,60 @@ public class GerminationTestEndpoint {
 
     SparLog.info("Received request to fetch germination test header for key: {}", riaKey);
     return testResultService.getGerminationTestHeader(riaKey);
+  }
+
+  /**
+   * Update a germination test header and its activity as one unit.
+   *
+   * <p>original_test_ind, current_test_ind and test_rank are computed by the
+   * backend and cannot be set by the client (issue #2447).
+   *
+   * @param riaKey identifier key for test activity related tables
+   * @param updateDto fields to update
+   * @return the refreshed germination test header
+   */
+  @PatchMapping(value = "/{riaKey}", consumes = "application/json")
+  @Operation(
+      summary = "Update germination test header and activity",
+      description = "Updates test status, dates, category and comment;"
+          + " the backend computes original/current/rank flags.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Successfully updated the germination test.",
+            content = @Content(schema = @Schema(implementation = GerminationTestHeaderDto.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request body",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "No data found for the given riaKey",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Record was modified by another user (stale update timestamp)",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "422",
+            description = "Business rule violation",
+            content = @Content(schema = @Schema(hidden = true)))
+      })
+  @ApiAuthResponse
+  @RoleAccessConfig({"SPAR_TSC_SUBMITTER", "SPAR_TSC_SUPERVISOR"})
+  public GerminationTestHeaderDto updateGerminationTest(
+      @PathVariable
+          @Positive(message = "riaKey must be a positive number")
+          @Parameter(
+              name = "riaKey",
+              in = ParameterIn.PATH,
+              description = "The ria key.",
+              required = true)
+          BigDecimal riaKey,
+      @Valid @RequestBody GerminationTestUpdateFormDto updateDto) {
+
+    SparLog.info("Received request to update germination test for key: {}", riaKey);
+    return testResultService.updateGerminationTest(riaKey, updateDto);
   }
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/ActivityRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/ActivityRepository.java
@@ -111,4 +111,33 @@ public interface ActivityRepository extends JpaRepository<ActivityEntity, BigDec
       @Param("riaKey") BigDecimal riaKey,
       @Param("updateTimestamp") LocalDateTime updateTimestamp
   );
+
+  /**
+   * Update activity dates/comment with optimistic locking (issue #2447).
+   *
+   * @return rows updated; 0 means the row changed since it was read (409).
+   */
+  @Modifying
+  @Transactional
+  @Query("""
+      UPDATE ActivityEntity a
+         SET a.actualBeginDateTime = :actualBeginDateTime,
+             a.actualEndDateTime = :actualEndDateTime,
+             a.revisedStartDate = :revisedStartDate,
+             a.revisedEndDate = :revisedEndDate,
+             a.riaComment = :riaComment,
+             a.intermediateCleaner = :intermediateCleaner,
+             a.updateTimestamp = CURRENT_TIMESTAMP
+       WHERE a.riaKey = :riaKey
+         AND a.updateTimestamp = :expectedUpdateTimestamp
+      """)
+  int updateGerminationTestActivity(
+      @Param("riaKey") BigDecimal riaKey,
+      @Param("actualBeginDateTime") LocalDateTime actualBeginDateTime,
+      @Param("actualEndDateTime") LocalDateTime actualEndDateTime,
+      @Param("revisedStartDate") LocalDate revisedStartDate,
+      @Param("revisedEndDate") LocalDate revisedEndDate,
+      @Param("riaComment") String riaComment,
+      @Param("intermediateCleaner") Integer intermediateCleaner,
+      @Param("expectedUpdateTimestamp") LocalDateTime expectedUpdateTimestamp);
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/ActivityRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/ActivityRepository.java
@@ -115,6 +115,10 @@ public interface ActivityRepository extends JpaRepository<ActivityEntity, BigDec
   /**
    * Update activity dates/comment with optimistic locking (issue #2447).
    *
+   * <p>The INTRMDT_CLEANR_IND column ({@code intermediateCleaner}) is repurposed by the
+   * germination test screen to store the "Comment is Critical" flag, hence the
+   * {@code commentIsCritical} parameter name.
+   *
    * @return rows updated; 0 means the row changed since it was read (409).
    */
   @Modifying
@@ -126,7 +130,7 @@ public interface ActivityRepository extends JpaRepository<ActivityEntity, BigDec
              a.revisedStartDate = :revisedStartDate,
              a.revisedEndDate = :revisedEndDate,
              a.riaComment = :riaComment,
-             a.intermediateCleaner = :intermediateCleaner,
+             a.intermediateCleaner = :commentIsCritical,
              a.updateTimestamp = CURRENT_TIMESTAMP
        WHERE a.riaKey = :riaKey
          AND a.updateTimestamp = :expectedUpdateTimestamp
@@ -138,6 +142,6 @@ public interface ActivityRepository extends JpaRepository<ActivityEntity, BigDec
       @Param("revisedStartDate") LocalDate revisedStartDate,
       @Param("revisedEndDate") LocalDate revisedEndDate,
       @Param("riaComment") String riaComment,
-      @Param("intermediateCleaner") Integer intermediateCleaner,
+      @Param("commentIsCritical") Integer commentIsCritical,
       @Param("expectedUpdateTimestamp") LocalDateTime expectedUpdateTimestamp);
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/TestResultRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/TestResultRepository.java
@@ -195,7 +195,9 @@ public interface TestResultRepository extends JpaRepository<TestResultEntity, Bi
             a.dryWeight,
             a.drybackWeight,
             a.intermediateCleaner,
-            r.requestTypeSt
+            r.requestTypeSt,
+            tst.updateTimestamp,
+            a.updateTimestamp
     )
     FROM TestResultEntity tst
     JOIN ActivityEntity a
@@ -220,8 +222,8 @@ public interface TestResultRepository extends JpaRepository<TestResultEntity, Bi
       WHERE a.seedlotNumber = :seedlotNumber
         AND t.activityType = :activityType
         AND t.testCategory = :testCategory
-        AND t.testCompleteInd = -1
-        AND t.acceptResult = -1
+        AND t.testCompleteInd <> 0
+        AND t.acceptResult <> 0
       """)
   LocalDateTime findMinCompletedAcceptedEndDate(
       @Param("seedlotNumber") String seedlotNumber,
@@ -237,8 +239,8 @@ public interface TestResultRepository extends JpaRepository<TestResultEntity, Bi
       WHERE a.seedlotNumber = :seedlotNumber
         AND t.activityType = :activityType
         AND t.testCategory = :testCategory
-        AND t.testCompleteInd = -1
-        AND t.acceptResult = -1
+        AND t.testCompleteInd <> 0
+        AND t.acceptResult <> 0
       """)
   LocalDateTime findMaxCompletedAcceptedEndDate(
       @Param("seedlotNumber") String seedlotNumber,

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/TestResultRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/TestResultRepository.java
@@ -5,6 +5,7 @@ import ca.bc.gov.oracleapi.dto.consep.GerminationTestHeaderDto;
 import ca.bc.gov.oracleapi.entity.consep.TestResultEntity;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -206,4 +207,145 @@ public interface TestResultRepository extends JpaRepository<TestResultEntity, Bi
   Optional<GerminationTestHeaderDto> findGerminationTestHeaderByRiaKey(
       @Param("riaKey") BigDecimal riaKey
   );
+
+  /**
+   * Earliest actual end among completed (+accepted) tests of the same
+   * seedlot / activity type / category. Spec: "Update (test and activity)".
+   */
+  @Query("""
+      SELECT MIN(a.actualEndDateTime)
+      FROM TestResultEntity t
+      JOIN ActivityEntity a
+        ON a.riaKey = t.riaKey
+      WHERE a.seedlotNumber = :seedlotNumber
+        AND t.activityType = :activityType
+        AND t.testCategory = :testCategory
+        AND t.testCompleteInd = -1
+        AND t.acceptResult = -1
+      """)
+  LocalDateTime findMinCompletedAcceptedEndDate(
+      @Param("seedlotNumber") String seedlotNumber,
+      @Param("activityType") String activityType,
+      @Param("testCategory") String testCategory);
+
+  /** Latest actual end among completed (+accepted) tests; see min variant. */
+  @Query("""
+      SELECT MAX(a.actualEndDateTime)
+      FROM TestResultEntity t
+      JOIN ActivityEntity a
+        ON a.riaKey = t.riaKey
+      WHERE a.seedlotNumber = :seedlotNumber
+        AND t.activityType = :activityType
+        AND t.testCategory = :testCategory
+        AND t.testCompleteInd = -1
+        AND t.acceptResult = -1
+      """)
+  LocalDateTime findMaxCompletedAcceptedEndDate(
+      @Param("seedlotNumber") String seedlotNumber,
+      @Param("activityType") String activityType,
+      @Param("testCategory") String testCategory);
+
+  /** All rank 'A' tests for a seedlot (rank computation input). */
+  @Query("""
+      SELECT t
+      FROM TestResultEntity t
+      JOIN ActivityEntity a
+        ON a.riaKey = t.riaKey
+      WHERE a.seedlotNumber = :seedlotNumber
+        AND t.testRank = 'A'
+      """)
+  List<TestResultEntity> findRankATestsBySeedlot(
+      @Param("seedlotNumber") String seedlotNumber);
+
+  /**
+   * Update the germination test header with optimistic locking.
+   * Related Test Results columns are zeroed on save per spec.
+   *
+   * @return rows updated; 0 means the row changed since it was read (409).
+   */
+  @Modifying
+  @Transactional
+  @Query("""
+      UPDATE TestResultEntity t
+         SET t.originalTest = :originalTest,
+             t.currentTest = :currentTest,
+             t.testRank = :testRank,
+             t.testCompleteInd = :testCompleteInd,
+             t.acceptResult = :acceptResult,
+             t.germinatorId = :germinatorId,
+             t.seedWithdrawDate = :seedWithdrawDate,
+             t.testCategory = :testCategory,
+             t.moisturePct = 0,
+             t.weightPer100 = 0,
+             t.seedsPerGram = 0,
+             t.purityPct = 0,
+             t.otherTestResult = 0,
+             t.updateTimestamp = CURRENT_TIMESTAMP
+       WHERE t.riaKey = :riaKey
+         AND t.updateTimestamp = :expectedUpdateTimestamp
+      """)
+  int updateGerminationTestHeader(
+      @Param("riaKey") BigDecimal riaKey,
+      @Param("originalTest") Integer originalTest,
+      @Param("currentTest") Integer currentTest,
+      @Param("testRank") String testRank,
+      @Param("testCompleteInd") Integer testCompleteInd,
+      @Param("acceptResult") Integer acceptResult,
+      @Param("germinatorId") String germinatorId,
+      @Param("seedWithdrawDate") LocalDate seedWithdrawDate,
+      @Param("testCategory") String testCategory,
+      @Param("expectedUpdateTimestamp") LocalDateTime expectedUpdateTimestamp);
+
+  /** Reset original_test_ind on sibling tests (post-update, AC #5). */
+  @Modifying
+  @Transactional
+  @Query("""
+      UPDATE TestResultEntity t
+         SET t.originalTest = 0,
+             t.updateTimestamp = CURRENT_TIMESTAMP
+       WHERE t.riaKey <> :riaKey
+         AND t.activityType = :activityType
+         AND t.testCategory = :testCategory
+         AND EXISTS (
+               SELECT 1 FROM ActivityEntity a
+                WHERE a.riaKey = t.riaKey
+                  AND a.seedlotNumber = :seedlotNumber)
+      """)
+  int resetOriginalTestIndForSiblings(
+      @Param("riaKey") BigDecimal riaKey,
+      @Param("activityType") String activityType,
+      @Param("testCategory") String testCategory,
+      @Param("seedlotNumber") String seedlotNumber);
+
+  /** Reset current_test_ind on sibling tests (post-update, AC #5). */
+  @Modifying
+  @Transactional
+  @Query("""
+      UPDATE TestResultEntity t
+         SET t.currentTest = 0,
+             t.updateTimestamp = CURRENT_TIMESTAMP
+       WHERE t.riaKey <> :riaKey
+         AND t.activityType = :activityType
+         AND t.testCategory = :testCategory
+         AND EXISTS (
+               SELECT 1 FROM ActivityEntity a
+                WHERE a.riaKey = t.riaKey
+                  AND a.seedlotNumber = :seedlotNumber)
+      """)
+  int resetCurrentTestIndForSiblings(
+      @Param("riaKey") BigDecimal riaKey,
+      @Param("activityType") String activityType,
+      @Param("testCategory") String testCategory,
+      @Param("seedlotNumber") String seedlotNumber);
+
+  /**
+   * Remove the test from its germinator location when Complete is first
+   * checked. No entity maps CNS_T_ASSIGND_GERM_LOC, hence native SQL.
+   */
+  @Modifying
+  @Transactional
+  @Query(
+      value = "DELETE FROM CONSEP.CNS_T_ASSIGND_GERM_LOC WHERE RIA_SKEY = :riaKey",
+      nativeQuery = true)
+  void deleteAssignedGermLocation(@Param("riaKey") BigDecimal riaKey);
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
@@ -2,6 +2,7 @@ package ca.bc.gov.oracleapi.service.consep;
 
 import ca.bc.gov.oracleapi.config.SparLog;
 import ca.bc.gov.oracleapi.dto.consep.DailyAbnormalResponseDto;
+import ca.bc.gov.oracleapi.dto.consep.GerminationTestUpdateFormDto;
 import ca.bc.gov.oracleapi.dto.consep.GermTestResultDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminationTestHeaderDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayCreateDto;
@@ -33,6 +34,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -750,6 +752,78 @@ public class TestResultService {
       throw new ResponseStatusException(
           HttpStatus.UNPROCESSABLE_ENTITY,
           repName + " germinated + abnormal total exceeds total seeds");
+    }
+  }
+
+  /**
+   * Update a germination test header and its activity as a single unit.
+   * Implements issue #2447 / Confluence "Update (test and activity)".
+   *
+   * @param riaKey the test's RIA key
+   * @param dto the fields to update
+   * @return the refreshed germination test header
+   */
+  @Transactional
+  public GerminationTestHeaderDto updateGerminationTest(
+      BigDecimal riaKey, GerminationTestUpdateFormDto dto) {
+
+    TestResultEntity storedTest = testResultRepository.findById(riaKey)
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "No germination test found for riaKey " + riaKey));
+    ActivityEntity storedActivity = activityRepository.findById(riaKey)
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "No activity found for riaKey " + riaKey));
+
+    boolean accept = Boolean.TRUE.equals(dto.acceptResultInd());
+    boolean complete = Boolean.TRUE.equals(dto.testCompleteInd());
+
+    validateGerminationTestUpdate(dto, storedTest, accept, complete);
+
+    // Updates implemented in the next tasks.
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  private void validateGerminationTestUpdate(
+      GerminationTestUpdateFormDto dto, TestResultEntity storedTest,
+      boolean accept, boolean complete) {
+
+    if (accept && !complete) {
+      throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+          "Cannot accept a test that has not been marked as complete");
+    }
+
+    boolean beginRequired = accept || complete
+        || (dto.riaComment() != null && !dto.riaComment().isBlank())
+        || dto.actualEndDateTime() != null;
+    if (beginRequired && dto.actualBeginDateTime() == null) {
+      throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+          "Begin date is mandatory when the test is accepted or complete,"
+              + " or a comment or test end is provided");
+    }
+
+    if (dto.actualBeginDateTime() != null && dto.actualEndDateTime() != null
+        && !dto.actualEndDateTime().isAfter(dto.actualBeginDateTime())) {
+      throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+          "Test end must be after begin date");
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    if (dto.actualBeginDateTime() != null && dto.actualBeginDateTime().isAfter(now)) {
+      throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+          "Begin date cannot be in the future");
+    }
+    if (dto.seedWithdrawalDate() != null
+        && dto.seedWithdrawalDate().isAfter(now.toLocalDate())) {
+      throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+          "Seed withdrawal date cannot be in the future");
+    }
+
+    boolean storedComplete = storedTest.getTestCompleteInd() != null
+        && storedTest.getTestCompleteInd() != 0;
+    if (storedComplete
+        && !dto.testCategoryCode().equals(storedTest.getTestCategory())) {
+      throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+          "Category cannot be updated once the test is complete");
     }
   }
 

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
@@ -45,6 +45,9 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class TestResultService {
 
+  /** Rank "A" is the primary/best rank assigned to the first accepted STD germination test. */
+  private static final String RANK_A = "A";
+
   private final TestResultRepository testResultRepository;
   private final GerminatorTrayRepository germinatorTrayRepository;
   private final ActivityRepository activityRepository;
@@ -789,34 +792,13 @@ public class TestResultService {
     String activityType = storedTest.getActivityType();
     String category = dto.testCategoryCode();
 
-    int updOriginal = 0;
-    int updCurrent = 0;
-    if (accept) {
-      LocalDateTime minEnd = testResultRepository
-          .findMinCompletedAcceptedEndDate(seedlotNumber, activityType, category);
-      LocalDateTime maxEnd = testResultRepository
-          .findMaxCompletedAcceptedEndDate(seedlotNumber, activityType, category);
-      if (maxEnd == null || effectiveEnd.isAfter(maxEnd)) {
-        updCurrent = -1;
-      }
-      if (minEnd == null || effectiveEnd.isBefore(minEnd)) {
-        updOriginal = -1;
-      }
-    }
+    int[] flags = computeOriginalCurrentFlags(
+        accept, effectiveEnd, seedlotNumber, activityType, category);
+    int updOriginal = flags[0];
+    int updCurrent = flags[1];
 
-    String updRank = null;
-    if ("STD".equals(category) && accept) {
-      List<TestResultEntity> rankATests =
-          testResultRepository.findRankATestsBySeedlot(seedlotNumber);
-      boolean anotherTestIsCurrent = rankATests.stream()
-          .anyMatch(t -> Integer.valueOf(-1).equals(t.getCurrentTest())
-              && !riaKey.equals(t.getRiaKey()));
-      if (updOriginal == -1 && updCurrent == -1 && rankATests.isEmpty()) {
-        updRank = "A";
-      } else if (updCurrent == -1 && anotherTestIsCurrent) {
-        updRank = "A";
-      }
-    }
+    String updRank = computeRankUpdate(
+        accept, category, seedlotNumber, riaKey, updOriginal, updCurrent);
 
     boolean storedComplete = storedTest.getTestCompleteInd() != null
         && storedTest.getTestCompleteInd() != 0;
@@ -861,7 +843,8 @@ public class TestResultService {
         .orElseThrow(() -> new ResponseStatusException(
             HttpStatus.NOT_FOUND, "No germination test found for riaKey " + riaKey));
 
-    // Spec comment: "the first completed activity processes the commitment".
+    // Spec: "the first completed activity processes the commitment" — skip if a sibling activity
+    // already has processCommitIndicator set (findConflictingActivities non-empty).
     if (complete && ("RTS".equals(refreshed.requestTypeSt())
         || "TST".equals(refreshed.requestTypeSt()))) {
       boolean alreadyProcessed = !activityRepository.findConflictingActivities(
@@ -872,6 +855,78 @@ public class TestResultService {
     }
 
     return refreshed;
+  }
+
+  /**
+   * Computes the original-test and current-test flag values for a germination test update.
+   *
+   * <p>Returns an {@code int[2]} where index 0 is {@code updOriginal} and index 1 is
+   * {@code updCurrent}. Each value is {@code -1} (set) or {@code 0} (leave unchanged).
+   *
+   * <p>Note: accept =&gt; complete =&gt; effectiveEnd non-null
+   * (enforced in validateGerminationTestUpdate).
+   *
+   * @param accept whether the test is being accepted
+   * @param effectiveEnd the resolved test-end timestamp (non-null when accept is true)
+   * @param seedlotNumber the seedlot number
+   * @param activityType the activity type code
+   * @param category the test category code
+   * @return int[2] with [updOriginal, updCurrent]
+   */
+  private int[] computeOriginalCurrentFlags(
+      boolean accept, LocalDateTime effectiveEnd,
+      String seedlotNumber, String activityType, String category) {
+
+    int updOriginal = 0;
+    int updCurrent = 0;
+    if (accept) {
+      // accept => complete => effectiveEnd non-null (enforced in validateGerminationTestUpdate)
+      LocalDateTime minEnd = testResultRepository
+          .findMinCompletedAcceptedEndDate(seedlotNumber, activityType, category);
+      LocalDateTime maxEnd = testResultRepository
+          .findMaxCompletedAcceptedEndDate(seedlotNumber, activityType, category);
+      if (maxEnd == null || effectiveEnd.isAfter(maxEnd)) {
+        updCurrent = -1;
+      }
+      if (minEnd == null || effectiveEnd.isBefore(minEnd)) {
+        updOriginal = -1;
+      }
+    }
+    return new int[]{updOriginal, updCurrent};
+  }
+
+  /**
+   * Determines the rank value to write when accepting a STD germination test.
+   *
+   * <p>Returns {@value #RANK_A} when this test should become the primary (rank A) result,
+   * or {@code null} when no rank change is needed.
+   *
+   * @param accept whether the test is being accepted
+   * @param category the test category code
+   * @param seedlotNumber the seedlot number
+   * @param riaKey the test's RIA key (used to exclude self from sibling checks)
+   * @param updOriginal the original-test flag computed by {@link #computeOriginalCurrentFlags}
+   * @param updCurrent the current-test flag computed by {@link #computeOriginalCurrentFlags}
+   * @return rank string or {@code null}
+   */
+  private String computeRankUpdate(
+      boolean accept, String category, String seedlotNumber,
+      BigDecimal riaKey, int updOriginal, int updCurrent) {
+
+    if (!"STD".equals(category) || !accept) {
+      return null;
+    }
+    List<TestResultEntity> rankATests =
+        testResultRepository.findRankATestsBySeedlot(seedlotNumber);
+    boolean anotherTestIsCurrent = rankATests.stream()
+        .anyMatch(t -> Integer.valueOf(-1).equals(t.getCurrentTest())
+            && !riaKey.equals(t.getRiaKey()));
+    if (updOriginal == -1 && updCurrent == -1 && rankATests.isEmpty()) {
+      return RANK_A;
+    } else if (updCurrent == -1 && anotherTestIsCurrent) {
+      return RANK_A;
+    }
+    return null;
   }
 
   private LocalDate computeRevisedEndDate(
@@ -967,7 +1022,7 @@ public class TestResultService {
     }
 
     long existingAcceptedStdRankA = testResultRepository.countAcceptedStdRankA(seedlotNumber);
-    String rank = existingAcceptedStdRankA > 0 ? "P" : "A";
+    String rank = existingAcceptedStdRankA > 0 ? "P" : RANK_A;
 
     SparLog.info(
         "Determined test rank={} for seedlot={} (existing accepted STD rank-A count={})",

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
@@ -157,7 +157,9 @@ public class TestResultService {
           dto.dryWeight(),
           dto.drybackWeight(),
           dto.intrmdtCleanrInd(),
-          dto.requestTypeSt());
+          dto.requestTypeSt(),
+          dto.testResultUpdateTimestamp(),
+          dto.riaUpdateTimestamp());
 
     } catch (IncorrectResultSizeDataAccessException ex) {
       SparLog.error("Data integrity issue: multiple rows found for RIA_SKEY {}", riaKey, ex);
@@ -780,13 +782,14 @@ public class TestResultService {
     boolean accept = Boolean.TRUE.equals(dto.acceptResultInd());
     boolean complete = Boolean.TRUE.equals(dto.testCompleteInd());
 
-    validateGerminationTestUpdate(dto, storedTest, accept, complete);
-
-    // Spec: when Complete is checked, Test End defaults to now.
+    // Spec: when Complete is checked, Test End defaults to now. Resolved before
+    // validation so the end-after-begin rule also covers the defaulted value.
     LocalDateTime effectiveEnd = dto.actualEndDateTime();
     if (complete && effectiveEnd == null) {
       effectiveEnd = LocalDateTime.now();
     }
+
+    validateGerminationTestUpdate(dto, storedTest, accept, complete, effectiveEnd);
 
     String seedlotNumber = storedActivity.getSeedlotNumber();
     String activityType = storedTest.getActivityType();
@@ -885,10 +888,13 @@ public class TestResultService {
           .findMinCompletedAcceptedEndDate(seedlotNumber, activityType, category);
       LocalDateTime maxEnd = testResultRepository
           .findMaxCompletedAcceptedEndDate(seedlotNumber, activityType, category);
-      if (maxEnd == null || effectiveEnd.isAfter(maxEnd)) {
+      // Field-description semantics: current stays set unless some test ends
+      // strictly LATER; original unless some test ends strictly EARLIER. Ties
+      // (e.g. re-saving the same test) therefore keep the flag.
+      if (maxEnd == null || !effectiveEnd.isBefore(maxEnd)) {
         updCurrent = -1;
       }
-      if (minEnd == null || effectiveEnd.isBefore(minEnd)) {
+      if (minEnd == null || !effectiveEnd.isAfter(minEnd)) {
         updOriginal = -1;
       }
     }
@@ -919,7 +925,7 @@ public class TestResultService {
     List<TestResultEntity> rankATests =
         testResultRepository.findRankATestsBySeedlot(seedlotNumber);
     boolean anotherTestIsCurrent = rankATests.stream()
-        .anyMatch(t -> Integer.valueOf(-1).equals(t.getCurrentTest())
+        .anyMatch(t -> t.getCurrentTest() != null && t.getCurrentTest() != 0
             && !riaKey.equals(t.getRiaKey()));
     if (updOriginal == -1 && updCurrent == -1 && rankATests.isEmpty()) {
       return RANK_A;
@@ -949,7 +955,7 @@ public class TestResultService {
 
   private void validateGerminationTestUpdate(
       GerminationTestUpdateFormDto dto, TestResultEntity storedTest,
-      boolean accept, boolean complete) {
+      boolean accept, boolean complete, LocalDateTime effectiveEnd) {
 
     if (accept && !complete) {
       throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
@@ -965,8 +971,8 @@ public class TestResultService {
               + " or a comment or test end is provided");
     }
 
-    if (dto.actualBeginDateTime() != null && dto.actualEndDateTime() != null
-        && !dto.actualEndDateTime().isAfter(dto.actualBeginDateTime())) {
+    if (dto.actualBeginDateTime() != null && effectiveEnd != null
+        && !effectiveEnd.isAfter(dto.actualBeginDateTime())) {
       throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
           "Test end must be after begin date");
     }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
@@ -779,8 +779,117 @@ public class TestResultService {
 
     validateGerminationTestUpdate(dto, storedTest, accept, complete);
 
-    // Updates implemented in the next tasks.
-    throw new UnsupportedOperationException("not yet implemented");
+    // Spec: when Complete is checked, Test End defaults to now.
+    LocalDateTime effectiveEnd = dto.actualEndDateTime();
+    if (complete && effectiveEnd == null) {
+      effectiveEnd = LocalDateTime.now();
+    }
+
+    String seedlotNumber = storedActivity.getSeedlotNumber();
+    String activityType = storedTest.getActivityType();
+    String category = dto.testCategoryCode();
+
+    int updOriginal = 0;
+    int updCurrent = 0;
+    if (accept) {
+      LocalDateTime minEnd = testResultRepository
+          .findMinCompletedAcceptedEndDate(seedlotNumber, activityType, category);
+      LocalDateTime maxEnd = testResultRepository
+          .findMaxCompletedAcceptedEndDate(seedlotNumber, activityType, category);
+      if (maxEnd == null || effectiveEnd.isAfter(maxEnd)) {
+        updCurrent = -1;
+      }
+      if (minEnd == null || effectiveEnd.isBefore(minEnd)) {
+        updOriginal = -1;
+      }
+    }
+
+    String updRank = null;
+    if ("STD".equals(category) && accept) {
+      List<TestResultEntity> rankATests =
+          testResultRepository.findRankATestsBySeedlot(seedlotNumber);
+      boolean anotherTestIsCurrent = rankATests.stream()
+          .anyMatch(t -> Integer.valueOf(-1).equals(t.getCurrentTest())
+              && !riaKey.equals(t.getRiaKey()));
+      if (updOriginal == -1 && updCurrent == -1 && rankATests.isEmpty()) {
+        updRank = "A";
+      } else if (updCurrent == -1 && anotherTestIsCurrent) {
+        updRank = "A";
+      }
+    }
+
+    boolean storedComplete = storedTest.getTestCompleteInd() != null
+        && storedTest.getTestCompleteInd() != 0;
+    if (complete && !storedComplete) {
+      testResultRepository.deleteAssignedGermLocation(riaKey);
+    }
+
+    int testRows = testResultRepository.updateGerminationTestHeader(
+        riaKey, updOriginal, updCurrent, updRank,
+        complete ? -1 : 0, accept ? -1 : 0,
+        dto.germinatorId(), dto.seedWithdrawalDate(), category,
+        dto.testResultUpdateTimestamp());
+    if (testRows == 0) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT,
+          "Test result was modified by another user; reload and retry");
+    }
+
+    int activityRows = activityRepository.updateGerminationTestActivity(
+        riaKey, dto.actualBeginDateTime(), effectiveEnd,
+        dto.actualBeginDateTime() == null ? null : dto.actualBeginDateTime().toLocalDate(),
+        computeRevisedEndDate(effectiveEnd, dto.actualBeginDateTime(),
+            storedActivity.getActivityDuration(), storedActivity.getActivityTimeUnit()),
+        dto.riaComment(),
+        Boolean.TRUE.equals(dto.commentIsCritical()) ? -1 : 0,
+        dto.riaUpdateTimestamp());
+    if (activityRows == 0) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT,
+          "Activity was modified by another user; reload and retry");
+    }
+
+    if (updOriginal == -1) {
+      testResultRepository.resetOriginalTestIndForSiblings(
+          riaKey, activityType, category, seedlotNumber);
+    }
+    if (updCurrent == -1) {
+      testResultRepository.resetCurrentTestIndForSiblings(
+          riaKey, activityType, category, seedlotNumber);
+    }
+
+    GerminationTestHeaderDto refreshed = testResultRepository
+        .findGerminationTestHeaderByRiaKey(riaKey)
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "No germination test found for riaKey " + riaKey));
+
+    // Spec comment: "the first completed activity processes the commitment".
+    if (complete && ("RTS".equals(refreshed.requestTypeSt())
+        || "TST".equals(refreshed.requestTypeSt()))) {
+      boolean alreadyProcessed = !activityRepository.findConflictingActivities(
+          riaKey, storedActivity.getRequestSkey(), storedActivity.getItemId()).isEmpty();
+      if (!alreadyProcessed) {
+        activityRepository.markSignificantAndCommit(riaKey);
+      }
+    }
+
+    return refreshed;
+  }
+
+  private LocalDate computeRevisedEndDate(
+      LocalDateTime effectiveEnd, LocalDateTime begin,
+      Integer duration, String timeUnit) {
+    if (effectiveEnd != null) {
+      return effectiveEnd.toLocalDate();
+    }
+    if (begin == null || duration == null) {
+      return null;
+    }
+    return switch (timeUnit == null ? "DY" : timeUnit) {
+      case "HR" -> begin.plusHours(duration).toLocalDate();
+      case "WK" -> begin.plusWeeks(duration).toLocalDate();
+      case "MO" -> begin.plusMonths(duration).toLocalDate();
+      case "YR" -> begin.plusYears(duration).toLocalDate();
+      default -> begin.plusDays(duration).toLocalDate();
+    };
   }
 
   private void validateGerminationTestUpdate(

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
@@ -34,10 +34,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 /** The class for Moisture Content Cones Service and test result service. */

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpointTest.java
@@ -1,12 +1,16 @@
 package ca.bc.gov.oracleapi.endpoint.consep;
 
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -25,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -274,6 +279,95 @@ public class GerminationTestEndpointTest {
 
     mockMvc
         .perform(get("/api/germination-tests/{riaKey}", riaKey))
+        .andExpect(status().isNotFound());
+  }
+
+  private static final String UPDATE_BODY = """
+      {
+        "testCategoryCode": "STD",
+        "acceptResultInd": true,
+        "testCompleteInd": true,
+        "germinatorId": "A",
+        "seedWithdrawalDate": "2026-04-30",
+        "actualBeginDateTime": "2026-05-02T08:00:00",
+        "actualEndDateTime": "2026-05-20T16:00:00",
+        "riaComment": "looks good",
+        "commentIsCritical": false,
+        "testResultUpdateTimestamp": "2026-05-01T10:00:00",
+        "riaUpdateTimestamp": "2026-05-01T11:00:00"
+      }
+      """;
+
+  @Test
+  void updateGerminationTest_validBody_returns200WithHeader() throws Exception {
+    BigDecimal riaKey = new BigDecimal("1234567890");
+    GerminationTestHeaderDto response = createHeaderDto(riaKey);
+    when(testResultService.updateGerminationTest(eq(riaKey), any()))
+        .thenReturn(response);
+
+    mockMvc
+        .perform(patch("/api/germination-tests/{riaKey}", riaKey)
+            .with(csrf().asHeader())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(UPDATE_BODY))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.riaSkey").value(1234567890L))
+        .andExpect(jsonPath("$.requestTypeSt").value("TSC"));
+
+    verify(testResultService).updateGerminationTest(eq(riaKey), any());
+  }
+
+  @Test
+  void updateGerminationTest_missingMandatoryField_returns400() throws Exception {
+    String missingCategory = UPDATE_BODY.replace("\"testCategoryCode\": \"STD\",", "");
+
+    mockMvc
+        .perform(patch("/api/germination-tests/{riaKey}", new BigDecimal("1234"))
+            .with(csrf().asHeader())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(missingCategory))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(testResultService);
+  }
+
+  @Test
+  void updateGerminationTest_serviceSaysConflict_returns409() throws Exception {
+    when(testResultService.updateGerminationTest(any(), any()))
+        .thenThrow(new ResponseStatusException(HttpStatus.CONFLICT, "stale"));
+
+    mockMvc
+        .perform(patch("/api/germination-tests/{riaKey}", new BigDecimal("1234"))
+            .with(csrf().asHeader())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(UPDATE_BODY))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void updateGerminationTest_serviceSaysUnprocessable_returns422() throws Exception {
+    when(testResultService.updateGerminationTest(any(), any()))
+        .thenThrow(new ResponseStatusException(
+            HttpStatus.UNPROCESSABLE_ENTITY, "cannot accept incomplete test"));
+
+    mockMvc
+        .perform(patch("/api/germination-tests/{riaKey}", new BigDecimal("1234"))
+            .with(csrf().asHeader())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(UPDATE_BODY))
+        .andExpect(status().isUnprocessableEntity());
+  }
+
+  @Test
+  void updateGerminationTest_serviceSaysNotFound_returns404() throws Exception {
+    when(testResultService.updateGerminationTest(any(), any()))
+        .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "missing"));
+
+    mockMvc
+        .perform(patch("/api/germination-tests/{riaKey}", new BigDecimal("1234"))
+            .with(csrf().asHeader())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(UPDATE_BODY))
         .andExpect(status().isNotFound());
   }
 

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpointTest.java
@@ -405,7 +405,9 @@ public class GerminationTestEndpointTest {
         new BigDecimal("10.220"), // dryWeight
         new BigDecimal("9.880"), // drybackWeight
         0, // intrmdtCleanrInd
-        "TSC" // requestTypeSt
+        "TSC", // requestTypeSt
+        LocalDateTime.parse("2026-05-01T10:00:00"), // testResultUpdateTimestamp
+        LocalDateTime.parse("2026-05-01T11:00:00") // riaUpdateTimestamp
     );
   }
 }

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
@@ -1047,7 +1047,9 @@ class TestResultServiceTest {
         new BigDecimal("10.220"), // dryWeight
         new BigDecimal("9.880"), // drybackWeight
         0, // intrmdtCleanrInd
-        "TSC" // requestTypeSt
+        "TSC", // requestTypeSt
+        TST_TS, // testResultUpdateTimestamp
+        RIA_TS // riaUpdateTimestamp
         );
   }
 
@@ -1217,7 +1219,7 @@ class TestResultServiceTest {
     return new GerminationTestHeaderDto(
         RIA_KEY, "G23", null, null, "STD", null, null, 0, 0, null, -1, null,
         null, null, null, null, null, null, null, 21, "DY", null, null, null,
-        null, null, null, null, null, null, null, null, "RTS");
+        null, null, null, null, null, null, null, null, "RTS", TST_TS, RIA_TS);
   }
 
   private void mockHappyPathRepos() {
@@ -1290,6 +1292,29 @@ class TestResultServiceTest {
 
     verify(testResultRepository).updateGerminationTestHeader(
         eq(RIA_KEY), eq(0), eq(0), isNull(), eq(-1), eq(-1),
+        eq("A"), eq(LocalDate.of(2026, 4, 30)), eq("STD"), eq(TST_TS));
+  }
+
+  @Test
+  void updateGerminationTest_acceptedEndEqualsSiblingEnds_keepsFlagsSet() {
+    // Re-saving a test whose end ties the sibling min/max must keep both
+    // flags (field-description semantics: only strictly earlier/later ends
+    // clear them). Guards against the strict-comparison regression.
+    mockHappyPathRepos();
+    LocalDateTime tiedEnd = LocalDateTime.of(2026, 5, 20, 16, 0);
+    when(testResultRepository.findMinCompletedAcceptedEndDate("60001", "G23", "STD"))
+        .thenReturn(tiedEnd);
+    when(testResultRepository.findMaxCompletedAcceptedEndDate("60001", "G23", "STD"))
+        .thenReturn(tiedEnd);
+    when(testResultRepository.findRankATestsBySeedlot("60001"))
+        .thenReturn(List.of());
+
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    testResultService.updateGerminationTest(
+        RIA_KEY, updateDto(true, true, begin, tiedEnd, null));
+
+    verify(testResultRepository).updateGerminationTestHeader(
+        eq(RIA_KEY), eq(-1), eq(-1), eq("A"), eq(-1), eq(-1),
         eq("A"), eq(LocalDate.of(2026, 4, 30)), eq("STD"), eq(TST_TS));
   }
 

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
@@ -1206,6 +1208,167 @@ class TestResultServiceTest {
                 LocalDateTime.of(2026, 5, 20, 8, 0), null)));
 
     assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
+  }
+
+  /*---------------------- updateGerminationTest update flow ---------------------------------*/
+
+  private GerminationTestHeaderDto headerDto() {
+    return new GerminationTestHeaderDto(
+        RIA_KEY, "G23", null, null, "STD", null, null, 0, 0, null, -1, null,
+        null, null, null, null, null, null, null, 21, "DY", null, null, null,
+        null, null, null, null, null, null, null, null, "RTS");
+  }
+
+  private void mockHappyPathRepos() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+    when(testResultRepository.updateGerminationTestHeader(
+        any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(1);
+    when(activityRepository.updateGerminationTestActivity(
+        any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(1);
+    when(testResultRepository.findGerminationTestHeaderByRiaKey(RIA_KEY))
+        .thenReturn(Optional.of(headerDto()));
+  }
+
+  @Test
+  void updateGerminationTest_notAccepted_writesZeroFlagsAndNullRank() {
+    mockHappyPathRepos();
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+
+    testResultService.updateGerminationTest(RIA_KEY, updateDto(false, false, begin, null, null));
+
+    verify(testResultRepository).updateGerminationTestHeader(
+        eq(RIA_KEY), eq(0), eq(0), isNull(), eq(0), eq(0),
+        eq("A"), eq(LocalDate.of(2026, 4, 30)), eq("STD"), eq(TST_TS));
+    verify(testResultRepository, never()).resetOriginalTestIndForSiblings(
+        any(), any(), any(), any());
+    verify(testResultRepository, never()).resetCurrentTestIndForSiblings(
+        any(), any(), any(), any());
+  }
+
+  @Test
+  void updateGerminationTest_acceptedNoSiblings_setsOriginalCurrentAndRankA() {
+    mockHappyPathRepos();
+    when(testResultRepository.findMinCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findMaxCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findRankATestsBySeedlot("60001"))
+        .thenReturn(List.of());
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    LocalDateTime end = LocalDateTime.of(2026, 5, 20, 16, 0);
+
+    testResultService.updateGerminationTest(RIA_KEY, updateDto(true, true, begin, end, null));
+
+    verify(testResultRepository).updateGerminationTestHeader(
+        eq(RIA_KEY), eq(-1), eq(-1), eq("A"), eq(-1), eq(-1),
+        eq("A"), eq(LocalDate.of(2026, 4, 30)), eq("STD"), eq(TST_TS));
+    verify(testResultRepository).resetOriginalTestIndForSiblings(
+        RIA_KEY, "G23", "STD", "60001");
+    verify(testResultRepository).resetCurrentTestIndForSiblings(
+        RIA_KEY, "G23", "STD", "60001");
+  }
+
+  @Test
+  void updateGerminationTest_acceptedBetweenSiblingEnds_keepsFlagsZero() {
+    mockHappyPathRepos();
+    when(testResultRepository.findMinCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(LocalDateTime.of(2026, 5, 1, 0, 0));
+    when(testResultRepository.findMaxCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(LocalDateTime.of(2026, 5, 30, 0, 0));
+    when(testResultRepository.findRankATestsBySeedlot("60001"))
+        .thenReturn(List.of());
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    LocalDateTime end = LocalDateTime.of(2026, 5, 20, 16, 0);
+
+    testResultService.updateGerminationTest(RIA_KEY, updateDto(true, true, begin, end, null));
+
+    verify(testResultRepository).updateGerminationTestHeader(
+        eq(RIA_KEY), eq(0), eq(0), isNull(), eq(-1), eq(-1),
+        eq("A"), eq(LocalDate.of(2026, 4, 30)), eq("STD"), eq(TST_TS));
+  }
+
+  @Test
+  void updateGerminationTest_acceptedLatestEnd_replacesCurrentRankA() {
+    mockHappyPathRepos();
+    when(testResultRepository.findMinCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(LocalDateTime.of(2026, 5, 1, 0, 0));
+    when(testResultRepository.findMaxCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(LocalDateTime.of(2026, 5, 10, 0, 0));
+    TestResultEntity otherRankA = new TestResultEntity();
+    otherRankA.setRiaKey(new BigDecimal("9999"));
+    otherRankA.setCurrentTest(-1);
+    when(testResultRepository.findRankATestsBySeedlot("60001"))
+        .thenReturn(List.of(otherRankA));
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    LocalDateTime end = LocalDateTime.of(2026, 5, 20, 16, 0);
+
+    testResultService.updateGerminationTest(RIA_KEY, updateDto(true, true, begin, end, null));
+
+    verify(testResultRepository).updateGerminationTestHeader(
+        eq(RIA_KEY), eq(0), eq(-1), eq("A"), eq(-1), eq(-1),
+        eq("A"), eq(LocalDate.of(2026, 4, 30)), eq("STD"), eq(TST_TS));
+    verify(testResultRepository).resetCurrentTestIndForSiblings(
+        RIA_KEY, "G23", "STD", "60001");
+    verify(testResultRepository, never()).resetOriginalTestIndForSiblings(
+        any(), any(), any(), any());
+  }
+
+  @Test
+  void updateGerminationTest_staleTestResultTimestamp_throwsConflict() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+    when(testResultRepository.updateGerminationTestHeader(
+        any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(0);
+
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY, updateDto(false, false, LocalDateTime.of(2026, 5, 2, 8, 0), null, null)));
+
+    assertEquals(HttpStatus.CONFLICT, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_staleActivityTimestamp_throwsConflict() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+    when(testResultRepository.updateGerminationTestHeader(
+        any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(1);
+    when(activityRepository.updateGerminationTestActivity(
+        any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(0);
+
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY, updateDto(false, false, LocalDateTime.of(2026, 5, 2, 8, 0), null, null)));
+
+    assertEquals(HttpStatus.CONFLICT, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_incompleteWithoutEnd_derivesRevisedEndFromDuration() {
+    mockHappyPathRepos();
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+
+    testResultService.updateGerminationTest(RIA_KEY, updateDto(false, false, begin, null, null));
+
+    verify(activityRepository).updateGerminationTestActivity(
+        eq(RIA_KEY), eq(begin), isNull(),
+        eq(begin.toLocalDate()),
+        eq(begin.toLocalDate().plusDays(21)),
+        isNull(), eq(0), eq(RIA_TS));
   }
 
   private void setAllAbnormalCountsToZero(DailyAbnormalEntity entity) {

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
@@ -1184,7 +1184,7 @@ class TestResultServiceTest {
         ResponseStatusException.class,
         () -> testResultService.updateGerminationTest(
             RIA_KEY,
-            updateDto(false, false, LocalDateTime.now().plusDays(2), null, null)));
+            updateDto(false, false, LocalDateTime.of(2099, 1, 1, 0, 0), null, null)));
 
     assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
   }

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeast;
@@ -1369,6 +1370,80 @@ class TestResultServiceTest {
         eq(begin.toLocalDate()),
         eq(begin.toLocalDate().plusDays(21)),
         isNull(), eq(0), eq(RIA_TS));
+  }
+
+  @Test
+  void updateGerminationTest_completeRtsRequest_processesCommitment() {
+    mockHappyPathRepos();
+    when(testResultRepository.findMinCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findMaxCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findRankATestsBySeedlot(anyString()))
+        .thenReturn(List.of());
+    when(activityRepository.findConflictingActivities(
+        RIA_KEY, new BigDecimal("9001"), "A"))
+        .thenReturn(List.of());
+
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    LocalDateTime end = LocalDateTime.of(2026, 5, 20, 16, 0);
+    testResultService.updateGerminationTest(
+        RIA_KEY, updateDto(true, true, begin, end, null));
+
+    verify(activityRepository).markSignificantAndCommit(RIA_KEY);
+  }
+
+  @Test
+  void updateGerminationTest_commitmentAlreadyProcessed_skipsCommit() {
+    mockHappyPathRepos();
+    when(testResultRepository.findMinCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findMaxCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findRankATestsBySeedlot(anyString()))
+        .thenReturn(List.of());
+    when(activityRepository.findConflictingActivities(
+        RIA_KEY, new BigDecimal("9001"), "A"))
+        .thenReturn(List.of(new ActivityEntity()));
+
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    LocalDateTime end = LocalDateTime.of(2026, 5, 20, 16, 0);
+    testResultService.updateGerminationTest(
+        RIA_KEY, updateDto(true, true, begin, end, null));
+
+    verify(activityRepository, never()).markSignificantAndCommit(any());
+  }
+
+  @Test
+  void updateGerminationTest_notComplete_skipsCommitmentAndGermLocDelete() {
+    mockHappyPathRepos();
+
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    testResultService.updateGerminationTest(
+        RIA_KEY, updateDto(false, false, begin, null, null));
+
+    verify(activityRepository, never()).markSignificantAndCommit(any());
+    verify(testResultRepository, never()).deleteAssignedGermLocation(any());
+  }
+
+  @Test
+  void updateGerminationTest_completeFirstTime_removesAssignedGermLocation() {
+    mockHappyPathRepos();
+    when(testResultRepository.findMinCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findMaxCompletedAcceptedEndDate(any(), any(), any()))
+        .thenReturn(null);
+    when(testResultRepository.findRankATestsBySeedlot(anyString()))
+        .thenReturn(List.of());
+    when(activityRepository.findConflictingActivities(any(), any(), any()))
+        .thenReturn(List.of());
+
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 2, 8, 0);
+    LocalDateTime end = LocalDateTime.of(2026, 5, 20, 16, 0);
+    testResultService.updateGerminationTest(
+        RIA_KEY, updateDto(true, true, begin, end, null));
+
+    verify(testResultRepository).deleteAssignedGermLocation(RIA_KEY);
   }
 
   private void setAllAbnormalCountsToZero(DailyAbnormalEntity entity) {

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ca.bc.gov.oracleapi.dto.consep.DailyAbnormalResponseDto;
+import ca.bc.gov.oracleapi.dto.consep.GerminationTestUpdateFormDto;
 import ca.bc.gov.oracleapi.dto.consep.GermTestResultDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminationTestHeaderDto;
 import ca.bc.gov.oracleapi.dto.consep.GerminatorTrayCreateDto;
@@ -1059,6 +1060,152 @@ class TestResultServiceTest {
     rep.setId(new ReplicateId(riaSkey, repNo));
     rep.setTotalNoSeeds(totalSeeds);
     return rep;
+  }
+
+  /*---------------------- updateGerminationTest validations ---------------------------------*/
+
+  private static final BigDecimal RIA_KEY = new BigDecimal("1234");
+  private static final LocalDateTime TST_TS = LocalDateTime.of(2026, 5, 1, 10, 0);
+  private static final LocalDateTime RIA_TS = LocalDateTime.of(2026, 5, 1, 11, 0);
+
+  private TestResultEntity storedTest(Integer completeInd, String category) {
+    TestResultEntity entity = new TestResultEntity();
+    entity.setRiaKey(RIA_KEY);
+    entity.setActivityType("G23");
+    entity.setTestCategory(category);
+    entity.setTestCompleteInd(completeInd);
+    entity.setUpdateTimestamp(TST_TS);
+    return entity;
+  }
+
+  private ActivityEntity storedActivity() {
+    ActivityEntity activity = new ActivityEntity();
+    activity.setRiaKey(RIA_KEY);
+    activity.setSeedlotNumber("60001");
+    activity.setRequestSkey(new BigDecimal("9001"));
+    activity.setItemId("A");
+    activity.setActivityDuration(21);
+    activity.setActivityTimeUnit("DY");
+    activity.setUpdateTimestamp(RIA_TS);
+    return activity;
+  }
+
+  private GerminationTestUpdateFormDto updateDto(
+      Boolean accept, Boolean complete,
+      LocalDateTime begin, LocalDateTime end, String comment) {
+    return new GerminationTestUpdateFormDto(
+        "STD", accept, complete, "A", LocalDate.of(2026, 4, 30),
+        begin, end, comment, false, TST_TS, RIA_TS);
+  }
+
+  @Test
+  void updateGerminationTest_unknownRiaKey_throwsNotFound() {
+    when(testResultRepository.findById(RIA_KEY)).thenReturn(Optional.empty());
+
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY,
+            updateDto(false, false, LocalDateTime.of(2026, 5, 2, 8, 0), null, null)));
+
+    assertEquals(HttpStatus.NOT_FOUND, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_acceptWithoutComplete_throwsUnprocessable() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY,
+            updateDto(true, false, LocalDateTime.of(2026, 5, 2, 8, 0), null, null)));
+
+    assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_completeWithoutBeginDate_throwsUnprocessable() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY, updateDto(false, true, null, null, null)));
+
+    assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_commentWithoutBeginDate_throwsUnprocessable() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY, updateDto(false, false, null, null, "a comment")));
+
+    assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_endNotAfterBegin_throwsUnprocessable() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+
+    LocalDateTime begin = LocalDateTime.of(2026, 5, 10, 8, 0);
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY, updateDto(false, false, begin, begin.minusDays(1), null)));
+
+    assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_beginInFuture_throwsUnprocessable() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(0, "STD")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY,
+            updateDto(false, false, LocalDateTime.now().plusDays(2), null, null)));
+
+    assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
+  }
+
+  @Test
+  void updateGerminationTest_categoryChangeOnCompletedTest_throwsUnprocessable() {
+    when(testResultRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedTest(-1, "QA")));
+    when(activityRepository.findById(RIA_KEY))
+        .thenReturn(Optional.of(storedActivity()));
+
+    // dto category is STD, stored is QA and test already complete
+    ResponseStatusException exc = assertThrows(
+        ResponseStatusException.class,
+        () -> testResultService.updateGerminationTest(
+            RIA_KEY,
+            updateDto(false, true,
+                LocalDateTime.of(2026, 5, 2, 8, 0),
+                LocalDateTime.of(2026, 5, 20, 8, 0), null)));
+
+    assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exc.getStatusCode());
   }
 
   private void setAllAbnormalCountsToZero(DailyAbnormalEntity entity) {


### PR DESCRIPTION
## Summary

Adds `PATCH /api/germination-tests/{riaKey}` (oracle-api) that updates the germination test header (`CNS_T_TSC_TEST_RESULT`) and its activity (`CNS_T_RQST_ITM_ACTVTY`) atomically, per the Confluence "Germination Testing" spec ("Update (test and activity)" + "Post update processing").

Closes #2447

## Acceptance criteria → tests

| AC | Test |
|---|---|
| Cannot accept a test not marked complete | `updateGerminationTest_acceptWithoutComplete_throwsUnprocessable` |
| Begin Date mandatory when accepted/complete/comment/Test End | `updateGerminationTest_completeWithoutBeginDate_throwsUnprocessable`, `…_commentWithoutBeginDate_…` |
| Test end must be after begin date | `updateGerminationTest_endNotAfterBegin_throwsUnprocessable` |
| Backend determines original/current_test_ind; client cannot set | flags absent from `GerminationTestUpdateFormDto`; computed in service (`updateGerminationTest_accepted*` flag-matrix tests) |
| Original/Current updated → reset flags on sibling tests | `updateGerminationTest_acceptedNoSiblings_setsOriginalCurrentAndRankA`, `…_acceptedLatestEnd_replacesCurrentRankA` |
| Test + activity + post-update commit/rollback as a unit | single `@Transactional` service method; optimistic-lock conflict tests (`…_staleTestResultTimestamp_throwsConflict`, `…_staleActivityTimestamp_throwsConflict`) |

Also implemented from spec: Test End defaults to now when Complete checked; first-time Complete removes `CNS_T_ASSIGND_GERM_LOC` row; Related Test Results columns zeroed on save; rank recomputation (STD + Accepted); RTS/TST first-completed-activity commitment processing; revised start/end derivation.

## API contract notes (FE ticket impact)

Optimistic locking implemented per spec SQL: request must include `testResultUpdateTimestamp` and `riaUpdateTimestamp` (values read from the GET header endpoint). Stale timestamp → **409 Conflict**. Other statuses: 400 invalid body, 404 unknown riaKey, 422 business-rule violation.

## Deviations from Confluence pseudocode (please confirm)

1. `If Test End < qry.min_end → updOriginal = 0` is a no-op contradicting the field-description table (original = -1 when no earlier-ending test). **Implemented as -1.**
2. `revised_end_dt` CASE uses `:TestEnd + duration` in the TestEnd-IS-NULL branch (always NULL); field description says Begin Date + duration. **Implemented as begin + duration.**
3. Commitment processing is unconditional in the pseudocode, but its comment says "the first **completed** activity processes the commitment". **Implemented to run only when Complete is checked** — reviewer please confirm.
4. Germ Tolerance transaction on Complete is out of scope (belongs to the replicates/counts ticket).
5. (post-Copilot-review) Flag comparisons follow the field-description table rather than the pseudocode's strict `>`/`<`: original/current stay set on ties (covers re-saving the same test), and the sibling min/max queries treat indicator columns as non-zero-true since this repo's own endpoints write `1` while legacy data uses `-1`.

## Test plan

- [x] `mvn verify` green (all oracle-api tests + checkstyle)
- [x] 16 new service tests (validations, flag matrix, 409s, commitment/germ-loc) + 5 new MockMvc endpoint tests (200/400/404/409/422)
- [ ] Manual smoke against dev once a FE consumer exists

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-4.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2504-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2504-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)
