### PR TITLE
fix(security): isolate actuator endpoints on a dedicated management port

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -76,7 +76,7 @@ objects:
         metadata:
           annotations:
             prometheus.io/scrape: "true"
-            prometheus.io/port: "8090"
+            prometheus.io/port: "8091"
             prometheus.io/path: "/metrics"
           labels:
             app: ${NAME}-${ZONE}
@@ -136,17 +136,19 @@ objects:
               ports:
                 - name: container-port
                   containerPort: 8090
+                - name: management-port
+                  containerPort: 8091
               readinessProbe:
                 httpGet:
                   path: /health
-                  port: container-port
+                  port: management-port
               livenessProbe:
                 httpGet:
                   path: /health
-                  port: container-port
+                  port: management-port
               startupProbe:
                 tcpSocket:
-                  port: container-port
+                  port: management-port
                 failureThreshold: 45
   - apiVersion: v1
     kind: Service

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -55,8 +55,8 @@ forest-client-api.key = ${FORESTCLIENTAPI_KEY:placeholder-api-key}
 
 # Metrics
 # Actuator endpoints live on a dedicated management port that is not exposed
-# by the OpenShift route; only in-cluster consumers (probes, Prometheus
-# scraping) can reach them.
+# by the OpenShift route (or Service). They are reachable only via the Pod IP
+# from within the cluster (e.g., probes, Prometheus scraping).
 management.server.port=8091
 management.endpoint.metrics.enabled=false
 management.endpoint.prometheus.enabled=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -54,11 +54,15 @@ forest-client-api.address = ${FORESTCLIENTAPI_ADDRESS:https://nr-forest-client-a
 forest-client-api.key = ${FORESTCLIENTAPI_KEY:placeholder-api-key}
 
 # Metrics
+# Actuator endpoints live on a dedicated management port that is not exposed
+# by the OpenShift route; only in-cluster consumers (probes, Prometheus
+# scraping) can reach them.
+management.server.port=8091
 management.endpoint.metrics.enabled=false
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.path-mapping.prometheus=metrics
 management.endpoints.web.base-path=/
-management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoints.web.exposure.include=health,info,prometheus
 management.metrics.export.prometheus.enabled=true
 
 # App fnfo


### PR DESCRIPTION
## Summary

Resolves CodeQL alert #339 (`java/spring-boot-exposed-actuators-config`).

**Problem:** `management.endpoints.web.base-path=/` + `anyRequest().permitAll()` in SecurityConfig meant `/health`, `/info` and `/metrics` (the path-mapped prometheus endpoint) were all reachable **unauthenticated through the public route**. Prometheus metrics can leak internal details (URIs, timings, JVM info).

**Fix:** move all actuator endpoints to a dedicated management port:

- `management.server.port=8091` — the OpenShift route still targets `8090`, so actuators are no longer publicly reachable at all
- readiness/liveness/startup probes → `management-port` (8091)
- `prometheus.io/port` annotation → `8091` (annotation-based scraping hits the pod IP directly, no Service change needed)
- dropped redundant `metrics` from `exposure.include` (that endpoint is disabled; `/metrics` is the path-mapped prometheus endpoint)

Unchanged: app port 8090, Service/Route, Dockerfile TCP healthcheck (checks 8090, still the app port).

## Verification

- [x] `mvn verify` green (backend)
- [x] YAML validated
- [ ] PR deploy env: pods become ready (probes on 8091) — gated by the Deploy check on this PR
- [ ] After merge: confirm Sysdig/Prometheus still collects backend metrics, then close CodeQL alert #339 if it doesn't auto-resolve

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-7.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2507-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2507-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)