### PR TITLE
fix: resolve backend checkstyle violations

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/response/FieldIssue.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/response/FieldIssue.java
@@ -3,5 +3,5 @@ package ca.bc.gov.backendstartapi.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /** Represents a single field-level validation issue with its name and error message. */
-@Schema(description = "An object with fields name and the respective error massages")
+@Schema(description = "An object with fields fieldName and fieldMessage")
 public record FieldIssue(String fieldName, String fieldMessage) {}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/response/FieldIssue.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/response/FieldIssue.java
@@ -2,5 +2,6 @@ package ca.bc.gov.backendstartapi.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+/** Represents a single field-level validation issue with its name and error message. */
 @Schema(description = "An object with fields name and the respective error massages")
 public record FieldIssue(String fieldName, String fieldMessage) {}

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormValidationServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormValidationServiceTest.java
@@ -226,7 +226,8 @@ class SeedlotFormValidationServiceTest {
   // ----- O2: species mismatch message content --------------------------------
 
   @Test
-  @DisplayName("O2 (strengthened): species-mismatch error message contains the orchard species code")
+  @DisplayName(
+      "O2 (strengthened): species-mismatch error message contains the orchard species code")
   void orchard_speciesMismatch_errorMessageContainsOrchardSpecies() {
     // Seedlot is PLI; orchard 405 has vegCode FDC -> message should mention "FDC"
     stubValidOrchard("405", "FDC");
@@ -546,7 +547,8 @@ class SeedlotFormValidationServiceTest {
   }
 
   @Test
-  @DisplayName("C1: upstream 403 (non-404 4xx) from forest client propagates, not a validation error")
+  @DisplayName(
+      "C1: upstream 403 (non-404 4xx) from forest client propagates, not a validation error")
   void collection_clientLocationForbidden_propagates() {
     stubValidOrchard("405", "PLI");
     stubValidOrchard("406", "PLI");

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -855,12 +855,16 @@ class SeedlotServiceTest {
   }
 
   @Test
-  @DisplayName("No DB mutation when validation fails: seedlotRepository.save and step services are never called")
+  @DisplayName(
+      "No DB mutation when validation fails: seedlotRepository.save and step services"
+          + " are never called")
   void updateSeedlotWithForm_invalidForm_doesNotPersist() {
     String statusCode = "PND";
     SeedlotStatusEntity seedlotStatusEntity =
         new SeedlotStatusEntity(
-            statusCode, "Pending", new EffectiveDateRange(LocalDate.now().minusDays(1L), LocalDate.now()));
+            statusCode,
+            "Pending",
+            new EffectiveDateRange(LocalDate.now().minusDays(1L), LocalDate.now()));
 
     String seedlotNumber = "63636";
     Seedlot seedlot = new Seedlot(seedlotNumber);
@@ -902,7 +906,8 @@ class SeedlotServiceTest {
     verify(seedlotRepository, never()).save(any());
 
     // CRITICAL: step-1 service must never be called (proves mutations were blocked)
-    verify(seedlotCollectionMethodService, never()).saveSeedlotFormStep1(any(), any(), anyBoolean());
+    verify(seedlotCollectionMethodService, never())
+        .saveSeedlotFormStep1(any(), any(), anyBoolean());
 
     // CRITICAL: step-2 service must never be called (proves mutations were blocked)
     verify(seedlotOwnerQuantityService, never()).saveSeedlotFormStep2(any(), any(), anyBoolean());


### PR DESCRIPTION
Fix 6 Checkstyle errors that broke the scheduled Backend Java CI:
- Add missing class Javadoc to FieldIssue (MissingJavadocType)
- Wrap 5 lines exceeding the 100-char limit in SeedlotFormValidationServiceTest and SeedlotServiceTest (LineLength)

Formatting only; no behaviour change.

# Description
Closes #issue

### Changelog
#### New
-

#### Changed
-

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-10.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2510-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2510-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)