### PR TITLE
fix: #2542 don't send empty string for secondary orchard id and check for e…

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotFormValidationService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotFormValidationService.java
@@ -72,7 +72,7 @@ public class SeedlotFormValidationService {
         seedlot, dto.primaryOrchardId(), "seedlotFormOrchardDto.primaryOrchardId", errors);
 
     // O4: secondary orchard (same O1-O3 checks, only when present)
-    if (dto.secondaryOrchardId() != null) {
+    if (dto.secondaryOrchardId() != null && !dto.secondaryOrchardId().isBlank()) {
       validateOrchardId(
           seedlot,
           dto.secondaryOrchardId(),
@@ -120,7 +120,7 @@ public class SeedlotFormValidationService {
 
   private void validateOrchardId(
       Seedlot seedlot, String orchardId, String fieldId, List<SeedlotValidationError> errors) {
-    if (orchardId == null) {
+    if (orchardId == null || orchardId.isBlank()) {
       return;
     }
     Optional<OrchardDto> orchardOpt = oracleApiProvider.findOrchardById(orchardId);

--- a/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
+++ b/frontend/src/views/Seedlot/ContextContainerClassA/utils.ts
@@ -919,10 +919,13 @@ export const convertOrchard = (
   parentTreeRows: RowDataDictType
 ): OrchardFormSubmitType => {
   const primaryOrchardId = orchardData.orchards.primaryOrchard.value.code;
-  const secondaryOrchardId = (orchardData.orchards.primaryOrchard.value.code
-    !== orchardData.orchards.secondaryOrchard.value.code)
-    ? orchardData.orchards.secondaryOrchard.value.code
-    : null;
+  const secondaryCode = orchardData.orchards.secondaryOrchard.value.code;
+  const secondaryOrchardId =
+    orchardData.orchards.secondaryOrchard.enabled
+    && secondaryCode
+    && primaryOrchardId !== secondaryCode
+      ? secondaryCode
+      : null;
 
   return ({
     primaryOrchardId,


### PR DESCRIPTION
…mpty string in orchard id validation

# Description
Closes #2542

### Changelog
#### New
-

#### Changed
- send null instead of empty string for secondary orchard id
- check for empty string when validating orchard id's

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-44.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2544-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2544-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)