### PR TITLE
fix: #2541 fix for saving crietria api

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/config/NativeImageConfig.java
@@ -137,5 +137,5 @@ import org.springframework.context.annotation.ImportRuntimeHints;
     SeedlotSaveInMemoryDto.class,
     ValueUtil.class,
 })
-@ImportRuntimeHints(value = {HttpServletRequestRuntimeHint.class})
+@ImportRuntimeHints(value = {HttpServletRequestRuntimeHint.class, ValidationRuntimeHint.class})
 public class NativeImageConfig {}

--- a/backend/src/main/java/ca/bc/gov/backendstartapi/config/ValidationRuntimeHint.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/config/ValidationRuntimeHint.java
@@ -1,0 +1,29 @@
+package ca.bc.gov.backendstartapi.config;
+
+import ca.bc.gov.backendstartapi.validation.ValidSearchCriteriaJsonValidator;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * Registers reflection hints for custom {@link jakarta.validation.ConstraintValidator}
+ * implementations.
+ *
+ * <p>Hibernate Validator instantiates constraint validators reflectively through their no-arg
+ * constructor. In a GraalVM native image that constructor is removed unless explicitly registered,
+ * which otherwise surfaces at runtime as "No default constructor found".
+ */
+public class ValidationRuntimeHint implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(@NonNull RuntimeHints hints, @Nullable ClassLoader classLoader) {
+    hints
+        .reflection()
+        .registerType(
+            ValidSearchCriteriaJsonValidator.class,
+            MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
+            MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+  }
+}


### PR DESCRIPTION
# Description
Closes #2541 

### Changelog

#### Changed
- fix for saving crietria api



### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-46.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2546-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2546-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)