### PR TITLE
feat: 2527 adds b-class seedlots card

### DIFF
--- a/frontend/src/components/SeedlotCards/constants.ts
+++ b/frontend/src/components/SeedlotCards/constants.ts
@@ -15,18 +15,20 @@ export const cards = [
     displayForAdmin: true,
     displayForNonAdmin: true
   },
-  // {
-  //   id: '2',
-  //   image: 'Farm_01',
-  //   header: 'Register a B-class seedlot',
-  //   description:
-  //     'Register a seedlot which has been collected from a natural stand',
-  //   link: '#',
-  //   highlighted: false,
-  //   isEmpty: false,
-  //   emptyTitle: '',
-  //   emptyDescription: ''
-  // },
+  {
+    id: '2',
+    image: 'Farm_01',
+    header: 'Register a B-class seedlot',
+    description:
+      'Register a seedlot which has been collected from a natural stand',
+    link: ROUTES.SEEDLOTS_B_CLASS_CREATION,
+    highlighted: false,
+    isEmpty: false,
+    emptyTitle: '',
+    emptyDescription: '',
+    displayForAdmin: true,
+    displayForNonAdmin: true
+  },
   {
     id: '3',
     image: 'Sprout',


### PR DESCRIPTION
# Description
Closes #2527

### Changelog
#### New
- seedlot b class card

#### Changed
-

#### Removed
-

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [ ] 🤖 Added tests

<!-- Sections below are optional, uncomment them to add related info -->

<!-- ## Are there any post-deployment tasks we need to perform? -->

###  What gif/image best describes this PR or how it makes you feel?
<!-- GIFs For Github Chrome Extension https://chromewebstore.google.com/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep consider using width="200" in the img tag -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-3.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2603-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2603-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)