### PR TITLE
fix: #2616 SMP contribution lost from genetic worth on review and approve

### DIFF
--- a/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
+++ b/backend/src/main/java/ca/bc/gov/backendstartapi/service/SeedlotService.java
@@ -68,6 +68,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -970,6 +971,62 @@ public class SeedlotService {
     SparLog.info("BEC values set");
   }
 
+  /**
+   * Computes the weighted SMP mix breeding values that feed the SMP contribution term of the
+   * genetic worth calculation.
+   *
+   * <p>The calculator multiplies each SMP breeding value by SMP success and the female crop
+   * contribution, so an all-zero value silently removes the SMP contribution from the persisted
+   * genetic worth. Mirrors what the registration form computes client-side: for each trait, the
+   * sum over the SMP mix rows of {@code geneticQualityValue * proportion}, where proportion is the
+   * row's share of the total volume (0-1).
+   *
+   * @param smpPtDtoList the submitted SMP mix parent trees, each carrying its proportion and
+   *     genetic qualities; may be null or empty
+   * @return the per-trait weighted SMP breeding values, all zero when there is no SMP mix
+   */
+  static SeedlotManagementBreedingValueDto calculateSmpMixBreedingValues(
+      List<SeedlotFormParentTreeSmpDto> smpPtDtoList) {
+    Map<String, BigDecimal> weightedByTrait = new HashMap<>();
+
+    if (smpPtDtoList != null) {
+      for (SeedlotFormParentTreeSmpDto smpPt : smpPtDtoList) {
+        BigDecimal proportion = smpPt.proportion();
+        if (proportion == null || smpPt.parentTreeGeneticQualities() == null) {
+          continue;
+        }
+        for (ParentTreeGeneticQualityDto genQual : smpPt.parentTreeGeneticQualities()) {
+          if (genQual.geneticWorthCode() == null || genQual.geneticQualityValue() == null) {
+            continue;
+          }
+          weightedByTrait.merge(
+              genQual.geneticWorthCode().toLowerCase(),
+              genQual.geneticQualityValue().multiply(proportion),
+              BigDecimal::add);
+        }
+      }
+    }
+
+    return new SeedlotManagementBreedingValueDto(
+        traitValue(weightedByTrait, "ad"),
+        traitValue(weightedByTrait, "dfs"),
+        traitValue(weightedByTrait, "dfu"),
+        traitValue(weightedByTrait, "dfw"),
+        traitValue(weightedByTrait, "dsb"),
+        traitValue(weightedByTrait, "dsc"),
+        traitValue(weightedByTrait, "dsg"),
+        traitValue(weightedByTrait, "gvo"),
+        traitValue(weightedByTrait, "iws"),
+        traitValue(weightedByTrait, "wdu"),
+        traitValue(weightedByTrait, "wve"),
+        traitValue(weightedByTrait, "wwd"));
+  }
+
+  private static Double traitValue(Map<String, BigDecimal> weightedByTrait, String traitCode) {
+    BigDecimal value = weightedByTrait.get(traitCode);
+    return value == null ? 0.0 : value.doubleValue();
+  }
+
   private void setParentTreeContribution(
       Seedlot seedlot,
       List<SeedlotFormParentTreeSmpDto> orchardPtDtoList,
@@ -984,7 +1041,7 @@ public class SeedlotService {
     PtValsCalReqDto ptValsCalReqDto =
         new PtValsCalReqDto(
             orchardPtVals, smpMixIdAndProps, smpParentsOutside,
-                contaminantPollenBv, new SeedlotManagementBreedingValueDto());
+                contaminantPollenBv, calculateSmpMixBreedingValues(smpPtDtoList));
 
     PtCalculationResDto ptCalculationResDto = parentTreeService.calculatePtVals(ptValsCalReqDto);
 

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotFormPutTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ca.bc.gov.backendstartapi.dto.CalculatedParentTreeValsDto;
@@ -13,6 +14,7 @@ import ca.bc.gov.backendstartapi.dto.GeospatialRespondDto;
 import ca.bc.gov.backendstartapi.dto.OrchardDto;
 import ca.bc.gov.backendstartapi.dto.ParentTreeGeneticQualityDto;
 import ca.bc.gov.backendstartapi.dto.PtCalculationResDto;
+import ca.bc.gov.backendstartapi.dto.PtValsCalReqDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormCollectionDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormExtractionDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormInterimDto;
@@ -53,6 +55,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -483,6 +486,15 @@ class SeedlotFormPutTest {
     Assertions.assertNotNull(scDto);
     Assertions.assertEquals("5432", scDto.seedlotNumber());
     Assertions.assertEquals("SUB", scDto.seedlotStatusCode());
+
+    // #2616: the submit-time recalculation must carry the weighted SMP mix breeding values,
+    // otherwise every smp*Contribution term is multiplied by zero and the genetic worth
+    // persisted for review/approve silently drops the SMP contribution.
+    ArgumentCaptor<PtValsCalReqDto> ptValsCaptor = ArgumentCaptor.forClass(PtValsCalReqDto.class);
+    verify(parentTreeService).calculatePtVals(ptValsCaptor.capture());
+    Assertions.assertNotNull(ptValsCaptor.getValue().smpBv());
+    // mocked SMP mix row is GVO 18 at proportion 100 -> 1800
+    Assertions.assertEquals(1800.0, ptValsCaptor.getValue().smpBv().getGvo(), 0.0001);
 
     Assertions.assertEquals(
         mockedForm.seedlotFormInterimDto().intermStrgClientNumber(),

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -1123,7 +1123,8 @@ class SeedlotServiceTest {
                 "0.5",
                 List.of(
                     new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("30"), null, null),
-                    new ParentTreeGeneticQualityDto("BV", "WVE", new BigDecimal("6"), null, null))));
+                    new ParentTreeGeneticQualityDto(
+                        "BV", "WVE", new BigDecimal("6"), null, null))));
 
     SeedlotManagementBreedingValueDto smpBv =
         SeedlotService.calculateSmpMixBreedingValues(smpMix);

--- a/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/backendstartapi/service/SeedlotServiceTest.java
@@ -29,6 +29,7 @@ import ca.bc.gov.backendstartapi.dto.SeedlotFormOwnershipDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormParentTreeSmpDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormSmpParentOutsideDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotFormSubmissionDto;
+import ca.bc.gov.backendstartapi.dto.SeedlotManagementBreedingValueDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotReviewElevationLatLongDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotReviewGeoInformationDto;
 import ca.bc.gov.backendstartapi.dto.SeedlotReviewSeedPlanZoneDto;
@@ -1078,5 +1079,93 @@ class SeedlotServiceTest {
 
     Assertions.assertNotNull(result);
     Assertions.assertNull(result.meanGeomSmpMix());
+  }
+
+  private SeedlotFormParentTreeSmpDto smpMixRow(
+      String proportion, List<ParentTreeGeneticQualityDto> genQuals) {
+    return new SeedlotFormParentTreeSmpDto(
+        "63001", 1001, "101", null, null, null, null, null, new BigDecimal(proportion), genQuals);
+  }
+
+  @Test
+  @DisplayName("SMP mix breeding values are the volume-weighted sum of each trait (#2616)")
+  void calculateSmpMixBreedingValues_weightsByProportion() {
+    // Two SMP mix rows: GVO 20 at 60% of the volume, GVO 10 at 40% -> 20*0.6 + 10*0.4 = 16
+    List<SeedlotFormParentTreeSmpDto> smpMix =
+        List.of(
+            smpMixRow(
+                "0.6", List.of(new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("20"),
+                    null, null))),
+            smpMixRow(
+                "0.4", List.of(new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("10"),
+                    null, null))));
+
+    SeedlotManagementBreedingValueDto smpBv =
+        SeedlotService.calculateSmpMixBreedingValues(smpMix);
+
+    Assertions.assertEquals(16.0, smpBv.getGvo(), 0.0001);
+    // Traits absent from the mix stay at zero rather than becoming null.
+    Assertions.assertEquals(0.0, smpBv.getAd(), 0.0001);
+    Assertions.assertEquals(0.0, smpBv.getWwd(), 0.0001);
+  }
+
+  @Test
+  @DisplayName("SMP mix breeding values accumulate per trait code independently (#2616)")
+  void calculateSmpMixBreedingValues_perTrait() {
+    List<SeedlotFormParentTreeSmpDto> smpMix =
+        List.of(
+            smpMixRow(
+                "0.5",
+                List.of(
+                    new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("20"), null, null),
+                    new ParentTreeGeneticQualityDto("BV", "DFS", new BigDecimal("8"), null, null))),
+            smpMixRow(
+                "0.5",
+                List.of(
+                    new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("30"), null, null),
+                    new ParentTreeGeneticQualityDto("BV", "WVE", new BigDecimal("6"), null, null))));
+
+    SeedlotManagementBreedingValueDto smpBv =
+        SeedlotService.calculateSmpMixBreedingValues(smpMix);
+
+    Assertions.assertEquals(25.0, smpBv.getGvo(), 0.0001);
+    Assertions.assertEquals(4.0, smpBv.getDfs(), 0.0001);
+    Assertions.assertEquals(3.0, smpBv.getWve(), 0.0001);
+    Assertions.assertEquals(0.0, smpBv.getIws(), 0.0001);
+  }
+
+  @Test
+  @DisplayName("No SMP mix yields all-zero breeding values (#2616)")
+  void calculateSmpMixBreedingValues_noSmpMix() {
+    Assertions.assertEquals(
+        0.0, SeedlotService.calculateSmpMixBreedingValues(List.of()).getGvo(), 0.0001);
+    Assertions.assertEquals(
+        0.0, SeedlotService.calculateSmpMixBreedingValues(null).getGvo(), 0.0001);
+  }
+
+  @Test
+  @DisplayName("Rows with a null proportion or null genetic quality are skipped (#2616)")
+  void calculateSmpMixBreedingValues_skipsIncompleteRows() {
+    List<SeedlotFormParentTreeSmpDto> smpMix =
+        List.of(
+            // null proportion -> cannot be weighted, must not blow up or contribute
+            new SeedlotFormParentTreeSmpDto(
+                "63001", 1001, "101", null, null, null, null, null, null,
+                List.of(new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("99"),
+                    null, null))),
+            // null genetic quality value
+            smpMixRow("0.5", List.of(
+                new ParentTreeGeneticQualityDto("BV", "GVO", null, null, null))),
+            // null genetic worth code
+            smpMixRow("0.5", List.of(
+                new ParentTreeGeneticQualityDto("BV", null, new BigDecimal("77"), null, null))),
+            // the only usable row
+            smpMixRow("0.5", List.of(
+                new ParentTreeGeneticQualityDto("BV", "GVO", new BigDecimal("20"), null, null))));
+
+    SeedlotManagementBreedingValueDto smpBv =
+        Assertions.assertDoesNotThrow(() -> SeedlotService.calculateSmpMixBreedingValues(smpMix));
+
+    Assertions.assertEquals(10.0, smpBv.getGvo(), 0.0001);
   }
 }


### PR DESCRIPTION
# Description

Closes #2616

The genetic worth persisted when a seedlot is submitted was computed as if the seedlot had **no SMP mix**. So review-and-approve mode (TSC admin) and the orchard manager's read-only step 5 both showed a total GW with no SMP contribution — while the registration form, which computes the same thing client-side, showed the correct value. That asymmetry is exactly what the issue reports.

## Root cause

`SeedlotService.setParentTreeContribution` built its calculation request like this:

```java
new PtValsCalReqDto(
    orchardPtVals, smpMixIdAndProps, smpParentsOutside,
        contaminantPollenBv, new SeedlotManagementBreedingValueDto());
```

`SeedlotManagementBreedingValueDto`'s no-arg constructor sets **all twelve SMP breeding values to `0.0`**. In `ParentTreeService` the SMP term is:

```
SMP_Contribution = (SMP_BV * SMP_Success/100) * FEMALE_CROP_CONTRIBUTION
```

`SMP_BV` is a direct multiplicand, so zeroing it makes every `smp*Contribution` exactly `0`, and the SMP term drops out of `maleTotalGw*Contrib` entirely. The persisted `spar.seedlot_genetic_worth` rows then understate the total.

Meanwhile the registration form calls the same calculator through `POST /api/parent-trees/calculate` but passes real values — `generatePtValCalcPayload` takes `smpBv` from `weightedGwInfoItems`, the SMP mix tab's weighted GW totals. Hence "correct during registration, wrong after submission".

## Why it surfaced now

| commit | date | effect |
|---|---|---|
| `c5906355` (#2139) | 2025-09-10 | added the `smpBv` parameter and the SMP contribution formula — the server-side submit path was wired with zeros from the start |
| `935918d9` (#2578) | 2026-07-09 | started showing the GW section in submitted status, which made the understated value visible |

So the defect has been latent for ~11 months and #2578 exposed it. It is not a regression in #2578.

## The fix

Compute the values server-side rather than trusting the client. The submitted SMP mix DTOs already carry everything needed — `proportion` (the row's share of total volume, 0–1) and `parentTreeGeneticQualities` — so `calculateSmpMixBreedingValues` sums `geneticQualityValue * proportion` per trait code.

That mirrors the client exactly. In the form:

```
proportion = volume / Σvolume            // fraction, 0–1
w_<gw>     = gwValue * proportion
smpBv[gw]  = Σ over mix rows of w_<gw>
```

No API change, no payload change, and no reliance on client-supplied breeding values.

## Tests

The wiring assertion is the one that pins the bug. `SeedlotFormPutTest` now captures the `PtValsCalReqDto` handed to the calculator:

```java
ArgumentCaptor<PtValsCalReqDto> ptValsCaptor = ArgumentCaptor.forClass(PtValsCalReqDto.class);
verify(parentTreeService).calculatePtVals(ptValsCaptor.capture());
Assertions.assertEquals(1800.0, ptValsCaptor.getValue().smpBv().getGvo(), 0.0001);
```

I verified it fails on the unfixed code by temporarily reverting the one-line call-site change:

```
SeedlotFormPutTest.submitSeedlotForm_happyPath_shouldSucceed:497
  expected: <1800.0> but was: <0.0>
```

`SeedlotServiceTest` adds four cases for the weighting itself:

- volume-weighted sum per trait (`20*0.6 + 10*0.4 = 16`)
- traits accumulate independently, absent traits stay `0.0` rather than `null`
- no SMP mix (empty list and `null`) yields all zeros — preserves current behaviour for seedlots without SMP
- rows with a null `proportion`, null `geneticQualityValue`, or null `geneticWorthCode` are skipped without throwing

Full backend suite: **406 tests, 0 failures**. Checkstyle clean.

### How was this tested?
- [x] 🤖 Added tests

## Notes for the reviewer

**Please verify on the PR environment against a seedlot with SMP**, ideally #68157 from the issue. The unit tests prove the breeding values now reach the calculator, but they mock `calculatePtVals`, so they don't prove the resulting total GW matches what the form displayed pre-submission. That end-to-end equality is the thing worth eyeballing: register with SMP, note the total GW, submit, and confirm review-and-approve shows the same number.

**Data remediation is not included here and needs a decision.** Every A-class seedlot submitted since 2025-09-10 with an SMP mix has an understated genetic worth stored in `spar.seedlot_genetic_worth`. This PR only fixes new submissions. Recalculating the existing rows is a separate task — worth scoping how many seedlots are affected before deciding whether to backfill or to recalculate on next edit.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-36.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2636-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2636-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)