### PR TITLE
feat: #2514 germination result table UI

### DIFF
--- a/frontend/src/__test__/views/CONSEP/DailyGermTable.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/DailyGermTable.test.tsx
@@ -79,6 +79,23 @@ describe('DailyGermTable', () => {
     );
   });
 
+  it('guards NaN when # seeds receives a value that does not parse to an integer', () => {
+    const props = renderTable();
+    // '.5' survives the number-input value sanitizer (valid float) but parseInt('.5', 10) is NaN
+    fireEvent.change(screen.getByTestId('germ-seeds-1'), { target: { value: '.5' } });
+    expect(props.onReplicatesChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ replicateNumber: 1, totalNoSeeds: undefined })
+      ])
+    );
+    // state must never receive NaN
+    (props.onReplicatesChange as ReturnType<typeof vi.fn>).mock.calls.forEach(([reps]) => {
+      (reps as GermReplicateType[]).forEach((rep) => {
+        expect(Number.isNaN(rep.totalNoSeeds as number)).toBe(false);
+      });
+    });
+  });
+
   it('disables inputs when not editable', () => {
     renderTable({ isEditable: false });
     expect(screen.getByTestId('germ-date-1')).toBeDisabled();

--- a/frontend/src/__test__/views/CONSEP/DailyGermTable.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/DailyGermTable.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DailyGermTable from '../../../views/CONSEP/TestingActivities/GerminationContent/DailyGermTable';
+import { GermCountSlotType, GermReplicateType } from '../../../types/consep/GerminationType';
+
+const emptySlots = (): GermCountSlotType[] => Array.from(
+  { length: 13 },
+  (_, i) => ({ slotIndex: i + 1 })
+);
+const defaultReps = (): GermReplicateType[] => Array.from(
+  { length: 4 },
+  (_, i) => ({ replicateNumber: i + 1, totalNoSeeds: 100, repAcceptedInd: 1 })
+);
+
+const renderTable = (over: Partial<React.ComponentProps<typeof DailyGermTable>> = {}) => {
+  const props = {
+    slots: emptySlots(),
+    replicates: defaultReps(),
+    germinatorEntry: '2024-10-31',
+    isEditable: true,
+    validationErrors: {},
+    onSlotsChange: vi.fn(),
+    onReplicatesChange: vi.fn(),
+    ...over
+  };
+  render(<DailyGermTable {...props} />);
+  return props;
+};
+
+describe('DailyGermTable', () => {
+  it('renders 13 date columns and 4 replicate rows', () => {
+    renderTable();
+    expect(screen.getAllByTestId(/^germ-date-/)).toHaveLength(13);
+    expect(screen.getAllByTestId(/^germ-seeds-/)).toHaveLength(4);
+  });
+
+  it('emits the day number when a count date is entered (AC1)', () => {
+    const props = renderTable();
+    fireEvent.change(screen.getByTestId('germ-date-1'), { target: { value: '2024-11-04' } });
+    expect(props.onSlotsChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ slotIndex: 1, countDt: '2024-11-04', dayNoOfTest: 4 })
+      ])
+    );
+  });
+
+  it('shows rep total and germination percent', () => {
+    const slots = emptySlots();
+    slots[0] = {
+      slotIndex: 1, countDt: '2024-11-04', dayNoOfTest: 4, rep1NoSeedsGerm: 45
+    };
+    renderTable({ slots });
+    expect(screen.getByTestId('germ-rep-total-1')).toHaveTextContent('45');
+    expect(screen.getByTestId('germ-pct-1')).toHaveTextContent('45%');
+  });
+
+  it('emits replicate change when # seeds is overridden (AC5)', () => {
+    const props = renderTable();
+    fireEvent.change(screen.getByTestId('germ-seeds-2'), { target: { value: '55' } });
+    expect(props.onReplicatesChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ replicateNumber: 2, totalNoSeeds: 55 })
+      ])
+    );
+  });
+
+  it('renders over-limit warnings (AC3)', () => {
+    renderTable({ validationErrors: { 'rep-1': 'Total germinated (110) exceeds number of seeds (100)' } });
+    expect(screen.getByText(/exceeds number of seeds/i)).toBeInTheDocument();
+  });
+
+  it('maps Ovr checkbox to tolrncOvrrdeDesc ok/null', () => {
+    const props = renderTable();
+    fireEvent.click(screen.getByTestId('germ-ovr-3'));
+    expect(props.onReplicatesChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ replicateNumber: 3, tolrncOvrrdeDesc: 'ok' })
+      ])
+    );
+  });
+
+  it('disables inputs when not editable', () => {
+    renderTable({ isEditable: false });
+    expect(screen.getByTestId('germ-date-1')).toBeDisabled();
+    expect(screen.getByTestId('germ-count-1-1')).toBeDisabled();
+  });
+});

--- a/frontend/src/__test__/views/CONSEP/DailyGermTable.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/DailyGermTable.test.tsx
@@ -44,6 +44,38 @@ describe('DailyGermTable', () => {
     );
   });
 
+  // Regression for I4: clearing a date column must also clear that slot's rep
+  // counts. They are dropped from the upsert payload and wiped server-side, so
+  // leaving them in state showed ghost values in disabled inputs and counted
+  // them into rep totals.
+  it('clears rep counts when the count date is cleared', () => {
+    const slots = emptySlots();
+    slots[0] = {
+      slotIndex: 1,
+      countDt: '2024-11-04',
+      dayNoOfTest: 4,
+      rep1NoSeedsGerm: 5,
+      rep2NoSeedsGerm: 6,
+      rep3NoSeedsGerm: 7,
+      rep4NoSeedsGerm: 8
+    };
+    const props = renderTable({ slots });
+    fireEvent.change(screen.getByTestId('germ-date-1'), { target: { value: '' } });
+    expect(props.onSlotsChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slotIndex: 1,
+          countDt: undefined,
+          dayNoOfTest: undefined,
+          rep1NoSeedsGerm: undefined,
+          rep2NoSeedsGerm: undefined,
+          rep3NoSeedsGerm: undefined,
+          rep4NoSeedsGerm: undefined
+        })
+      ])
+    );
+  });
+
   it('shows rep total and germination percent', () => {
     const slots = emptySlots();
     slots[0] = {

--- a/frontend/src/__test__/views/CONSEP/GerminationContent.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/GerminationContent.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  render, screen, fireEvent, waitFor
+} from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import GerminationContent from '../../../views/CONSEP/TestingActivities/GerminationContent';
+
+vi.mock('../../../components/PageTitle', () => ({
+  default: ({ title }: { title: string }) => <h1>{title}</h1>
+}));
+
+const putMock = vi.fn().mockResolvedValue({ updateTimestamp: '2026-01-02T00:00:00' });
+vi.mock('../../../api-service/consep/germinationTestAPI', () => ({
+  getGerminationTestHeader: () => Promise.resolve({
+    riaSkey: 123,
+    activityTypeCd: 'G10',
+    testCategoryCd: 'QA',
+    testCompleteInd: 0,
+    acceptResultInd: 0,
+    germinatorEntry: '2024-10-31',
+    requestId: 'TST20170140',
+    seedlotNumber: '07080',
+    vegetationState: 'SX'
+  }),
+  getGermCounts: () => Promise.reject(
+    Object.assign(new Error('Not found'), { response: { status: 404 } })
+  ),
+  getTestReplicates: () => Promise.resolve([]),
+  putGermCounts: (...args: unknown[]) => putMock(...args)
+}));
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useParams: () => ({ riaKey: '123' })
+}));
+
+const renderView = () => render(
+  <BrowserRouter>
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <GerminationContent />
+    </QueryClientProvider>
+  </BrowserRouter>
+);
+
+describe('GerminationContent', () => {
+  beforeEach(() => {
+    putMock.mockClear();
+  });
+
+  it('renders title and header card from the header API', async () => {
+    renderView();
+    await screen.findByText(/Germination test result/i);
+    expect(await screen.findByText('TST20170140')).toBeInTheDocument();
+    expect(screen.getByText('07080')).toBeInTheDocument();
+  });
+
+  it('defaults # seeds to 50 for QA category (AC4)', async () => {
+    renderView();
+    await screen.findByText(/Germination test result/i);
+    await waitFor(() => {
+      expect(screen.getByTestId('germ-seeds-1')).toHaveValue(50);
+    });
+  });
+
+  it('autosaves via PUT once a count date and count exist', async () => {
+    renderView();
+    await screen.findByText(/Germination test result/i);
+    fireEvent.change(screen.getByTestId('germ-date-1'), { target: { value: '2024-11-04' } });
+    fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '5' } });
+    await waitFor(() => expect(putMock).toHaveBeenCalled(), { timeout: 5000 });
+    const payload = putMock.mock.calls[0][1];
+    expect(payload.days[0]).toMatchObject({ slotIndex: 1, countDt: '2024-11-04', dayNoOfTest: 4 });
+    expect(payload.replicates).toHaveLength(4);
+  });
+
+  // Extended timeout: this test includes a real 4s wait (on top of the
+  // findByText/waitFor calls above it) to prove no autosave PUT fires while
+  // blocked, which exceeds vitest's default 5000ms per-test timeout.
+  //
+  // Deviation from brief: the brief's first count value was '60'. The
+  // shared header mock above sets testCategoryCd: 'QA', which per AC4 (and
+  // Task 4's getDefaultSeeds) defaults totalNoSeeds to 50 for every
+  // replicate. 60 already exceeds 50, so checkOverLimit flags it and blocks
+  // the very first autosave -- the putMock.toHaveBeenCalled() wait below
+  // would never resolve. Using '5' (consistent with the sibling autosave
+  // test) keeps rep-1 within the 50-seed QA limit so the first save can
+  // succeed, while '999' still clearly exceeds the limit for the block
+  // assertion that follows.
+  it('blocks autosave while a rep is over limit (AC3)', async () => {
+    renderView();
+    await screen.findByText(/Germination test result/i);
+    fireEvent.change(screen.getByTestId('germ-date-1'), { target: { value: '2024-11-04' } });
+    fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '5' } });
+    await waitFor(() => expect(putMock).toHaveBeenCalled(), { timeout: 5000 });
+    putMock.mockClear();
+    fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '999' } });
+    expect(await screen.findByText(/exceeds number of seeds/i)).toBeInTheDocument();
+    await new Promise((resolve) => { setTimeout(resolve, 4000); });
+    expect(putMock).not.toHaveBeenCalled();
+  }, 15000);
+});

--- a/frontend/src/__test__/views/CONSEP/GerminationContent.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/GerminationContent.test.tsx
@@ -87,6 +87,23 @@ describe('GerminationContent', () => {
   // test) keeps rep-1 within the 50-seed QA limit so the first save can
   // succeed, while '999' still clearly exceeds the limit for the block
   // assertion that follows.
+  // C3: clearing a rep's "# seeds" must surface a validation error (so the
+  // row is flagged) and block autosave, because the payload would otherwise
+  // miss totalNoSeeds and the backend @NotNull would 400 the whole request.
+  it('shows an error and blocks autosave when # seeds is cleared', async () => {
+    renderView();
+    await screen.findByText(/Germination test result/i);
+    fireEvent.change(screen.getByTestId('germ-date-1'), { target: { value: '2024-11-04' } });
+    fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '5' } });
+    await waitFor(() => expect(putMock).toHaveBeenCalled(), { timeout: 5000 });
+    putMock.mockClear();
+    // Clear rep 1's number of seeds.
+    fireEvent.change(screen.getByTestId('germ-seeds-1'), { target: { value: '' } });
+    expect(await screen.findByText('Number of seeds is required')).toBeInTheDocument();
+    await new Promise((resolve) => { setTimeout(resolve, 4000); });
+    expect(putMock).not.toHaveBeenCalled();
+  }, 15000);
+
   it('blocks autosave while a rep is over limit (AC3)', async () => {
     renderView();
     await screen.findByText(/Germination test result/i);

--- a/frontend/src/__test__/views/CONSEP/GerminationContentConflict.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/GerminationContentConflict.test.tsx
@@ -74,15 +74,13 @@ describe('GerminationContent optimistic-lock conflict', () => {
     );
 
     putMock.mockClear();
-    // Deviation from brief: the brief's second edit targeted germ-count-2-1,
-    // but DailyGermTable disables a replicate's count input until that slot
-    // has a countDt (see DailyGermTable.tsx: `disabled={!isEditable ||
-    // !slot.countDt}`). Slot 2 never received a date in this test, so
-    // germ-count-2-1 is disabled and fireEvent.change on it would be a
-    // no-op, making the "no further autosave" assertion vacuous. Slot 1
-    // already has a date from the first edit above, so germ-count-1-1
-    // stays enabled and is a real edit attempt while conflicted -- also
-    // consistent with the isEditable=false-on-conflict guard.
+    // Edit after the conflict: fireEvent.change fires React onChange even on
+    // disabled inputs in jsdom, so this edit lands in component state despite
+    // every input being disabled while conflicted (isEditable is false). The
+    // assertion therefore proves useAutosave's `enabled` gate -- isEditable
+    // folds in isConflict -- is what blocks the PUT, not DOM disabled state.
+    // (Uses germ-count-1-1 instead of the brief's germ-count-2-1 -- both are
+    // slot-1 inputs, rep 1 vs rep 2; either exercises the same gate.)
     fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '6' } });
     await new Promise((resolve) => { setTimeout(resolve, 4000); });
     expect(putMock).not.toHaveBeenCalled();

--- a/frontend/src/__test__/views/CONSEP/GerminationContentConflict.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/GerminationContentConflict.test.tsx
@@ -11,21 +11,24 @@ vi.mock('../../../components/PageTitle', () => ({
 }));
 
 const putMock = vi.fn();
+const headerMock = vi.fn();
 vi.mock('../../../api-service/consep/germinationTestAPI', () => ({
-  getGerminationTestHeader: () => Promise.resolve({
-    riaSkey: 123,
-    activityTypeCd: 'G10',
-    testCategoryCd: 'QA',
-    testCompleteInd: 0,
-    acceptResultInd: 0,
-    germinatorEntry: '2024-10-31'
-  }),
+  getGerminationTestHeader: (...args: unknown[]) => headerMock(...args),
   getGermCounts: () => Promise.reject(
     Object.assign(new Error('Not found'), { response: { status: 404 } })
   ),
   getTestReplicates: () => Promise.resolve([]),
   putGermCounts: (...args: unknown[]) => putMock(...args)
 }));
+
+const baseHeader = {
+  riaSkey: 123,
+  activityTypeCd: 'G10',
+  testCategoryCd: 'QA',
+  testCompleteInd: 0,
+  acceptResultInd: 0,
+  germinatorEntry: '2024-10-31'
+};
 
 vi.mock('react-router-dom', async (orig) => ({
   ...(await orig<typeof import('react-router-dom')>()),
@@ -48,6 +51,8 @@ describe('GerminationContent optimistic-lock conflict', () => {
 
   beforeEach(() => {
     putMock.mockReset();
+    headerMock.mockReset();
+    headerMock.mockResolvedValue({ ...baseHeader });
     // TanStack Query's mutate() applies .catch(noop) but the rejected Promise
     // from the mutationFn may still surface as an "unhandledRejection" for a
     // microtask before the catch is registered. Suppress it here.
@@ -84,5 +89,39 @@ describe('GerminationContent optimistic-lock conflict', () => {
     fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '6' } });
     await new Promise((resolve) => { setTimeout(resolve, 4000); });
     expect(putMock).not.toHaveBeenCalled();
+  }, 15000);
+
+  // Regression for I5: the conflict reload must refetch the HEADER too, not
+  // just germ-counts + replicates. germinatorEntry (day-calc anchor) and
+  // testCompleteInd (the isEditable gate) live on the header, so a stale
+  // header would leave the screen editable/miscalculating after reload.
+  // Assertion: header refetch returns testCompleteInd:1 and the inputs become
+  // disabled after Reload. (Also proves getGerminationTestHeader ran twice.)
+  it('refetches the header on conflict reload and applies the fresh testCompleteInd', async () => {
+    const conflictError = Object.assign(new Error('Conflict'), { response: { status: 409 } });
+    putMock.mockRejectedValue(conflictError);
+    // Initial load: editable. Reload: test now complete -> read-only.
+    headerMock
+      .mockResolvedValueOnce({ ...baseHeader, testCompleteInd: 0 })
+      .mockResolvedValue({ ...baseHeader, testCompleteInd: 1 });
+    renderView();
+
+    await screen.findByText(/Germination test result/i);
+    expect(screen.getByTestId('germ-date-1')).not.toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('germ-date-1'), { target: { value: '2024-11-04' } });
+    fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '5' } });
+
+    await waitFor(
+      () => expect(screen.getByText('Conflict detected')).toBeInTheDocument(),
+      { timeout: 5000 }
+    );
+
+    fireEvent.click(screen.getByText('Reload'));
+
+    // The refetched header (testCompleteInd:1) must reapply and disable inputs.
+    await waitFor(() => expect(screen.getByTestId('germ-date-1')).toBeDisabled());
+    // Header endpoint hit at least twice: initial mount + conflict reload.
+    expect(headerMock.mock.calls.length).toBeGreaterThanOrEqual(2);
   }, 15000);
 });

--- a/frontend/src/__test__/views/CONSEP/GerminationContentConflict.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/GerminationContentConflict.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import {
+  render, screen, fireEvent, waitFor
+} from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import GerminationContent from '../../../views/CONSEP/TestingActivities/GerminationContent';
+
+vi.mock('../../../components/PageTitle', () => ({
+  default: ({ title }: { title: string }) => <h1>{title}</h1>
+}));
+
+const putMock = vi.fn();
+vi.mock('../../../api-service/consep/germinationTestAPI', () => ({
+  getGerminationTestHeader: () => Promise.resolve({
+    riaSkey: 123,
+    activityTypeCd: 'G10',
+    testCategoryCd: 'QA',
+    testCompleteInd: 0,
+    acceptResultInd: 0,
+    germinatorEntry: '2024-10-31'
+  }),
+  getGermCounts: () => Promise.reject(
+    Object.assign(new Error('Not found'), { response: { status: 404 } })
+  ),
+  getTestReplicates: () => Promise.resolve([]),
+  putGermCounts: (...args: unknown[]) => putMock(...args)
+}));
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useParams: () => ({ riaKey: '123' })
+}));
+
+const renderView = () => render(
+  <BrowserRouter>
+    <QueryClientProvider client={new QueryClient({
+      defaultOptions: { mutations: { throwOnError: false }, queries: { retry: false } }
+    })}
+    >
+      <GerminationContent />
+    </QueryClientProvider>
+  </BrowserRouter>
+);
+
+describe('GerminationContent optimistic-lock conflict', () => {
+  let rejectionHandler: (event: PromiseRejectionEvent) => void;
+
+  beforeEach(() => {
+    putMock.mockReset();
+    // TanStack Query's mutate() applies .catch(noop) but the rejected Promise
+    // from the mutationFn may still surface as an "unhandledRejection" for a
+    // microtask before the catch is registered. Suppress it here.
+    rejectionHandler = (event: PromiseRejectionEvent) => { event.preventDefault(); };
+    window.addEventListener('unhandledrejection', rejectionHandler);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('unhandledrejection', rejectionHandler);
+  });
+
+  it('shows the conflict banner on 409 and stops further autosaves', async () => {
+    const conflictError = Object.assign(new Error('Conflict'), { response: { status: 409 } });
+    putMock.mockRejectedValue(conflictError);
+    renderView();
+
+    await screen.findByText(/Germination test result/i);
+    fireEvent.change(screen.getByTestId('germ-date-1'), { target: { value: '2024-11-04' } });
+    fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '5' } });
+
+    await waitFor(
+      () => expect(screen.getByText('Conflict detected')).toBeInTheDocument(),
+      { timeout: 5000 }
+    );
+
+    putMock.mockClear();
+    // Deviation from brief: the brief's second edit targeted germ-count-2-1,
+    // but DailyGermTable disables a replicate's count input until that slot
+    // has a countDt (see DailyGermTable.tsx: `disabled={!isEditable ||
+    // !slot.countDt}`). Slot 2 never received a date in this test, so
+    // germ-count-2-1 is disabled and fireEvent.change on it would be a
+    // no-op, making the "no further autosave" assertion vacuous. Slot 1
+    // already has a date from the first edit above, so germ-count-1-1
+    // stays enabled and is a real edit attempt while conflicted -- also
+    // consistent with the isEditable=false-on-conflict guard.
+    fireEvent.change(screen.getByTestId('germ-count-1-1'), { target: { value: '6' } });
+    await new Promise((resolve) => { setTimeout(resolve, 4000); });
+    expect(putMock).not.toHaveBeenCalled();
+  }, 15000);
+});

--- a/frontend/src/__test__/views/CONSEP/GerminationContentHydration.test.tsx
+++ b/frontend/src/__test__/views/CONSEP/GerminationContentHydration.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  render, screen, waitFor
+} from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import GerminationContent from '../../../views/CONSEP/TestingActivities/GerminationContent';
+
+vi.mock('../../../components/PageTitle', () => ({
+  default: ({ title }: { title: string }) => <h1>{title}</h1>
+}));
+
+const putMock = vi.fn().mockResolvedValue({ updateTimestamp: '2026-01-02T00:00:00' });
+vi.mock('../../../api-service/consep/germinationTestAPI', () => ({
+  getGerminationTestHeader: () => Promise.resolve({
+    riaSkey: 123,
+    activityTypeCd: 'G10',
+    testCategoryCd: 'QA',
+    testCompleteInd: 0,
+    acceptResultInd: 0,
+    germinatorEntry: '2024-10-31',
+    requestId: 'TST20170140',
+    seedlotNumber: '07080',
+    vegetationState: 'SX'
+  }),
+  // Existing germ-count row already present on load.
+  getGermCounts: () => Promise.resolve({
+    riaSkey: 123,
+    updateTimestamp: '2026-01-01T00:00:00',
+    slots: [{
+      slotIndex: 1, countDt: '2024-11-04', dayNoOfTest: 4, rep1NoSeedsGerm: 5
+    }]
+  }),
+  // Four persisted replicates.
+  getTestReplicates: () => Promise.resolve([
+    { replicateNumber: 1, totalNoSeeds: 100, repAcceptedInd: 1, tolrncOvrrdeDesc: null },
+    { replicateNumber: 2, totalNoSeeds: 100, repAcceptedInd: 1, tolrncOvrrdeDesc: null },
+    { replicateNumber: 3, totalNoSeeds: 100, repAcceptedInd: 1, tolrncOvrrdeDesc: null },
+    { replicateNumber: 4, totalNoSeeds: 100, repAcceptedInd: 1, tolrncOvrrdeDesc: null }
+  ]),
+  putGermCounts: (...args: unknown[]) => putMock(...args)
+}));
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useParams: () => ({ riaKey: '123' })
+}));
+
+const renderView = () => render(
+  <BrowserRouter>
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <GerminationContent />
+    </QueryClientProvider>
+  </BrowserRouter>
+);
+
+describe('GerminationContent hydration (no ghost autosave)', () => {
+  beforeEach(() => {
+    putMock.mockClear();
+  });
+
+  // Regression for C1: opening a test that already has data must not fire an
+  // autosave PUT and must not surface a "saved" toast, because the user made
+  // no edits. The bug was a markSaved effect keyed on [isHydrated] that
+  // captured a stale (pre-hydration) autosaveData closure, leaving savedRef a
+  // render behind so useAutosave saw a "change" and PUT ~800ms after load.
+  it('does not PUT or toast when opening a test that already has data', async () => {
+    renderView();
+    await screen.findByText(/Germination test result/i);
+    // Confirm the hydrated data actually rendered.
+    await waitFor(() => {
+      expect(screen.getByTestId('germ-count-1-1')).toHaveValue(5);
+    });
+    // Wait well past debounce (800ms) and maxWait (3000ms).
+    await new Promise((resolve) => { setTimeout(resolve, 4000); });
+    expect(putMock).not.toHaveBeenCalled();
+    expect(screen.queryByText('Daily germination counts saved')).not.toBeInTheDocument();
+  }, 15000);
+});

--- a/frontend/src/__test__/views/CONSEP/GerminationUtils.test.ts
+++ b/frontend/src/__test__/views/CONSEP/GerminationUtils.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-undef */
+import { describe, it, expect } from 'vitest';
+import {
+  getDefaultSeeds, calcDayNumber, validateCountDates,
+  calcRepTotal, checkOverLimit, calcGermPct, buildUpsertPayload
+} from '../../../views/CONSEP/TestingActivities/GerminationContent/utils';
+
+describe('getDefaultSeeds', () => {
+  it('returns 50 for QA and 100 otherwise', () => {
+    expect(getDefaultSeeds('QA')).toBe(50);
+    expect(getDefaultSeeds('STD')).toBe(100);
+    expect(getDefaultSeeds(undefined)).toBe(100);
+  });
+});
+
+describe('calcDayNumber', () => {
+  // Ticket AC1: into germinator 2024-10-31, first count 2024-11-04 -> day 4
+  it('counts whole days from germinator entry', () => {
+    expect(calcDayNumber('2024-10-31', '2024-11-04')).toBe(4);
+  });
+  it('returns undefined without a germinator entry date', () => {
+    expect(calcDayNumber(undefined, '2024-11-04')).toBeUndefined();
+  });
+});
+
+describe('validateCountDates', () => {
+  it('flags a count date not after the previous one', () => {
+    const slots = [
+      { slotIndex: 1, countDt: '2024-11-04' },
+      { slotIndex: 2, countDt: '2024-11-04' }
+    ];
+    const errors = validateCountDates(slots as any);
+    expect(errors['slot-2']).toBe('Count date must be after the previous count date');
+    expect(errors['slot-1']).toBeUndefined();
+  });
+});
+
+describe('rep totals and over-limit', () => {
+  const slots = [
+    { slotIndex: 1, countDt: '2024-11-04', rep1NoSeedsGerm: 60, rep2NoSeedsGerm: 10 },
+    { slotIndex: 2, countDt: '2024-11-05', rep1NoSeedsGerm: 50, rep2NoSeedsGerm: 20 }
+  ] as any;
+
+  it('sums one replicate across slots', () => {
+    expect(calcRepTotal(slots, 1)).toBe(110);
+    expect(calcRepTotal(slots, 2)).toBe(30);
+  });
+
+  it('flags replicates whose total exceeds their seeds', () => {
+    const reps = [
+      { replicateNumber: 1, totalNoSeeds: 100 },
+      { replicateNumber: 2, totalNoSeeds: 100 }
+    ] as any;
+    const errors = checkOverLimit(slots, reps);
+    expect(errors['rep-1']).toBe('Total germinated (110) exceeds number of seeds (100)');
+    expect(errors['rep-2']).toBeUndefined();
+  });
+});
+
+describe('calcGermPct', () => {
+  it('rounds the percentage and handles missing seeds', () => {
+    expect(calcGermPct(45, 100)).toBe(45);
+    expect(calcGermPct(45, undefined)).toBe(0);
+  });
+});
+
+describe('buildUpsertPayload', () => {
+  it('keeps only dated slots and strips derived fields', () => {
+    const slots = [
+      {
+        slotIndex: 1, countDt: '2024-11-04', dayNoOfTest: 4, rep1NoSeedsGerm: 5,
+        dailyGermSkey: 99, cumulativeGerm: 1.5
+      },
+      { slotIndex: 2 }
+    ] as any;
+    const reps = [{ replicateNumber: 1, totalNoSeeds: 100 }] as any;
+    const payload = buildUpsertPayload(slots, reps, '2026-01-01T00:00:00');
+    expect(payload.days).toHaveLength(1);
+    expect(payload.days[0]).not.toHaveProperty('dailyGermSkey');
+    expect(payload.days[0].slotIndex).toBe(1);
+    expect(payload.replicates).toHaveLength(1);
+    expect(payload.updateTimestamp).toBe('2026-01-01T00:00:00');
+  });
+});

--- a/frontend/src/__test__/views/CONSEP/GerminationUtils.test.ts
+++ b/frontend/src/__test__/views/CONSEP/GerminationUtils.test.ts
@@ -55,6 +55,19 @@ describe('rep totals and over-limit', () => {
     expect(errors['rep-1']).toBe('Total germinated (110) exceeds number of seeds (100)');
     expect(errors['rep-2']).toBeUndefined();
   });
+
+  // C3: a cleared "# seeds" cell leaves totalNoSeeds undefined. The backend
+  // rejects the whole payload with a @NotNull 400, so autosave must be blocked
+  // client-side with a rep-scoped error.
+  it('flags a replicate whose number of seeds is missing', () => {
+    const reps = [
+      { replicateNumber: 1, totalNoSeeds: undefined },
+      { replicateNumber: 2, totalNoSeeds: 100 }
+    ] as any;
+    const errors = checkOverLimit(slots, reps);
+    expect(errors['rep-1']).toBe('Number of seeds is required');
+    expect(errors['rep-2']).toBeUndefined();
+  });
 });
 
 describe('calcGermPct', () => {

--- a/frontend/src/api-service/ApiConfig.ts
+++ b/frontend/src/api-service/ApiConfig.ts
@@ -73,7 +73,13 @@ const ApiConfig = {
 
   requestSeedLotAndVegLot: `${oracleServerHost}/api/request-seedlot-and-veglot`,
 
-  germinatorTrays: `${oracleServerHost}/api/germinator-trays`
+  germinatorTrays: `${oracleServerHost}/api/germinator-trays`,
+
+  germinationTests: `${oracleServerHost}/api/germination-tests`,
+
+  germCounts: `${oracleServerHost}/api/germ-counts`,
+
+  testReplicates: `${oracleServerHost}/api/test-replicates`
 };
 
 export default ApiConfig;

--- a/frontend/src/api-service/consep/germinationTestAPI.ts
+++ b/frontend/src/api-service/consep/germinationTestAPI.ts
@@ -1,0 +1,33 @@
+import ApiConfig from '../ApiConfig';
+import api from '../api';
+import {
+  GermCountDataType,
+  GermCountUpsertPayload,
+  GerminationTestHeaderType,
+  GermReplicateType
+} from '../../types/consep/GerminationType';
+
+export const getGerminationTestHeader = (
+  riaKey: string
+): Promise<GerminationTestHeaderType> => api
+  .get(`${ApiConfig.germinationTests}/${riaKey}`)
+  .then((res) => res.data);
+
+export const getGermCounts = (
+  riaKey: string
+): Promise<GermCountDataType> => api
+  .get(`${ApiConfig.germCounts}/${riaKey}`)
+  .then((res) => res.data);
+
+export const putGermCounts = (
+  riaKey: string,
+  payload: GermCountUpsertPayload
+): Promise<GermCountDataType> => api
+  .put(`${ApiConfig.germCounts}/${riaKey}`, payload)
+  .then((res) => res.data);
+
+export const getTestReplicates = (
+  riaKey: string
+): Promise<GermReplicateType[]> => api
+  .get(`${ApiConfig.testReplicates}/${riaKey}`)
+  .then((res) => res.data);

--- a/frontend/src/routes/constants.ts
+++ b/frontend/src/routes/constants.ts
@@ -28,6 +28,7 @@ const ROUTES = {
   FAMILY_LOT_SUMMARY_REPORT: '/consep/family-lot-summary-report',
   GERMINATION_SPECIES_AVERAGE: '/consep/germination-species-average',
   GERM_COUNT_PREDICTIONS: '/consep/germ-count-predictions',
+  GERMINATION_TEST_RESULT: '/consep/germination-test/:riaKey',
   IDENTIFY_AVAILABLE_LONG_TERM_LOCATION: '/consep/identify-available-long-term-location',
   IN_HOUSE_INVENTORY: '/consep/in-house-inventory',
   INVENTORY_LOCATION_REPORT: '/consep/inventory-location-report',

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -20,6 +20,7 @@ import MoistureContent from '../views/CONSEP/TestingActivities/MoistureContent';
 import PurityContent from '../views/CONSEP/TestingActivities/PurityContent';
 import TestSearch from '../views/CONSEP/TestingActivities/TestSearch';
 import MaintainGermTray from '../views/CONSEP/TestingActivities/GerminatorTray/MaintainGermTray';
+import GerminationContent from '../views/CONSEP/TestingActivities/GerminationContent';
 
 const BrowserRoutes: Array<RouteObject> = [
   // Ensures that root paths get redirected to
@@ -119,6 +120,12 @@ const BrowserRoutes: Array<RouteObject> = [
     path: ROUTES.MANUAL_PURITY_CONTENT,
     element: (
       <PurityContent />
+    )
+  },
+  {
+    path: ROUTES.GERMINATION_TEST_RESULT,
+    element: (
+      <GerminationContent />
     )
   },
   {

--- a/frontend/src/types/consep/GerminationType.ts
+++ b/frontend/src/types/consep/GerminationType.ts
@@ -1,0 +1,58 @@
+/** Types for the CONSEP germination test result screen (issue #2514). */
+
+export type GermCountSlotType = {
+  slotIndex: number; // 1-13
+  dailyGermSkey?: number;
+  countDt?: string; // 'YYYY-MM-DD'
+  dayNoOfTest?: number;
+  rep1NoSeedsGerm?: number;
+  rep2NoSeedsGerm?: number;
+  rep3NoSeedsGerm?: number;
+  rep4NoSeedsGerm?: number;
+  cumulativeGerm?: number;
+};
+
+export type GermReplicateType = {
+  replicateNumber: number; // 1-4
+  totalNoSeeds?: number;
+  repAcceptedInd?: number; // 1 | 0
+  tolrncOvrrdeDesc?: string | null; // 'ok' | null
+};
+
+export type GermCountDataType = {
+  riaSkey: number;
+  slots: GermCountSlotType[];
+  updateTimestamp?: string;
+};
+
+export type GerminationTestHeaderType = {
+  riaSkey: number;
+  activityTypeCd: string;
+  actualBeginDtTm?: string;
+  actualEndDtTm?: string;
+  testCategoryCd?: string;
+  acceptResultInd?: number;
+  testCompleteInd?: number;
+  riaComment?: string;
+  testRank?: string;
+  germinationPct?: number;
+  germinationValue?: number;
+  peakValueGrmPct?: number;
+  peakValueNoDays?: number;
+  seedWithdrawalDate?: string;
+  germinatorEntry?: string; // 'YYYY-MM-DD'
+  germinatorTrayId?: number;
+  germinatorId?: string;
+  testResultUpdateTimestamp?: string;
+  riaUpdateTimestamp?: string;
+  requestId?: string;
+  seedlotNumber?: string;
+  familyLotNumber?: string;
+  vegetationState?: string;
+};
+
+export type GermCountUpsertPayload = {
+  updateTimestamp?: string;
+  days: Array<Omit<GermCountSlotType, 'dailyGermSkey' | 'cumulativeGerm'>>;
+  replicates: GermReplicateType[];
+};

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/DailyGermTable.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/DailyGermTable.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+
+import {
+  GermCountSlotType,
+  GermReplicateType
+} from '../../../../types/consep/GerminationType';
+import { calcDayNumber, calcRepTotal, calcGermPct } from './utils';
+
+import './styles.scss';
+
+const SLOT_COUNT = 13;
+const REP_COUNT_KEYS = [
+  'rep1NoSeedsGerm', 'rep2NoSeedsGerm', 'rep3NoSeedsGerm', 'rep4NoSeedsGerm'
+] as const;
+
+type DailyGermTableProps = {
+  slots: GermCountSlotType[];
+  replicates: GermReplicateType[];
+  germinatorEntry?: string;
+  isEditable: boolean;
+  validationErrors: Record<string, string>;
+  onSlotsChange: (slots: GermCountSlotType[]) => void;
+  onReplicatesChange: (replicates: GermReplicateType[]) => void;
+};
+
+const DailyGermTable = ({
+  slots, replicates, germinatorEntry, isEditable,
+  validationErrors, onSlotsChange, onReplicatesChange
+}: DailyGermTableProps) => {
+  const updateSlot = (slotIndex: number, patch: Partial<GermCountSlotType>) => {
+    onSlotsChange(slots.map((slot) => (
+      slot.slotIndex === slotIndex ? { ...slot, ...patch } : slot
+    )));
+  };
+
+  const handleDateChange = (slotIndex: number, value: string) => {
+    updateSlot(slotIndex, {
+      countDt: value || undefined,
+      dayNoOfTest: value ? calcDayNumber(germinatorEntry, value) : undefined
+    });
+  };
+
+  const handleCountChange = (repNumber: number, slotIndex: number, raw: string) => {
+    const parsed = raw === '' ? undefined : parseInt(raw, 10);
+    updateSlot(slotIndex, {
+      [REP_COUNT_KEYS[repNumber - 1]]: Number.isNaN(parsed) ? undefined : parsed
+    });
+  };
+
+  const updateReplicate = (repNumber: number, patch: Partial<GermReplicateType>) => {
+    onReplicatesChange(replicates.map((rep) => (
+      rep.replicateNumber === repNumber ? { ...rep, ...patch } : rep
+    )));
+  };
+
+  const errorMessages = Object.values(validationErrors).filter(Boolean);
+
+  return (
+    <div className="daily-germ-table-container">
+      <h3>Daily germination</h3>
+      {errorMessages.length > 0 && (
+        <div className="daily-germ-errors" role="alert">
+          {errorMessages.map((message) => (
+            <p key={message}>{message}</p>
+          ))}
+        </div>
+      )}
+      <div className="daily-germ-table-scroll">
+        <table className="daily-germ-table">
+          <thead>
+            <tr>
+              <th rowSpan={2}>Rep</th>
+              {Array.from({ length: SLOT_COUNT }, (_, i) => {
+                const slot = slots[i];
+                return (
+                  <th key={`date-${slot.slotIndex}`} className={validationErrors[`slot-${slot.slotIndex}`] ? 'cell-invalid' : ''}>
+                    <input
+                      type="date"
+                      data-testid={`germ-date-${slot.slotIndex}`}
+                      aria-label={`Count date ${slot.slotIndex}`}
+                      value={slot.countDt ?? ''}
+                      disabled={!isEditable}
+                      onChange={(e) => handleDateChange(slot.slotIndex, e.target.value)}
+                    />
+                  </th>
+                );
+              })}
+              <th rowSpan={2}>Rep total</th>
+              <th rowSpan={2}># seeds</th>
+              <th rowSpan={2}>Ovr</th>
+              <th rowSpan={2}>Acc</th>
+            </tr>
+            <tr>
+              {slots.map((slot) => (
+                <th key={`day-${slot.slotIndex}`} data-testid={`germ-day-${slot.slotIndex}`}>
+                  {slot.dayNoOfTest ?? ''}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {replicates.map((rep) => {
+              const repNumber = rep.replicateNumber as 1 | 2 | 3 | 4;
+              const repTotal = calcRepTotal(slots, repNumber);
+              return (
+                <tr key={repNumber} className={validationErrors[`rep-${repNumber}`] ? 'row-invalid' : ''}>
+                  <td>{repNumber}</td>
+                  {slots.map((slot) => (
+                    <td key={`count-${repNumber}-${slot.slotIndex}`}>
+                      <input
+                        type="number"
+                        min={0}
+                        data-testid={`germ-count-${repNumber}-${slot.slotIndex}`}
+                        aria-label={`Replicate ${repNumber} count ${slot.slotIndex}`}
+                        value={slot[REP_COUNT_KEYS[repNumber - 1]] ?? ''}
+                        disabled={!isEditable || !slot.countDt}
+                        onChange={(e) => handleCountChange(repNumber, slot.slotIndex, e.target.value)}
+                      />
+                    </td>
+                  ))}
+                  <td data-testid={`germ-rep-total-${repNumber}`}>{repTotal}</td>
+                  <td>
+                    <input
+                      type="number"
+                      min={0}
+                      data-testid={`germ-seeds-${repNumber}`}
+                      aria-label={`Replicate ${repNumber} number of seeds`}
+                      value={rep.totalNoSeeds ?? ''}
+                      disabled={!isEditable}
+                      onChange={(e) => updateReplicate(repNumber, {
+                        totalNoSeeds: e.target.value === '' ? undefined : parseInt(e.target.value, 10)
+                      })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      data-testid={`germ-ovr-${repNumber}`}
+                      aria-label={`Replicate ${repNumber} tolerance override`}
+                      checked={rep.tolrncOvrrdeDesc === 'ok'}
+                      disabled={!isEditable}
+                      onChange={(e) => updateReplicate(repNumber, {
+                        tolrncOvrrdeDesc: e.target.checked ? 'ok' : null
+                      })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      data-testid={`germ-acc-${repNumber}`}
+                      aria-label={`Replicate ${repNumber} accepted`}
+                      checked={rep.repAcceptedInd === 1}
+                      disabled={!isEditable || !!validationErrors[`rep-${repNumber}`]}
+                      onChange={(e) => updateReplicate(repNumber, {
+                        repAcceptedInd: e.target.checked ? 1 : 0
+                      })}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td>Germ %</td>
+              {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+              <td colSpan={SLOT_COUNT} />
+              <td colSpan={4} className="germ-pct-cells">
+                {replicates.map((rep) => (
+                  <span key={rep.replicateNumber} data-testid={`germ-pct-${rep.replicateNumber}`}>
+                    {`${calcGermPct(calcRepTotal(slots, rep.replicateNumber as 1 | 2 | 3 | 4), rep.totalNoSeeds)}%`}
+                  </span>
+                ))}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default DailyGermTable;

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/DailyGermTable.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/DailyGermTable.tsx
@@ -127,9 +127,12 @@ const DailyGermTable = ({
                       aria-label={`Replicate ${repNumber} number of seeds`}
                       value={rep.totalNoSeeds ?? ''}
                       disabled={!isEditable}
-                      onChange={(e) => updateReplicate(repNumber, {
-                        totalNoSeeds: e.target.value === '' ? undefined : parseInt(e.target.value, 10)
-                      })}
+                      onChange={(e) => {
+                        const parsed = e.target.value === '' ? undefined : parseInt(e.target.value, 10);
+                        updateReplicate(repNumber, {
+                          totalNoSeeds: Number.isNaN(parsed) ? undefined : parsed
+                        });
+                      }}
                     />
                   </td>
                   <td>

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/DailyGermTable.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/DailyGermTable.tsx
@@ -34,9 +34,21 @@ const DailyGermTable = ({
   };
 
   const handleDateChange = (slotIndex: number, value: string) => {
+    // Clearing the date (I4) must also clear that slot's rep counts: they are
+    // dropped from the payload and wiped server-side, so keeping them in state
+    // would show ghost values in the now-disabled inputs and inflate totals.
+    const cleared = value
+      ? {}
+      : {
+        rep1NoSeedsGerm: undefined,
+        rep2NoSeedsGerm: undefined,
+        rep3NoSeedsGerm: undefined,
+        rep4NoSeedsGerm: undefined
+      };
     updateSlot(slotIndex, {
       countDt: value || undefined,
-      dayNoOfTest: value ? calcDayNumber(germinatorEntry, value) : undefined
+      dayNoOfTest: value ? calcDayNumber(germinatorEntry, value) : undefined,
+      ...cleared
     });
   };
 

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/index.tsx
@@ -1,0 +1,290 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { AxiosError } from 'axios';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+  FlexGrid, Row, Column, InlineNotification, TextInput
+} from '@carbon/react';
+import { CheckmarkFilled } from '@carbon/icons-react';
+
+import ROUTES from '../../../../routes/constants';
+import {
+  getGerminationTestHeader, getGermCounts, getTestReplicates, putGermCounts
+} from '../../../../api-service/consep/germinationTestAPI';
+import {
+  GermCountSlotType, GermReplicateType, GerminationTestHeaderType
+} from '../../../../types/consep/GerminationType';
+import useAutosave from '../../../../hooks/useAutosave';
+import useActivityConflict from '../hooks/useActivityConflict';
+
+import Breadcrumbs from '../../../../components/Breadcrumbs';
+import PageTitle from '../../../../components/PageTitle';
+import StatusTag from '../../../../components/StatusTag';
+import ConflictNotification from '../../../../components/CONSEP/ConflictNotification';
+
+import DailyGermTable from './DailyGermTable';
+import {
+  getDefaultSeeds, validateCountDates, checkOverLimit, buildUpsertPayload
+} from './utils';
+
+import './styles.scss';
+
+const emptySlots = (): GermCountSlotType[] => Array.from(
+  { length: 13 },
+  (_, i) => ({ slotIndex: i + 1 })
+);
+
+const defaultReplicates = (testCategoryCd?: string): GermReplicateType[] => Array.from(
+  { length: 4 },
+  (_, i) => ({
+    replicateNumber: i + 1,
+    totalNoSeeds: getDefaultSeeds(testCategoryCd),
+    repAcceptedInd: 1,
+    tolrncOvrrdeDesc: null
+  })
+);
+
+const GerminationContent = () => {
+  const navigate = useNavigate();
+  const { riaKey } = useParams();
+
+  const [header, setHeader] = useState<GerminationTestHeaderType>();
+  const [slots, setSlots] = useState<GermCountSlotType[]>(emptySlots());
+  const [replicates, setReplicates] = useState<GermReplicateType[]>([]);
+  const [alert, setAlert] = useState<{ isSuccess: boolean; message: string } | null>(null);
+  const [updateTimestamp, setUpdateTimestamp] = useState<string | undefined>(undefined);
+  const { isConflict, markConflict, clearConflict } = useActivityConflict();
+
+  const headerQuery = useQuery({
+    queryKey: ['germination-test-header', riaKey],
+    queryFn: () => getGerminationTestHeader(riaKey ?? ''),
+    refetchOnMount: true
+  });
+
+  const germCountQuery = useQuery({
+    queryKey: ['germ-counts', riaKey],
+    queryFn: () => getGermCounts(riaKey ?? ''),
+    retry: false,
+    refetchOnMount: true
+  });
+
+  const replicatesQuery = useQuery({
+    queryKey: ['test-replicates', riaKey],
+    queryFn: () => getTestReplicates(riaKey ?? ''),
+    retry: false,
+    refetchOnMount: true
+  });
+
+  useEffect(() => {
+    if (
+      headerQuery.isFetched
+      && headerQuery.status === 'error'
+      && (headerQuery.error as AxiosError).response?.status === 404
+    ) {
+      navigate(ROUTES.FOUR_OH_FOUR);
+    } else if (headerQuery.data) {
+      setHeader(headerQuery.data);
+    }
+  }, [headerQuery.status, headerQuery.isFetched]);
+
+  // Hydrate slots: merge sparse API slots into the fixed 13-slot grid
+  useEffect(() => {
+    if (germCountQuery.data) {
+      const next = emptySlots();
+      germCountQuery.data.slots.forEach((slot) => {
+        next[slot.slotIndex - 1] = slot;
+      });
+      setSlots(next);
+      setUpdateTimestamp(germCountQuery.data.updateTimestamp);
+    }
+  }, [germCountQuery.data]);
+
+  // Hydrate replicates: API rows or category defaults (AC4)
+  useEffect(() => {
+    if (!headerQuery.data || !replicatesQuery.isFetched) {
+      return;
+    }
+    const fetched = replicatesQuery.data;
+    if (fetched && fetched.length > 0) {
+      setReplicates(fetched);
+    } else {
+      setReplicates(defaultReplicates(headerQuery.data.testCategoryCd));
+    }
+  }, [replicatesQuery.isFetched, replicatesQuery.data, headerQuery.data]);
+
+  const validationErrors = useMemo(() => ({
+    ...validateCountDates(slots),
+    ...checkOverLimit(slots, replicates)
+  }), [slots, replicates]);
+
+  const hasDatedSlot = slots.some((slot) => slot.countDt);
+  const isEditable = header?.testCompleteInd !== 1 && !isConflict;
+
+  // Hydration completes once both the germ-count query (200 or 404) and the
+  // replicates query have settled — until then autosave must stay disabled,
+  // otherwise the pre-hydration empty/default state would be saved as if it
+  // were a real edit.
+  const isHydrated = germCountQuery.isFetched && replicatesQuery.isFetched;
+
+  const saveMutation = useMutation({
+    mutationFn: (data: { slots: GermCountSlotType[]; replicates: GermReplicateType[] }) => (
+      putGermCounts(
+        riaKey ?? '',
+        buildUpsertPayload(data.slots, data.replicates, updateTimestamp)
+      )
+    ),
+    onSuccess: (response) => {
+      setUpdateTimestamp(response.updateTimestamp);
+      setAlert({ isSuccess: true, message: 'Daily germination counts saved' });
+      setTimeout(() => setAlert(null), 3000);
+    },
+    onError: (error) => {
+      if ((error as AxiosError).response?.status === 409) {
+        markConflict();
+        return;
+      }
+      setAlert({
+        isSuccess: false,
+        message: `Failed to save germination counts: ${(error as AxiosError).message}`
+      });
+    }
+  });
+
+  const autosaveData = useMemo(
+    () => ({ slots, replicates }),
+    [slots, replicates]
+  );
+
+  const { markSaved } = useAutosave({
+    data: autosaveData,
+    onSave: (data) => saveMutation.mutateAsync(data),
+    enabled:
+      isHydrated
+      && isEditable
+      && hasDatedSlot
+      && replicates.length > 0
+      && Object.keys(validationErrors).length === 0
+      && !saveMutation.isPending
+  });
+
+  // Mark the freshly hydrated data as already-saved so the debounce/maxWait
+  // timers in useAutosave never fire for the initial load itself — only for
+  // edits made after hydration. This must run from an effect keyed on the
+  // hydration flags (not assigned inline during render via a ref) so it
+  // fires exactly once per hydration, after state settles, avoiding a
+  // spurious early PUT with empty days on first render.
+  useEffect(() => {
+    if (isHydrated) {
+      markSaved(autosaveData);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated]);
+
+  const handleReloadOnConflict = async () => {
+    const [countResult] = await Promise.all([
+      germCountQuery.refetch(),
+      replicatesQuery.refetch()
+    ]);
+    // germ-counts may legitimately 404 (no row yet); only a fresh read matters
+    if (countResult.status === 'success' || countResult.status === 'error') {
+      clearConflict();
+    }
+  };
+
+  const crumbs = [
+    { name: 'CONSEP', path: ROUTES.CONSEP_FAVOURITE_ACTIVITIES },
+    { name: 'Testing activities search', path: ROUTES.TESTING_REQUESTS_REPORT },
+    { name: 'Testing list', path: ROUTES.TESTING_ACTIVITIES_LIST }
+  ];
+
+  const headerFields: Array<{ label: string; value?: string | number }> = [
+    { label: 'Request ID', value: header?.requestId },
+    { label: 'Activity', value: header?.activityTypeCd },
+    { label: 'Seedlot number', value: header?.seedlotNumber },
+    { label: 'Species', value: header?.vegetationState },
+    { label: 'Germ tray', value: header?.germinatorTrayId },
+    { label: 'Category', value: header?.testCategoryCd },
+    { label: 'Rank', value: header?.testRank },
+    { label: 'Germination %', value: header?.germinationPct },
+    { label: 'GV', value: header?.germinationValue },
+    { label: 'PV', value: header?.peakValueGrmPct },
+    { label: 'Germinator ID', value: header?.germinatorId }
+  ];
+
+  return (
+    <FlexGrid className="consep-germination-content">
+      {isConflict && (
+        <ConflictNotification
+          className="consep-germination-content-conflict"
+          onReload={handleReloadOnConflict}
+        />
+      )}
+      {alert?.message && (
+        <InlineNotification
+          lowContrast
+          kind={alert.isSuccess ? 'success' : 'error'}
+          title={alert.isSuccess ? 'Success' : 'Error'}
+          subtitle={alert.message}
+        />
+      )}
+      <Row className="consep-germination-content-breadcrumb">
+        <Breadcrumbs crumbs={crumbs} />
+      </Row>
+      {/* Title (and everything below) is gated on the header having loaded:
+          the header card, table hydration and day-number calculations all
+          depend on header fields (e.g. germinatorEntry), so rendering them
+          before header exists would show stale/blank data and let a user
+          interact with the table before day numbers can be computed. */}
+      {header && (
+        <>
+          <Row className="consep-germination-content-title">
+            <PageTitle title={`Germination test result (${header.activityTypeCd ?? ''})`} />
+            <>
+              {header.testCompleteInd === 1 && <StatusTag type="Completed" renderIcon={CheckmarkFilled} />}
+              {header.acceptResultInd === 1 && <StatusTag type="Accepted" renderIcon={CheckmarkFilled} />}
+            </>
+          </Row>
+          <Row className="consep-germination-content-header-card">
+            {headerFields.map((field) => (
+              <Column key={field.label} sm={2} md={2} lg={3} xlg={3}>
+                <div className="consep-germination-content-header-field">
+                  <span className="consep-germination-content-header-label">{field.label}</span>
+                  <span className="consep-germination-content-header-value">
+                    {field.value?.toString() ?? '—'}
+                  </span>
+                </div>
+              </Column>
+            ))}
+          </Row>
+          <Row className="consep-germination-content-comments">
+            <Column>
+              <TextInput
+                id="germ-header-comments"
+                labelText="Comments"
+                value={header.riaComment ?? ''}
+                readOnly
+              />
+            </Column>
+          </Row>
+          <Row className="consep-germination-content-table">
+            <Column>
+              <DailyGermTable
+                slots={slots}
+                replicates={replicates}
+                germinatorEntry={header.germinatorEntry}
+                isEditable={isEditable}
+                validationErrors={validationErrors}
+                onSlotsChange={setSlots}
+                onReplicatesChange={setReplicates}
+              />
+            </Column>
+          </Row>
+          {/* Abnormals table (#2606) and legacy action buttons (Final/Rank/Curve/...)
+              are out of scope for #2514 — placeholders intentionally omitted. */}
+        </>
+      )}
+    </FlexGrid>
+  );
+};
+
+export default GerminationContent;

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/index.tsx
@@ -157,7 +157,7 @@ const GerminationContent = () => {
 
   const { markSaved } = useAutosave({
     data: autosaveData,
-    onSave: (data) => saveMutation.mutateAsync(data),
+    onSave: async (data) => { await saveMutation.mutateAsync(data); },
     enabled:
       isHydrated
       && isEditable

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/index.tsx
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/index.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, {
+  useEffect, useMemo, useRef, useState
+} from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -53,7 +55,30 @@ const GerminationContent = () => {
   const [replicates, setReplicates] = useState<GermReplicateType[]>([]);
   const [alert, setAlert] = useState<{ isSuccess: boolean; message: string } | null>(null);
   const [updateTimestamp, setUpdateTimestamp] = useState<string | undefined>(undefined);
+  // Hydration completes once both the germ-count query (200 or 404) and the
+  // replicates query have settled — until then autosave must stay disabled,
+  // otherwise the pre-hydration empty/default state would be saved as if it
+  // were a real edit. Held in state so autosave re-evaluates its `enabled`
+  // gate when it flips true.
+  const [isHydrated, setIsHydrated] = useState(false);
   const { isConflict, markConflict, clearConflict } = useActivityConflict();
+
+  // Latest slots/replicates mirrored into refs so a hydration effect can hand
+  // useAutosave a combined { slots, replicates } snapshot as already-saved,
+  // even when only one half is being set in that effect. Mirroring during
+  // render is the "latest ref" pattern — read only in effects below, never to
+  // drive rendering — so the lint warning does not apply here.
+  const slotsRef = useRef<GermCountSlotType[]>(slots);
+  // eslint-disable-next-line react-hooks/refs
+  slotsRef.current = slots;
+  const replicatesRef = useRef<GermReplicateType[]>(replicates);
+  // eslint-disable-next-line react-hooks/refs
+  replicatesRef.current = replicates;
+  // markSaved is created by useAutosave below, but the hydration effects run
+  // after that hook on every render; a ref lets them call the latest instance.
+  const markSavedRef = useRef<(v: { slots: GermCountSlotType[]; replicates: GermReplicateType[] }) => void>(
+    () => {}
+  );
 
   const headerQuery = useQuery({
     queryKey: ['germination-test-header', riaKey],
@@ -85,31 +110,54 @@ const GerminationContent = () => {
     } else if (headerQuery.data) {
       setHeader(headerQuery.data);
     }
-  }, [headerQuery.status, headerQuery.isFetched]);
+    // headerQuery.data is included so a conflict-reload refetch (I5) that
+    // returns a changed header — e.g. testCompleteInd flipping to 1 — actually
+    // reapplies; status/isFetched alone can stay unchanged across a refetch.
+  }, [headerQuery.status, headerQuery.isFetched, headerQuery.data]);
 
-  // Hydrate slots: merge sparse API slots into the fixed 13-slot grid
+  // Hydrate slots: merge sparse API slots into the fixed 13-slot grid.
+  // Sets state AND marks the resulting { slots, replicates } snapshot as
+  // already-saved in the same effect (via refs for the replicates half), so
+  // useAutosave's savedRef is never a render behind the hydrated data — the
+  // C1 ghost-PUT root cause. germ-counts may legitimately 404 (no row yet):
+  // isFetched (not data) is what settles this half.
   useEffect(() => {
+    if (!germCountQuery.isFetched) {
+      return;
+    }
+    const nextSlots = emptySlots();
     if (germCountQuery.data) {
-      const next = emptySlots();
       germCountQuery.data.slots.forEach((slot) => {
-        next[slot.slotIndex - 1] = slot;
+        nextSlots[slot.slotIndex - 1] = slot;
       });
-      setSlots(next);
       setUpdateTimestamp(germCountQuery.data.updateTimestamp);
     }
-  }, [germCountQuery.data]);
+    setSlots(nextSlots);
+    slotsRef.current = nextSlots;
+    if (replicatesQuery.isFetched && headerQuery.data) {
+      markSavedRef.current({ slots: nextSlots, replicates: replicatesRef.current });
+      setIsHydrated(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [germCountQuery.isFetched, germCountQuery.data]);
 
-  // Hydrate replicates: API rows or category defaults (AC4)
+  // Hydrate replicates: API rows or category defaults (AC4). Same
+  // set-state-then-markSaved discipline as the slots effect.
   useEffect(() => {
     if (!headerQuery.data || !replicatesQuery.isFetched) {
       return;
     }
     const fetched = replicatesQuery.data;
-    if (fetched && fetched.length > 0) {
-      setReplicates(fetched);
-    } else {
-      setReplicates(defaultReplicates(headerQuery.data.testCategoryCd));
+    const nextReplicates = (fetched && fetched.length > 0)
+      ? fetched
+      : defaultReplicates(headerQuery.data.testCategoryCd);
+    setReplicates(nextReplicates);
+    replicatesRef.current = nextReplicates;
+    if (germCountQuery.isFetched) {
+      markSavedRef.current({ slots: slotsRef.current, replicates: nextReplicates });
+      setIsHydrated(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [replicatesQuery.isFetched, replicatesQuery.data, headerQuery.data]);
 
   const validationErrors = useMemo(() => ({
@@ -119,12 +167,6 @@ const GerminationContent = () => {
 
   const hasDatedSlot = slots.some((slot) => slot.countDt);
   const isEditable = header?.testCompleteInd !== 1 && !isConflict;
-
-  // Hydration completes once both the germ-count query (200 or 404) and the
-  // replicates query have settled — until then autosave must stay disabled,
-  // otherwise the pre-hydration empty/default state would be saved as if it
-  // were a real edit.
-  const isHydrated = germCountQuery.isFetched && replicatesQuery.isFetched;
 
   const saveMutation = useMutation({
     mutationFn: (data: { slots: GermCountSlotType[]; replicates: GermReplicateType[] }) => (
@@ -167,23 +209,26 @@ const GerminationContent = () => {
       && !saveMutation.isPending
   });
 
-  // Mark the freshly hydrated data as already-saved so the debounce/maxWait
-  // timers in useAutosave never fire for the initial load itself — only for
-  // edits made after hydration. This must run from an effect keyed on the
-  // hydration flags (not assigned inline during render via a ref) so it
-  // fires exactly once per hydration, after state settles, avoiding a
-  // spurious early PUT with empty days on first render.
-  useEffect(() => {
-    if (isHydrated) {
-      markSaved(autosaveData);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isHydrated]);
+  // Keep the ref the hydration effects call pointing at the latest markSaved.
+  // markSaved is a fresh closure each render but always mutates the same
+  // savedRef inside useAutosave, so the hydration effects (which run after
+  // this assignment on every commit) hand it the freshly hydrated snapshot —
+  // never a stale pre-hydration closure. This replaces the old
+  // [isHydrated]-keyed markSaved effect whose captured autosaveData lagged a
+  // render behind and produced the C1 ghost PUT. Assigning during render (not
+  // in an effect) is deliberate: effects run after render, so this guarantees
+  // the ref is current before the hydration effects below fire this commit.
+  // eslint-disable-next-line react-hooks/refs
+  markSavedRef.current = markSaved;
 
   const handleReloadOnConflict = async () => {
+    // Refetch the header too (I5): germinatorEntry drives day-number calc and
+    // testCompleteInd gates isEditable, so a stale header would leave both
+    // wrong after a conflict reload.
     const [countResult] = await Promise.all([
       germCountQuery.refetch(),
-      replicatesQuery.refetch()
+      replicatesQuery.refetch(),
+      headerQuery.refetch()
     ]);
     // germ-counts may legitimately 404 (no row yet); only a fresh read matters
     if (countResult.status === 'success' || countResult.status === 'error') {

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/styles.scss
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/styles.scss
@@ -1,0 +1,61 @@
+.daily-germ-table-container {
+  width: 100%;
+
+  h3 {
+    margin-bottom: 1rem;
+  }
+
+  .daily-germ-errors p {
+    color: var(--cds-text-error, #da1e28);
+    font-size: 0.875rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .daily-germ-table-scroll {
+    overflow-x: auto;
+  }
+
+  .daily-germ-table {
+    border-collapse: collapse;
+
+    th,
+    td {
+      border: 1px solid #8d8d8d;
+      padding: 0.25rem;
+      text-align: left;
+      font-size: 0.75rem;
+      white-space: nowrap;
+    }
+
+    thead th {
+      background: #e0e0e0;
+    }
+
+    input[type='number'],
+    input[type='date'] {
+      width: 5.5rem;
+      border: none;
+      background: transparent;
+
+      &:focus {
+        outline: 2px solid var(--cds-focus, #0f62fe);
+      }
+    }
+
+    input[type='number'] {
+      width: 3.5rem;
+      text-align: right;
+    }
+
+    .cell-invalid input,
+    .row-invalid td:first-child {
+      outline: 2px solid var(--cds-support-error, #da1e28);
+    }
+
+    .germ-pct-cells span {
+      display: inline-block;
+      min-width: 3rem;
+      margin-right: 0.5rem;
+    }
+  }
+}

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/styles.scss
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/styles.scss
@@ -59,3 +59,37 @@
     }
   }
 }
+
+.consep-germination-content {
+  padding: 2rem;
+
+  .consep-germination-content-header-card {
+    background: var(--cds-layer-01, #f4f4f4);
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+
+    input[readonly] {
+      background: transparent;
+      border-bottom: none;
+    }
+
+    .consep-germination-content-header-field {
+      display: flex;
+      flex-direction: column;
+
+      .consep-germination-content-header-label {
+        font-size: 0.75rem;
+        color: var(--cds-text-secondary, #525252);
+      }
+
+      .consep-germination-content-header-value {
+        font-size: 0.875rem;
+        font-weight: 600;
+      }
+    }
+  }
+
+  .consep-germination-content-table {
+    margin-top: 1.5rem;
+  }
+}

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/utils.ts
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/utils.ts
@@ -1,0 +1,77 @@
+import { GermCountSlotType, GermReplicateType, GermCountUpsertPayload } from '../../../../types/consep/GerminationType';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const getDefaultSeeds = (testCategoryCd?: string): number => (
+  testCategoryCd === 'QA' ? 50 : 100
+);
+
+export const calcDayNumber = (
+  germinatorEntry: string | undefined,
+  countDt: string
+): number | undefined => {
+  if (!germinatorEntry || !countDt) {
+    return undefined;
+  }
+  const entry = Date.parse(`${germinatorEntry}T00:00:00`);
+  const count = Date.parse(`${countDt}T00:00:00`);
+  if (Number.isNaN(entry) || Number.isNaN(count)) {
+    return undefined;
+  }
+  return Math.round((count - entry) / MS_PER_DAY);
+};
+
+export const validateCountDates = (
+  slots: GermCountSlotType[]
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+  const dated = slots.filter((s) => s.countDt);
+  for (let i = 1; i < dated.length; i += 1) {
+    const currentDt = dated[i].countDt;
+    const previousDt = dated[i - 1].countDt;
+    if (currentDt && previousDt && currentDt <= previousDt) {
+      errors[`slot-${dated[i].slotIndex}`] = 'Count date must be after the previous count date';
+    }
+  }
+  return errors;
+};
+
+const REP_KEYS = ['rep1NoSeedsGerm', 'rep2NoSeedsGerm', 'rep3NoSeedsGerm', 'rep4NoSeedsGerm'] as const;
+
+export const calcRepTotal = (
+  slots: GermCountSlotType[],
+  repNumber: 1 | 2 | 3 | 4
+): number => slots.reduce(
+  (sum, slot) => sum + (slot[REP_KEYS[repNumber - 1]] ?? 0),
+  0
+);
+
+export const checkOverLimit = (
+  slots: GermCountSlotType[],
+  replicates: GermReplicateType[]
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+  replicates.forEach((rep) => {
+    const total = calcRepTotal(slots, rep.replicateNumber as 1 | 2 | 3 | 4);
+    if (rep.totalNoSeeds !== undefined && total > rep.totalNoSeeds) {
+      errors[`rep-${rep.replicateNumber}`] = `Total germinated (${total}) exceeds number of seeds (${rep.totalNoSeeds})`;
+    }
+  });
+  return errors;
+};
+
+export const calcGermPct = (repTotal: number, totalSeeds?: number): number => (
+  totalSeeds ? Math.round((repTotal / totalSeeds) * 100) : 0
+);
+
+export const buildUpsertPayload = (
+  slots: GermCountSlotType[],
+  replicates: GermReplicateType[],
+  updateTimestamp?: string
+): GermCountUpsertPayload => ({
+  updateTimestamp,
+  days: slots
+    .filter((slot) => slot.countDt)
+    .map(({ dailyGermSkey, cumulativeGerm, ...rest }) => rest),
+  replicates
+});

--- a/frontend/src/views/CONSEP/TestingActivities/GerminationContent/utils.ts
+++ b/frontend/src/views/CONSEP/TestingActivities/GerminationContent/utils.ts
@@ -52,8 +52,16 @@ export const checkOverLimit = (
 ): Record<string, string> => {
   const errors: Record<string, string> = {};
   replicates.forEach((rep) => {
+    // A cleared "# seeds" cell (undefined) must block autosave: the backend
+    // rejects a payload missing totalNoSeeds with a @NotNull 400 that discards
+    // the whole request, including valid count edits (C3). Typing stays
+    // unblocked — this only gates the save.
+    if (rep.totalNoSeeds === undefined) {
+      errors[`rep-${rep.replicateNumber}`] = 'Number of seeds is required';
+      return;
+    }
     const total = calcRepTotal(slots, rep.replicateNumber as 1 | 2 | 3 | 4);
-    if (rep.totalNoSeeds !== undefined && total > rep.totalNoSeeds) {
+    if (total > rep.totalNoSeeds) {
       errors[`rep-${rep.replicateNumber}`] = `Total germinated (${total}) exceeds number of seeds (${rep.totalNoSeeds})`;
     }
   });

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminationTestHeaderDto.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/dto/consep/GerminationTestHeaderDto.java
@@ -180,6 +180,18 @@ public record GerminationTestHeaderDto(
             + " echo back as riaUpdateTimestamp when updating (optimistic lock)",
         example = "2026-05-01T11:00:00"
     )
-    LocalDateTime riaUpdateTimestamp
+    LocalDateTime riaUpdateTimestamp,
+
+    @Schema(description = "Request ID", example = "TST20170140")
+    String requestId,
+
+    @Schema(description = "Seedlot number", example = "07080")
+    String seedlotNumber,
+
+    @Schema(description = "Family lot number")
+    String familyLotNumber,
+
+    @Schema(description = "Vegetation (species) code", example = "SX")
+    String vegetationState
 ) {
 }

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/TestResultRepository.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/repository/consep/TestResultRepository.java
@@ -197,7 +197,11 @@ public interface TestResultRepository extends JpaRepository<TestResultEntity, Bi
             a.intermediateCleaner,
             r.requestTypeSt,
             tst.updateTimestamp,
-            a.updateTimestamp
+            a.updateTimestamp,
+            a.requestId,
+            a.seedlotNumber,
+            a.familyLotNumber,
+            a.vegetationState
     )
     FROM TestResultEntity tst
     JOIN ActivityEntity a

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GermCountService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/GermCountService.java
@@ -307,7 +307,16 @@ public class GermCountService {
       if (s.dailyGermSkey() == null) {
         continue;
       }
-      toSave.add(toAbnormalEntity(s.dailyGermSkey(), dayBySlot.get(s.slotIndex())));
+      DayGermCountDto day = dayBySlot.get(s.slotIndex());
+      // Skip days that carry no abnormal DTOs at all (this UI never sends
+      // them). Writing an all-null DailyAbnormalEntity here would merge over
+      // and NULL out any abnormals an earlier edit recorded for the day. When
+      // any rep abnormal DTO IS present we still upsert, preserving prior
+      // behaviour for callers that do send abnormals.
+      if (!hasAnyAbnormal(day)) {
+        continue;
+      }
+      toSave.add(toAbnormalEntity(s.dailyGermSkey(), day));
     }
     if (!toSave.isEmpty()) {
       dailyAbnormalRepository.saveAll(toSave);
@@ -343,6 +352,15 @@ public class GermCountService {
     }
     SparLog.info("Deleting {} orphaned daily abnormal row(s)", orphaned.size());
     dailyAbnormalRepository.deleteAllById(orphaned);
+  }
+
+  /** True when the day carries at least one non-null rep abnormal DTO. */
+  private static boolean hasAnyAbnormal(DayGermCountDto d) {
+    if (d == null) {
+      return false;
+    }
+    return d.rep1Abnormal() != null || d.rep2Abnormal() != null
+        || d.rep3Abnormal() != null || d.rep4Abnormal() != null;
   }
 
   private DailyAbnormalEntity toAbnormalEntity(BigDecimal skey, DayGermCountDto d) {

--- a/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
+++ b/oracle-api/src/main/java/ca/bc/gov/oracleapi/service/consep/TestResultService.java
@@ -159,7 +159,11 @@ public class TestResultService {
           dto.intrmdtCleanrInd(),
           dto.requestTypeSt(),
           dto.testResultUpdateTimestamp(),
-          dto.riaUpdateTimestamp());
+          dto.riaUpdateTimestamp(),
+          dto.requestId(),
+          dto.seedlotNumber(),
+          dto.familyLotNumber(),
+          dto.vegetationState());
 
     } catch (IncorrectResultSizeDataAccessException ex) {
       SparLog.error("Data integrity issue: multiple rows found for RIA_SKEY {}", riaKey, ex);

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpointTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/endpoint/consep/GerminationTestEndpointTest.java
@@ -407,7 +407,11 @@ public class GerminationTestEndpointTest {
         0, // intrmdtCleanrInd
         "TSC", // requestTypeSt
         LocalDateTime.parse("2026-05-01T10:00:00"), // testResultUpdateTimestamp
-        LocalDateTime.parse("2026-05-01T11:00:00") // riaUpdateTimestamp
+        LocalDateTime.parse("2026-05-01T11:00:00"), // riaUpdateTimestamp
+        "TST20170140", // requestId
+        "64132", // seedlotNumber
+        null, // familyLotNumber
+        "SX" // vegetationState
     );
   }
 }

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/GermCountServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/GermCountServiceTest.java
@@ -200,6 +200,13 @@ class GermCountServiceTest {
         zeroAbnormal(), zeroAbnormal(), zeroAbnormal(), zeroAbnormal());
   }
 
+  /** A day whose four rep abnormal DTOs are all absent — what this UI sends. */
+  private static DayGermCountDto dayNoAbnormals(int slot, LocalDate dt, int dayNo,
+      Integer r1, Integer r2, Integer r3, Integer r4) {
+    return new DayGermCountDto(slot, dt, dayNo, r1, r2, r3, r4,
+        null, null, null, null);
+  }
+
   private static TestRepGermFormDto rep(int n, int total) {
     return new TestRepGermFormDto(n, total, 0, 0, 0, 0, 0, 0, 0, 1, null);
   }
@@ -454,6 +461,68 @@ class GermCountServiceTest {
     assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
     assertTrue(ex.getReason().contains("Replicate 1"));
     verify(germCountRepository, never()).save(any());
+  }
+
+  @Test
+  void upsert_dayWithoutAbnormalDtos_doesNotWriteAbnormalRow() {
+    // C2: every save from this UI carries no abnormal DTOs. The service must
+    // then leave existing abnormal rows untouched rather than upserting an
+    // all-null DailyAbnormalEntity that NULLs them out. With the only dated
+    // day carrying no abnormals, no abnormal row is written at all.
+    BigDecimal riaSkey = new BigDecimal("881191");
+    LocalDateTime ts = LocalDateTime.of(2026, 4, 5, 14, 30);
+
+    GermCountEntity existing = new GermCountEntity();
+    existing.setRiaSkey(riaSkey);
+    existing.setUpdateTimestamp(ts);
+    existing.setDailyGermSkey1(new BigDecimal("3001"));
+    existing.setCountDt1(LocalDate.of(2026, 4, 1));
+    existing.setRep1NoSeedsGerm1(10);
+    existing.setCumulativeGerm1(new BigDecimal("10"));
+
+    stubChildSaves();
+    when(germCountRepository.existsById(riaSkey)).thenReturn(true);
+    when(germCountRepository.touchIfTimestampMatches(riaSkey, ts)).thenReturn(1);
+    when(germCountRepository.findById(riaSkey)).thenReturn(Optional.of(existing));
+    when(germCountRepository.save(any(GermCountEntity.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
+
+    // Resend slot 1 (same dated day) with no abnormal DTOs.
+    List<DayGermCountDto> days =
+        List.of(dayNoAbnormals(1, LocalDate.of(2026, 4, 1), 1, 10, 0, 0, 0));
+
+    germCountService.upsertGermCounts(riaSkey, request(ts, days), "USER1");
+
+    // No abnormal row is upserted for the abnormal-less day, so the existing
+    // row (skey 3001) is left as-is. deleteOrphanedAbnormals also must not
+    // remove it — slot 1 is still referenced.
+    verify(dailyAbnormalRepository, never()).saveAll(any());
+    verify(dailyAbnormalRepository, never()).deleteAllById(any());
+  }
+
+  @Test
+  void upsert_mixedDays_writesAbnormalRowOnlyForDayThatHasThem() {
+    // A day WITH abnormal DTOs still writes; a sibling day WITHOUT them is
+    // skipped. Guards against the fix over-reaching.
+    BigDecimal riaSkey = new BigDecimal("881191");
+    stubChildSaves();
+    when(germCountRepository.existsById(riaSkey)).thenReturn(false);
+    when(germCountRepository.nextDailyGermSkey())
+        .thenReturn(new BigDecimal("2001"), new BigDecimal("2002"));
+    when(germCountRepository.save(any(GermCountEntity.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
+
+    List<DayGermCountDto> days = new ArrayList<>();
+    days.add(day(1, LocalDate.of(2026, 4, 1), 1, 10, 12, 11, 9));       // has abnormals
+    days.add(dayNoAbnormals(2, LocalDate.of(2026, 4, 3), 2, 5, 6, 7, 8)); // none
+
+    germCountService.upsertGermCounts(riaSkey, request(null, days), "USER1");
+
+    ArgumentCaptor<List<DailyAbnormalEntity>> abCaptor = ArgumentCaptor.forClass(List.class);
+    verify(dailyAbnormalRepository).saveAll(abCaptor.capture());
+    // Only slot 1 (skey 2001) gets an abnormal row; slot 2 is skipped.
+    assertEquals(1, abCaptor.getValue().size());
+    assertEquals(new BigDecimal("2001"), abCaptor.getValue().get(0).getDailyGermSkey());
   }
 
   @Test

--- a/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
+++ b/oracle-api/src/test/java/ca/bc/gov/oracleapi/service/consep/TestResultServiceTest.java
@@ -976,6 +976,10 @@ class TestResultServiceTest {
     assertEquals(LocalDateTime.parse("2026-04-15T20:30:00"), result.soakEndDate());
     assertEquals("G64", result.activityTypeCd());
     assertEquals("TSC", result.requestTypeSt());
+    assertEquals("TST20170140", result.requestId());
+    assertEquals("64132", result.seedlotNumber());
+    assertNull(result.familyLotNumber());
+    assertEquals("SX", result.vegetationState());
   }
 
   @Test
@@ -1049,7 +1053,11 @@ class TestResultServiceTest {
         0, // intrmdtCleanrInd
         "TSC", // requestTypeSt
         TST_TS, // testResultUpdateTimestamp
-        RIA_TS // riaUpdateTimestamp
+        RIA_TS, // riaUpdateTimestamp
+        "TST20170140", // requestId
+        "64132", // seedlotNumber
+        null, // familyLotNumber
+        "SX" // vegetationState
         );
   }
 
@@ -1219,7 +1227,8 @@ class TestResultServiceTest {
     return new GerminationTestHeaderDto(
         RIA_KEY, "G23", null, null, "STD", null, null, 0, 0, null, -1, null,
         null, null, null, null, null, null, null, 21, "DY", null, null, null,
-        null, null, null, null, null, null, null, null, "RTS", TST_TS, RIA_TS);
+        null, null, null, null, null, null, null, null, "RTS", TST_TS, RIA_TS,
+        null, null, null, null);
   }
 
   private void mockHappyPathRepos() {


### PR DESCRIPTION
# Description
Closes #2514

New **Germination Test Result** screen at `/consep/germination-test/:riaKey` with the Daily Germination data table (replicates 1–4 as rows × up to 13 count-date columns), following the MoistureContent/PurityContent page pattern (TanStack Query + `useAutosave` + optimistic locking).

Acceptance criteria coverage:
- ✅ Day number auto-calculated from germinator entry date on first count (e.g. 2024-10-31 → 2024-11-04 = day 4) and for each subsequent count date
- ✅ Warning when a replicate's germination total exceeds its number of seeds (inline error; autosave blocked, typing never blocked)
- ✅ Number of seeds auto-populated by category: QA = 50, otherwise 100
- ✅ Default seeds overridable per replicate; persisted via `PUT /api/germ-counts` `replicates[].totalNoSeeds`

### Changelog
#### New
- `GerminationContent` page + route (`/consep/germination-test/:riaKey`), header card, read-only test metadata, autosave with 409 conflict banner/reload
- `DailyGermTable` custom table component (13 slot columns, per-slot date + day headers, Rep total / # seeds / Ovr / Acc columns, Germ % footer)
- Germination utils: day-number calc, ascending count-date validation, over-limit + required-seeds checks, upsert payload builder
- `germinationTestAPI` service + `ApiConfig` entries (`germination-tests`, `germ-counts`, `test-replicates`)
- Frontend types for germination test data

#### Changed
- oracle-api: `GerminationTestHeaderDto` now exposes `requestId`, `seedlotNumber`, `familyLotNumber`, `vegetationState` (already available on the joined activity row) for the screen header
- oracle-api: `GermCountService.saveAbnormals` now skips days whose payload carries no abnormal data — previously any upsert without abnormal DTOs overwrote existing `CNS_T_DAILY_ABNORMAL` rows with NULLs (this screen never sends abnormals; #2606 will). Forward fix only: rows already NULLed by earlier saves are not backfilled.

#### Removed
- n/a

### How was this tested?
- [ ] 🧠 Not needed
- [ ] 👀 Eyeball
- [x] 🤖 Added tests

29 new frontend tests across 5 files (utils unit tests; table component incl. NaN guard + date-clear; page hydration proving no spurious autosave PUT on load; over-limit autosave gating; 409 conflict + reload refetching header). Backend: +2 `GermCountServiceTest` cases for the abnormals-preservation fix; germination/test-result suites 125/125 green. Repo-wide `tsc --noEmit` clean; eslint 0 errors.

## Are there any post-deployment tasks we need to perform?
- Data check (ops): `CNS_T_DAILY_ABNORMAL` rows may have been NULLed by pre-fix saves through the new PUT endpoint (#2590) — none in prod yet since this is the first UI caller, but worth confirming
- Follow-up candidates: edits typed before hydration completes are overwritten when queries resolve (pre-existing pattern shared with sibling screens); abnormals table is #2606

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-spar-43.apps.silver.devops.gov.bc.ca/)
- [Backend](https://nr-spar-2643-backend.apps.silver.devops.gov.bc.ca/swagger-ui/index.html)
- [Oracle-API](https://nr-spar-2643-oracle-api.apps.silver.devops.gov.bc.ca/actuator/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-spar/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-spar/actions/workflows/merge.yml)